### PR TITLE
Add create_workdir function to avoid code duplication.

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -39,7 +39,6 @@ import subprocess as _subprocess
 import shutil as _shutil
 import shlex as _shlex
 import sys as _sys
-import tempfile as _tempfile
 
 from .._Utils import _try_import, _have_imported, _assert_imported
 
@@ -294,20 +293,8 @@ def generateNetwork(
                 f"'n_edges_forced' must be 0 < value < {n_edges_fully_connected}."
             )
 
-    # Create a temporary working directory and store the directory name.
-    if work_dir is None:
-        tmp_dir = _tempfile.TemporaryDirectory()
-        work_dir = tmp_dir.name
-
-    # User specified working directory.
-    else:
-        # Use full path.
-        if work_dir[0] != "/":
-            work_dir = _os.getcwd() + "/" + work_dir
-
-        # Create the directory if it doesn't already exist.
-        if not _os.path.isdir(work_dir):
-            _os.makedirs(work_dir, exist_ok=True)
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir(work_dir)
 
     # Make the LOMAP input and output directories.
     _os.makedirs(work_dir + "/inputs", exist_ok=True)
@@ -903,9 +890,8 @@ def matchAtoms(
     # Convert the timeout to seconds and take the value as an integer.
     timeout = int(timeout.seconds().value())
 
-    # Create a temporary working directory.
-    tmp_dir = _tempfile.TemporaryDirectory()
-    work_dir = tmp_dir.name
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir()
 
     # Use RDKkit to find the maximum common substructure.
 
@@ -1254,9 +1240,8 @@ def flexAlign(
     # Convert the mapping to AtomIdx key:value pairs.
     sire_mapping = _to_sire_mapping(mapping)
 
-    # Create a temporary working directory.
-    tmp_dir = _tempfile.TemporaryDirectory()
-    work_dir = tmp_dir.name
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir()
 
     # Execute in the working directory.
     with _Utils.cd(work_dir):
@@ -1561,9 +1546,8 @@ def viewMapping(
         )
         molecule0 = rmsdAlign(molecule0, molecule1, mapping)
 
-    # Create a temporary working directory and store the directory name.
-    tmp_dir = _tempfile.TemporaryDirectory()
-    work_dir = tmp_dir.name
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir()
 
     # Write the molecules to PDB format.
     _IO.saveMolecules(

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -36,7 +36,6 @@ import sys as _sys
 import os as _os
 import shutil as _shutil
 import subprocess as _subprocess
-import tempfile as _tempfile
 import warnings as _warnings
 import zipfile as _zipfile
 
@@ -170,22 +169,13 @@ class Relative:
         else:
             self._setup_only = setup_only
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            if setup_only:
-                raise ValueError(
-                    "A 'work_dir' must be specified when 'setup_only' is True!"
-                )
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
+        if work_dir is None and setup_only:
+            raise ValueError(
+                "A 'work_dir' must be specified when 'setup_only' is True!"
+            )
 
-        # User specified working directory.
-        else:
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Validate the user specified molecular dynamics engine.
         if engine is not None:

--- a/python/BioSimSpace/Parameters/_process.py
+++ b/python/BioSimSpace/Parameters/_process.py
@@ -47,7 +47,6 @@ import glob as _glob
 import os as _os
 import queue as _queue
 import sys as _sys
-import tempfile as _tempfile
 import threading as _threading
 import warnings as _warnings
 import zipfile as _zipfile
@@ -56,6 +55,7 @@ from .. import _is_notebook
 from .. import _isVerbose
 from .._Exceptions import ParameterisationError as _ParameterisationError
 from .._SireWrappers import Molecule as _Molecule
+from .. import _Utils
 
 from . import _Protocol
 
@@ -157,21 +157,8 @@ class Process:
         # Create a hash for the object.
         self._hash = hash((molecule, protocol)) % ((_sys.maxsize + 1) * 2)
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            # Make sure the path is absolute.
-            if not _os.path.isabs(work_dir):
-                work_dir = _os.path.abspath(work_dir)
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Flag that the process hasn't started/finished.
         self._is_started = False

--- a/python/BioSimSpace/Process/_process.py
+++ b/python/BioSimSpace/Process/_process.py
@@ -38,7 +38,6 @@ import random as _random
 import timeit as _timeit
 import warnings as _warnings
 import sys as _sys
-import tempfile as _tempfile
 import zipfile as _zipfile
 
 from sire.legacy import Mol as _SireMol
@@ -50,6 +49,7 @@ from ..Protocol._protocol import Protocol as _Protocol
 from .._SireWrappers import System as _System
 from ..Types._type import Type as _Type
 from .. import Units as _Units
+from .. import _Utils as _Utils
 
 if _is_notebook:
     from IPython.display import FileLink as _FileLink
@@ -228,21 +228,8 @@ class Process:
         # Set the list of input files to None.
         self._input_files = None
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            # Use absolute path.
-            if not _os.path.isabs(work_dir):
-                work_dir = _os.path.abspath(work_dir)
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Files for redirection of stdout and stderr.
         self._stdout_file = "%s/%s.out" % (self._work_dir, name)

--- a/python/BioSimSpace/Process/_process_runner.py
+++ b/python/BioSimSpace/Process/_process_runner.py
@@ -101,6 +101,10 @@ class ProcessRunner:
         if work_dir is not None and not isinstance(work_dir, str):
             raise TypeError("'work_dir' must be of type 'str'")
 
+        # Convert to absolute path.
+        if not _os.path.isabs(work_dir):
+            work_dir = _os.path.abspath(work_dir)
+
         # Set the list of processes.
         self._processes = processes
 

--- a/python/BioSimSpace/Process/_task.py
+++ b/python/BioSimSpace/Process/_task.py
@@ -30,15 +30,16 @@ from IPython.display import FileLink as _FileLink
 
 import glob as _glob
 import os as _os
-import tempfile as _tempfile
 import threading as _threading
 import zipfile as _zipfile
 
 from .. import _is_notebook
+from .. import _Utils
 
 
 def _wrap_task(task):
-    """A simple wrapper function to run a background tasks and catch exceptions.
+    """
+    A simple wrapper function to run a background tasks and catch exceptions.
 
     Parameters
     ----------
@@ -108,23 +109,8 @@ class Task:
         # Initialise the zip file name.
         self._zipfile = None
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            self._tmp_dir = None
-
-            # Use full path.
-            if work_dir[0] != "/":
-                work_dir = _os.getcwd() + "/" + work_dir
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Start the task.
         if auto_start:

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_align.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_align.py
@@ -39,7 +39,6 @@ import subprocess as _subprocess
 import shutil as _shutil
 import shlex as _shlex
 import sys as _sys
-import tempfile as _tempfile
 
 from .._Utils import _try_import, _have_imported, _assert_imported
 
@@ -294,20 +293,8 @@ def generateNetwork(
                 f"'n_edges_forced' must be 0 < value < {n_edges_fully_connected}."
             )
 
-    # Create a temporary working directory and store the directory name.
-    if work_dir is None:
-        tmp_dir = _tempfile.TemporaryDirectory()
-        work_dir = tmp_dir.name
-
-    # User specified working directory.
-    else:
-        # Use full path.
-        if work_dir[0] != "/":
-            work_dir = _os.getcwd() + "/" + work_dir
-
-        # Create the directory if it doesn't already exist.
-        if not _os.path.isdir(work_dir):
-            _os.makedirs(work_dir, exist_ok=True)
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir(work_dir)
 
     # Make the LOMAP input and output directories.
     _os.makedirs(work_dir + "/inputs", exist_ok=True)
@@ -927,9 +914,8 @@ def matchAtoms(
     # Convert the timeout to seconds and take the value as an integer.
     timeout = int(timeout.seconds().value())
 
-    # Create a temporary working directory.
-    tmp_dir = _tempfile.TemporaryDirectory()
-    work_dir = tmp_dir.name
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir()
 
     # Use RDKkit to find the maximum common substructure.
 
@@ -1288,9 +1274,8 @@ def flexAlign(
     # Convert the mapping to AtomIdx key:value pairs.
     sire_mapping = _to_sire_mapping(mapping)
 
-    # Create a temporary working directory.
-    tmp_dir = _tempfile.TemporaryDirectory()
-    work_dir = tmp_dir.name
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir()
 
     # Execute in the working directory.
     with _Utils.cd(work_dir):
@@ -1606,9 +1591,8 @@ def viewMapping(
         )
         molecule0 = rmsdAlign(molecule0, molecule1, mapping)
 
-    # Create a temporary working directory and store the directory name.
-    tmp_dir = _tempfile.TemporaryDirectory()
-    work_dir = tmp_dir.name
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir()
 
     # Write the molecules to PDB format.
     _IO.saveMolecules(

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -36,7 +36,6 @@ import os as _os
 import re as _re
 import shutil as _shutil
 import subprocess as _subprocess
-import tempfile as _tempfile
 import warnings as _warnings
 import zipfile as _zipfile
 
@@ -212,22 +211,13 @@ class Relative:
         else:
             self._setup_only = setup_only
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            if setup_only:
-                raise ValueError(
-                    "A 'work_dir' must be specified when 'setup_only' is True!"
-                )
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
+        if work_dir is None and setup_only:
+            raise ValueError(
+                "A 'work_dir' must be specified when 'setup_only' is True!"
+            )
 
-        # User specified working directory.
-        else:
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Validate the user specified molecular dynamics engine.
         self._exe = None

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -32,7 +32,6 @@ __all__ = ["RestraintSearch"]
 import numpy as _np
 import os as _os
 import sys as _sys
-import tempfile as _tempfile
 import warnings as _warnings
 
 from numpy.linalg import norm as _norm
@@ -56,6 +55,7 @@ from ..Units.Length import angstrom as _angstrom
 from ..Units.Angle import radian as _radian
 from ..Units.Angle import degree as _degree
 from ..Units.Energy import kcal_per_mol as _kcal_per_mol
+from .._Utils import create_workdir as _create_workdir
 from .._Utils import _try_import, _have_imported
 from .... import _isVerbose
 
@@ -217,18 +217,8 @@ class RestraintSearch:
         else:
             self._extra_lines = extra_lines
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _create_workdir(work_dir)
 
         # There must be a single molecule to be decoupled (or annihilated).
         if system.nDecoupledMolecules() != 1:

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
@@ -47,7 +47,6 @@ import glob as _glob
 import os as _os
 import queue as _queue
 import sys as _sys
-import tempfile as _tempfile
 import threading as _threading
 import warnings as _warnings
 import zipfile as _zipfile
@@ -56,6 +55,7 @@ from .. import _is_notebook
 from .. import _isVerbose
 from .._Exceptions import ParameterisationError as _ParameterisationError
 from .._SireWrappers import Molecule as _Molecule
+from .. import _Utils
 
 from . import _Protocol
 
@@ -157,21 +157,8 @@ class Process:
         # Create a hash for the object.
         self._hash = hash((molecule, protocol)) % ((_sys.maxsize + 1) * 2)
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            # Make sure the path is absolute.
-            if not _os.path.isabs(work_dir):
-                work_dir = _os.path.abspath(work_dir)
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Flag that the process hasn't started/finished.
         self._is_started = False

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
@@ -38,7 +38,6 @@ import random as _random
 import timeit as _timeit
 import warnings as _warnings
 import sys as _sys
-import tempfile as _tempfile
 import zipfile as _zipfile
 
 from sire.legacy import Mol as _SireMol
@@ -52,6 +51,7 @@ from ..Protocol._protocol import Protocol as _Protocol
 from .._SireWrappers import System as _System
 from ..Types._type import Type as _Type
 from .. import Units as _Units
+from .. import _Utils
 from ..FreeEnergy._restraint import Restraint as _Restraint
 
 if _is_notebook:
@@ -236,21 +236,8 @@ class Process:
         # Set the list of input files to None.
         self._input_files = None
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            # Use absolute path.
-            if not _os.path.isabs(work_dir):
-                work_dir = _os.path.abspath(work_dir)
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Files for redirection of stdout and stderr.
         self._stdout_file = "%s/%s.out" % (self._work_dir, name)

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process_runner.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process_runner.py
@@ -101,6 +101,10 @@ class ProcessRunner:
         if work_dir is not None and not isinstance(work_dir, str):
             raise TypeError("'work_dir' must be of type 'str'")
 
+        # Convert to absolute path.
+        if not _os.path.isabs(work_dir):
+            work_dir = _os.path.abspath(work_dir)
+
         # Set the list of processes.
         self._processes = processes
 
@@ -484,7 +488,7 @@ class ProcessRunner:
 
     def start(self, index):
         """
-        Start a specific process. The same can be achieved using:\n.
+        Start a specific process. The same can be achieved using:\n
 
             runner.processes()[index].start()
 
@@ -744,7 +748,7 @@ class ProcessRunner:
 
     def kill(self, index):
         """
-        Kill a specific process. The same can be achieved using:\n.
+        Kill a specific process. The same can be achieved using:\n
 
             runner.processes()[index].kill()
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_task.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_task.py
@@ -30,11 +30,11 @@ from IPython.display import FileLink as _FileLink
 
 import glob as _glob
 import os as _os
-import tempfile as _tempfile
 import threading as _threading
 import zipfile as _zipfile
 
 from .. import _is_notebook
+from .. import _Utils
 
 
 def _wrap_task(task):
@@ -109,23 +109,8 @@ class Task:
         # Initialise the zip file name.
         self._zipfile = None
 
-        # Create a temporary working directory and store the directory name.
-        if work_dir is None:
-            self._tmp_dir = _tempfile.TemporaryDirectory()
-            self._work_dir = self._tmp_dir.name
-
-        # User specified working directory.
-        else:
-            self._tmp_dir = None
-
-            # Use full path.
-            if work_dir[0] != "/":
-                work_dir = _os.getcwd() + "/" + work_dir
-            self._work_dir = work_dir
-
-            # Create the directory if it doesn't already exist.
-            if not _os.path.isdir(work_dir):
-                _os.makedirs(work_dir, exist_ok=True)
+        # Create the working directory.
+        self._work_dir, self._tmp_dir = _Utils.create_workdir(work_dir)
 
         # Start the task.
         if auto_start:

--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
@@ -31,7 +31,6 @@ import re as _re
 import subprocess as _subprocess
 import shlex as _shlex
 import sys as _sys
-import tempfile as _tempfile
 import warnings as _warnings
 
 from sire.legacy import Base as _SireBase
@@ -69,7 +68,7 @@ def solvate(
     property_map={},
 ):
     """
-    Solvate with the specified water model..
+    Solvate with the specified water model.
 
     Parameters
     ----------
@@ -583,8 +582,8 @@ def _validate_input(
         The name of the water model.
 
     molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, \
-               :class:`Molecule <BioSimSpace._SireWrappers.Molecules>`, \
-               :class:`System <BioSimSpace._SireWrappers.System>`
+                :class:`Molecule <BioSimSpace._SireWrappers.Molecules>`, \
+                :class:`System <BioSimSpace._SireWrappers.System>`
         A molecule, or container/system of molecules.
 
     box : [:class:`Length <BioSimSpace.Types.Length>`]
@@ -873,20 +872,8 @@ def _solvate(
             molecule.removeWaterMolecules()
             molecule = molecule + waters
 
-    # Create a temporary working directory and store the directory name.
-    if work_dir is None:
-        tmp_dir = _tempfile.TemporaryDirectory()
-        work_dir = tmp_dir.name
-
-    # User specified working directory.
-    else:
-        # Use absolute path.
-        if not _os.path.isabs(work_dir):
-            work_dir = _os.path.abspath(work_dir)
-
-        # Create the directory if it doesn't already exist.
-        if not _os.path.isdir(work_dir):
-            _os.makedirs(work_dir, exist_ok=True)
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir(work_dir)
 
     # Write to 6dp, unless precision is specified by use.
     _property_map = property_map.copy()

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/__init__.py
@@ -29,13 +29,22 @@ Context managers
     :toctree: generated/
 
     cd
+
+Functions
+=========
+
+.. autosummary::
+    :toctree: generated/
+
     command_split
+    create_workdir
     _module_stub
     _try_import
     _have_imported
     _assert_imported
 """
 
+from ._command_split import *
 from ._contextmanagers import *
 from ._module_stub import *
-from ._command_split import *
+from ._workdir import *

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/_contextmanagers.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/_contextmanagers.py
@@ -30,6 +30,8 @@ from contextlib import contextmanager as _contextmanager
 
 import os as _os
 
+from ._workdir import create_workdir as _create_workdir
+
 
 # Adapted from: http://ralsina.me/weblog/posts/BB963.html
 @_contextmanager
@@ -53,7 +55,7 @@ def cd(work_dir):
 
     # Create the working directory if it doesn't exist.
     if not _os.path.isdir(work_dir):
-        _os.makedirs(work_dir)
+        work_dir, _ = _create_workdir(work_dir)
 
     # Change to the new directory.
     _os.chdir(work_dir)

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -31,7 +31,6 @@ import re as _re
 import subprocess as _subprocess
 import shlex as _shlex
 import sys as _sys
-import tempfile as _tempfile
 import warnings as _warnings
 
 from sire.legacy import Base as _SireBase
@@ -873,20 +872,8 @@ def _solvate(
             molecule.removeWaterMolecules()
             molecule = molecule + waters
 
-    # Create a temporary working directory and store the directory name.
-    if work_dir is None:
-        tmp_dir = _tempfile.TemporaryDirectory()
-        work_dir = tmp_dir.name
-
-    # User specified working directory.
-    else:
-        # Use absolute path.
-        if not _os.path.isabs(work_dir):
-            work_dir = _os.path.abspath(work_dir)
-
-        # Create the directory if it doesn't already exist.
-        if not _os.path.isdir(work_dir):
-            _os.makedirs(work_dir, exist_ok=True)
+    # Create the working directory.
+    work_dir, tmp_dir = _Utils.create_workdir(work_dir)
 
     # Write to 6dp, unless precision is specified by use.
     _property_map = property_map.copy()

--- a/python/BioSimSpace/_Utils/__init__.py
+++ b/python/BioSimSpace/_Utils/__init__.py
@@ -29,13 +29,22 @@ Context managers
     :toctree: generated/
 
     cd
+
+Functions
+=========
+
+.. autosummary::
+    :toctree: generated/
+
     command_split
+    create_workdir
     _module_stub
     _try_import
     _have_imported
     _assert_imported
 """
 
+from ._command_split import *
 from ._contextmanagers import *
 from ._module_stub import *
-from ._command_split import *
+from ._workdir import *


### PR DESCRIPTION
# Is this pull request to introduce new functionality?

With the recent addition of file caching support I've switched to using `BioSimSpace.IO.saveMolecules` throughout, which has exposed a couple of small bugs where a mixture of absolute and relative paths have been used. In fixing those I decided to refactor the code to provide a unified way of creating a working directory. This PR adds a `BioSimSpace._Utils.create_workdir` function, which does the following:

```python
from BioSimSpace._Utils import create_workdir

work_dir, tmp_dir = create_work_dir("some/path")
```

If the user passes a `str`, then the function creates the desired working directory and returns the _absolute_ path to it, along with `None` for `tmp_dir`. If the user passes `None` to the function, then the function creates a temporary directory and returns its name, along with the associated `tempfile.TemporaryDirectory()` object.

Note that prior to adding file caching support I sometimes used the `Sire.IO` objects directly. This was because:

* Sometimes it was faster due to the extra logic in `readMolecules`.
* When the code was intitially written, the output of `readMolecules` didn't have the same file extension required by the specific engines, e.g. GROMACS, so I needed to rename. Using things like `Sire.IO.GroTop` directly allowed me to specify the extension too.
 
In addition, the way in which working directories were set up used to differ depending on the application. This is no longer the case, so it now makes sense to have a single function to avoid code duplication. 

## Checklist:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y] (All existing tests use this functionality.)
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y] (Function docstring is exposed to Sphinx.)
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods