### PR TITLE
Add isSame method to allow file caching based on system/molecule properties

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -188,7 +188,7 @@ class Relative:
             # Check that the engine is supported.
             if engine not in self._engines:
                 raise ValueError(
-                    "Unsupported molecular dynamics engine '%s'. "
+                    f"Unsupported molecular dynamics engine {engine}. "
                     "Supported engines are: %r." % ", ".join(self._engines)
                 )
 

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -77,7 +77,13 @@ _cache = _FixedSizeOrderedDict()
 
 
 def check_cache(
-    system, format, filebase, property_map={}, excluded_properties=[], skip_water=True
+    system,
+    format,
+    filebase,
+    property_map={},
+    excluded_properties=[],
+    skip_water=True,
+    **kwargs,
 ):
     """
     Check whether a Sire system has previously been written to the specified format.
@@ -137,7 +143,12 @@ def check_cache(
         raise TypeError("'skip_water' must be of type 'bool'.")
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+    key = (
+        system._sire_object.uid().toString(),
+        format,
+        str(set(excluded_properties)),
+        str(skip_water),
+    )
 
     # Get the existing file path and MD5 hash from the cache.
     try:
@@ -190,7 +201,9 @@ def check_cache(
         return ext
 
 
-def update_cache(system, format, path, excluded_properties=[]):
+def update_cache(
+    system, format, path, excluded_properties=[], skip_water=True, **kwargs
+):
     """
     Update the file cache when a new system is written to a specified format.
 
@@ -208,6 +221,9 @@ def update_cache(system, format, path, excluded_properties=[]):
 
     excluded_properties : [str]
         A list of properties to exclude when comparing systems when checking
+
+    skip_water : bool
+        Whether to skip water molecules when comparing systems.
     """
 
     # Validate input.
@@ -230,6 +246,9 @@ def update_cache(system, format, path, excluded_properties=[]):
     if not all(isinstance(x, str) for x in excluded_properties):
         raise TypeError("'excluded_properties' must be a list of 'str' types.")
 
+    if not isinstance(skip_water, bool):
+        raise TypeError("'skip_water' must be of type 'bool'.")
+
     # Convert to an absolute path.
     path = _os.path.abspath(path)
 
@@ -237,7 +256,12 @@ def update_cache(system, format, path, excluded_properties=[]):
     hash = _get_md5_hash(path)
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+    key = (
+        system._sire_object.uid().toString(),
+        format,
+        str(set(excluded_properties)),
+        str(skip_water),
+    )
 
     # Update the cache.
     _cache[key] = (system, path, hash)

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -1,0 +1,216 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2023
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""Functionality for caching molecular files to avoid re-writing."""
+
+__author__ = "Lester Hedges"
+__email__ = "lester.hedges@gmail.com"
+
+__all__ = ["check_cache", "update_cache"]
+
+import hashlib as _hashlib
+import os as _os
+import shutil as _shutil
+
+from .._SireWrappers import System as _System
+
+# Initialise a "cache" dictionary. This maps a key of the system UID, file format
+# and excluded properties a value of the system and file path. When saving to a
+# given format, we can then to see if a matching system has previously been written
+# to the same format, allowing us to re-use the existing file.
+_cache = {}
+
+
+def check_cache(system, format, filebase, property_map={}, excluded_properties=[]):
+    """
+    Check whether a Sire system has previously been written to the specified format.
+
+    Parameters
+    ----------
+
+    system : :class:`System <BioSimSpace._SireWrappers.System>`
+        The system.
+
+    format : str
+        The molecular file format.
+
+    filebase : str
+        The file base to copy the file to.
+
+    property_map : dict
+        A dictionary that maps system "properties" to their user
+        defined values. This allows the user to refer to properties
+        with their own naming scheme, e.g. { "charge" : "my-charge" }
+
+    excluded_properties : [str]
+        A list of properties to exclude when comparing systems when checking
+        the file cache.
+
+    Returns
+    -------
+
+    extension : str
+        The extension for cached file. False if no file was found.
+    """
+
+    # Validate input.
+
+    if not isinstance(system, _System):
+        raise TypeError("'system' must be of type 'BioSimSpace._SireWrappers.System'")
+
+    if not isinstance(format, str):
+        raise TypeError("'format' must be of type 'str'")
+
+    if not isinstance(filebase, str):
+        raise TypeError("'filebase' must be of type 'str'")
+
+    if not isinstance(excluded_properties, (list, tuple)):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    if not all(isinstance(x, str) for x in excluded_properties):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    if not isinstance(property_map, dict):
+        raise TypeError("'property_map' must be of type 'dict'.")
+
+    # Create the key.
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+
+    # Get the existing file path and MD5 hash from the cache.
+    try:
+        (prev_system, path, original_hash) = _cache[key]
+    except:
+        return False
+
+    # Whether the cache entry is still valid.
+    cache_valid = True
+
+    # Is this system the same as the previous?
+    if not system.isSame(
+        prev_system,
+        excluded_properties=excluded_properties,
+        property_map0=property_map,
+        property_map1=property_map,
+    ):
+        cache_valid = False
+
+    # Make sure the file still exists.
+    if not _os.path.exists(path):
+        cache_valid = False
+    # Make sure the MD5 sum is still the same.
+    else:
+        current_hash = _get_md5_hash(path)
+        if current_hash != original_hash:
+            cache_valid = False
+
+    # If the cache isn't valid, delete the entry and return False.
+    if not cache_valid:
+        if key in _cache:
+            del _cache[key]
+        return False
+
+    # Copy the old file to the new location.
+    else:
+        # Get the file extension.
+        ext = _os.path.splitext(path)[1]
+
+        # Add the extension to the file base.
+        new_path = filebase + ext
+
+        # Copy the file to the new location.
+        try:
+            _shutil.copyfile(path, new_path)
+        except _shutil.SameFileError:
+            pass
+
+        return ext
+
+
+def update_cache(system, format, path, excluded_properties=[]):
+    """
+    Update the file cache when a new system is written to a specified format.
+
+    Parameters
+    ----------
+
+    system : :class:`System <BioSimSpace._SireWrappers.System>`
+        The system.
+
+    format : str
+        The molecular file format.
+
+    path : str
+        The path to the file.
+
+    excluded_properties : [str]
+        A list of properties to exclude when comparing systems when checking
+    """
+
+    # Validate input.
+
+    if not isinstance(system, _System):
+        raise TypeError("'system' must be of type 'BioSimSpace._SireWrappers.System'")
+
+    if not isinstance(format, str):
+        raise TypeError("'format' must be of type 'str'")
+
+    if not isinstance(excluded_properties, (list, tuple)):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    if not isinstance(path, str):
+        raise TypeError("'path' must be of type 'str'")
+
+    if not _os.path.exists(path):
+        raise IOError(f"File does not exist: '{path}'")
+
+    if not all(isinstance(x, str) for x in excluded_properties):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    # Convert to an absolute path.
+    path = _os.path.abspath(path)
+
+    # Get the MD5 checksum for the file.
+    hash = _get_md5_hash(path)
+
+    # Create the key.
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+
+    # Update the cache.
+    _cache[key] = (system, path, hash)
+
+
+def _get_md5_hash(path):
+    """
+    Internal helper function to return the MD5 checksum for a file.
+
+    Returns
+    -------
+
+    hash : hashlib.HASH
+    """
+    # Get the MD5 hash of the file. Process in chunks in case the file is too
+    # large to process.
+    hash = _hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash.update(chunk)
+
+    return hash.hexdigest()

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -197,6 +197,9 @@ def check_cache(
             _shutil.copyfile(path, new_path)
         except _shutil.SameFileError:
             pass
+        except:
+            del _cache[key]
+            return False
 
         return ext
 

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -65,8 +65,8 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
         self._num_atoms += value[0].nAtoms()
         if self._max_atoms > 0:
             if self._num_atoms > self._max_atoms:
-                item = self.popitem(False)
-                self._num_atoms -= item[0].nAtoms()
+                key, value = self.popitem(False)
+                self._num_atoms -= value[0].nAtoms()
 
 
 # Initialise a "cache" dictionary. This maps a key of the system UID, file format

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -76,7 +76,9 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
 _cache = _FixedSizeOrderedDict()
 
 
-def check_cache(system, format, filebase, property_map={}, excluded_properties=[]):
+def check_cache(
+    system, format, filebase, property_map={}, excluded_properties=[], skip_water=True
+):
     """
     Check whether a Sire system has previously been written to the specified format.
 
@@ -100,6 +102,9 @@ def check_cache(system, format, filebase, property_map={}, excluded_properties=[
     excluded_properties : [str]
         A list of properties to exclude when comparing systems when checking
         the file cache.
+
+    skip_water : bool
+        Whether to skip water molecules when comparing systems.
 
     Returns
     -------
@@ -128,6 +133,9 @@ def check_cache(system, format, filebase, property_map={}, excluded_properties=[
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'.")
 
+    if not isinstance(skip_water, bool):
+        raise TypeError("'skip_water' must be of type 'bool'.")
+
     # Create the key.
     key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
 
@@ -146,6 +154,7 @@ def check_cache(system, format, filebase, property_map={}, excluded_properties=[
         excluded_properties=excluded_properties,
         property_map0=property_map,
         property_map1=property_map,
+        skip_water=skip_water,
     ):
         cache_valid = False
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -1102,7 +1102,7 @@ def _check_cache(system, format, filebase, property_map={}, excluded_properties=
         raise TypeError("'property_map' must be of type 'dict'.")
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(excluded_properties))
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
 
     # Get the existing file path and MD5 hash from the cache.
     try:
@@ -1202,7 +1202,7 @@ def _update_cache(system, format, path, excluded_properties=[]):
     hash = _get_md5_hash(path)
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(excluded_properties))
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
 
     # Update the cache.
     _file_cache[key] = (system, path, hash)

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -530,9 +530,7 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
     return _System(system)
 
 
-def saveMolecules(
-    filebase, system, fileformat, property_map={}, excluded_properties=[]
-):
+def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
     """
     Save a molecular system to file.
 
@@ -554,10 +552,6 @@ def saveMolecules(
         A dictionary that maps system "properties" to their user
         defined values. This allows the user to refer to properties
         with their own naming scheme, e.g. { "charge" : "my-charge" }
-
-    excluded_properties : [str]
-        A list of properties to exclude when comparing systems when checking
-        the file cache.
 
     Returns
     -------
@@ -661,12 +655,6 @@ def saveMolecules(
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'")
 
-    # Validate the excluded property_map.
-    if not isinstance(excluded_properties, (list, tuple)):
-        raise TypeError("'excluded_properties' must be a list of 'str' types.")
-    if not all(isinstance(x, str) for x in excluded_properties):
-        raise TypeError("'excluded_properties' must be a list of 'str' types.")
-
     # Copy the map.
     _property_map = property_map.copy()
 
@@ -692,7 +680,7 @@ def saveMolecules(
             format,
             filebase,
             property_map=property_map,
-            excluded_properties=excluded_properties,
+            **kwargs,
         )
         if ext:
             files.append(_os.path.abspath(filebase + ext))
@@ -763,9 +751,7 @@ def saveMolecules(
             files += file
 
             # If this is a new file, then add it to the cache.
-            _update_cache(
-                system, format, file[0], excluded_properties=excluded_properties
-            )
+            _update_cache(system, format, file[0], **kwargs)
 
         except Exception as e:
             msg = "Failed to save system to format: '%s'" % format

--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -306,9 +306,7 @@ class Amber(_process.Process):
         # RST file (coordinates).
         try:
             file = _os.path.splitext(self._rst_file)[0]
-            _IO.saveMolecules(
-                self._rst_file, system, "rst7", property_map=self._property_map
-            )
+            _IO.saveMolecules(file, system, "rst7", property_map=self._property_map)
         except Exception as e:
             msg = "Failed to write system to 'RST7' format."
             if _isVerbose():
@@ -319,9 +317,7 @@ class Amber(_process.Process):
         # PRM file (topology).
         try:
             file = _os.path.splitext(self._top_file)[0]
-            _IO.saveMolecules(
-                self._top_file, system, "prm7", property_map=self._property_map
-            )
+            _IO.saveMolecules(file, system, "prm7", property_map=self._property_map)
         except Exception as e:
             msg = "Failed to write system to 'PRM7' format."
             if _isVerbose():

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -231,7 +231,7 @@ class Relative:
             # Check that the engine is supported.
             if engine not in self._engines:
                 raise ValueError(
-                    "Unsupported molecular dynamics engine '%s'. "
+                    f"Unsupported molecular dynamics engine {engine}. "
                     "Supported engines are: %r." % ", ".join(self._engines)
                 )
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -1,0 +1,253 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2023
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""Functionality for caching molecular files to avoid re-writing."""
+
+__author__ = "Lester Hedges"
+__email__ = "lester.hedges@gmail.com"
+
+__all__ = ["check_cache", "update_cache"]
+
+import collections as _collections
+import hashlib as _hashlib
+import os as _os
+import shutil as _shutil
+import sys as _sys
+
+from .._SireWrappers import System as _System
+
+
+class _FixedSizeOrderedDict(_collections.OrderedDict):
+    """A utility class to implement a fixed-sized cache."""
+
+    def __init__(self, *args, max=2, **kwargs):
+        """
+        Constructor.
+
+        Parameters
+        ----------
+
+        max : float
+            The maximum size in GB.
+        """
+
+        # Work out the approximate maximum number of atoms.
+        if max > 0:
+            self._max_atoms = int((max * 1e9) / (9 * _sys.getsizeof(float())))
+        else:
+            self._max_atoms = 0
+
+        # Store the total number of atoms.
+        self._num_atoms = 0
+
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key, value):
+        _collections.OrderedDict.__setitem__(self, key, value)
+        self._num_atoms += value[0].nAtoms()
+        if self._max_atoms > 0:
+            if self._num_atoms > self._max_atoms:
+                item = self.popitem(False)
+                self._num_atoms -= item[0].nAtoms()
+
+
+# Initialise a "cache" dictionary. This maps a key of the system UID, file format
+# and excluded properties a value of the system and file path. When saving to a
+# given format, we can then to see if a matching system has previously been written
+# to the same format, allowing us to re-use the existing file.
+_cache = _FixedSizeOrderedDict()
+
+
+def check_cache(system, format, filebase, property_map={}, excluded_properties=[]):
+    """
+    Check whether a Sire system has previously been written to the specified format.
+
+    Parameters
+    ----------
+
+    system : :class:`System <BioSimSpace._SireWrappers.System>`
+        The system.
+
+    format : str
+        The molecular file format.
+
+    filebase : str
+        The file base to copy the file to.
+
+    property_map : dict
+        A dictionary that maps system "properties" to their user
+        defined values. This allows the user to refer to properties
+        with their own naming scheme, e.g. { "charge" : "my-charge" }
+
+    excluded_properties : [str]
+        A list of properties to exclude when comparing systems when checking
+        the file cache.
+
+    Returns
+    -------
+
+    extension : str
+        The extension for cached file. False if no file was found.
+    """
+
+    # Validate input.
+
+    if not isinstance(system, _System):
+        raise TypeError("'system' must be of type 'BioSimSpace._SireWrappers.System'")
+
+    if not isinstance(format, str):
+        raise TypeError("'format' must be of type 'str'")
+
+    if not isinstance(filebase, str):
+        raise TypeError("'filebase' must be of type 'str'")
+
+    if not isinstance(excluded_properties, (list, tuple)):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    if not all(isinstance(x, str) for x in excluded_properties):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    if not isinstance(property_map, dict):
+        raise TypeError("'property_map' must be of type 'dict'.")
+
+    # Create the key.
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+
+    # Get the existing file path and MD5 hash from the cache.
+    try:
+        (prev_system, path, original_hash) = _cache[key]
+    except:
+        return False
+
+    # Whether the cache entry is still valid.
+    cache_valid = True
+
+    # Is this system the same as the previous?
+    if not system.isSame(
+        prev_system,
+        excluded_properties=excluded_properties,
+        property_map0=property_map,
+        property_map1=property_map,
+    ):
+        cache_valid = False
+
+    # Make sure the file still exists.
+    if not _os.path.exists(path):
+        cache_valid = False
+    # Make sure the MD5 sum is still the same.
+    else:
+        current_hash = _get_md5_hash(path)
+        if current_hash != original_hash:
+            cache_valid = False
+
+    # If the cache isn't valid, delete the entry and return False.
+    if not cache_valid:
+        if key in _cache:
+            del _cache[key]
+        return False
+
+    # Copy the old file to the new location.
+    else:
+        # Get the file extension.
+        ext = _os.path.splitext(path)[1]
+
+        # Add the extension to the file base.
+        new_path = filebase + ext
+
+        # Copy the file to the new location.
+        try:
+            _shutil.copyfile(path, new_path)
+        except _shutil.SameFileError:
+            pass
+
+        return ext
+
+
+def update_cache(system, format, path, excluded_properties=[]):
+    """
+    Update the file cache when a new system is written to a specified format.
+
+    Parameters
+    ----------
+
+    system : :class:`System <BioSimSpace._SireWrappers.System>`
+        The system.
+
+    format : str
+        The molecular file format.
+
+    path : str
+        The path to the file.
+
+    excluded_properties : [str]
+        A list of properties to exclude when comparing systems when checking
+    """
+
+    # Validate input.
+
+    if not isinstance(system, _System):
+        raise TypeError("'system' must be of type 'BioSimSpace._SireWrappers.System'")
+
+    if not isinstance(format, str):
+        raise TypeError("'format' must be of type 'str'")
+
+    if not isinstance(excluded_properties, (list, tuple)):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    if not isinstance(path, str):
+        raise TypeError("'path' must be of type 'str'")
+
+    if not _os.path.exists(path):
+        raise IOError(f"File does not exist: '{path}'")
+
+    if not all(isinstance(x, str) for x in excluded_properties):
+        raise TypeError("'excluded_properties' must be a list of 'str' types.")
+
+    # Convert to an absolute path.
+    path = _os.path.abspath(path)
+
+    # Get the MD5 checksum for the file.
+    hash = _get_md5_hash(path)
+
+    # Create the key.
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+
+    # Update the cache.
+    _cache[key] = (system, path, hash)
+
+
+def _get_md5_hash(path):
+    """
+    Internal helper function to return the MD5 checksum for a file.
+
+    Returns
+    -------
+
+    hash : hashlib.HASH
+    """
+    # Get the MD5 hash of the file. Process in chunks in case the file is too
+    # large to process.
+    hash = _hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash.update(chunk)
+
+    return hash.hexdigest()

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -77,7 +77,13 @@ _cache = _FixedSizeOrderedDict()
 
 
 def check_cache(
-    system, format, filebase, property_map={}, excluded_properties=[], skip_water=True
+    system,
+    format,
+    filebase,
+    property_map={},
+    excluded_properties=[],
+    skip_water=True,
+    **kwargs,
 ):
     """
     Check whether a Sire system has previously been written to the specified format.
@@ -137,7 +143,12 @@ def check_cache(
         raise TypeError("'skip_water' must be of type 'bool'.")
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+    key = (
+        system._sire_object.uid().toString(),
+        format,
+        str(set(excluded_properties)),
+        str(skip_water),
+    )
 
     # Get the existing file path and MD5 hash from the cache.
     try:
@@ -190,7 +201,9 @@ def check_cache(
         return ext
 
 
-def update_cache(system, format, path, excluded_properties=[]):
+def update_cache(
+    system, format, path, excluded_properties=[], skip_water=True, **kwargs
+):
     """
     Update the file cache when a new system is written to a specified format.
 
@@ -208,6 +221,9 @@ def update_cache(system, format, path, excluded_properties=[]):
 
     excluded_properties : [str]
         A list of properties to exclude when comparing systems when checking
+
+    skip_water : bool
+        Whether to skip water molecules when comparing systems.
     """
 
     # Validate input.
@@ -230,6 +246,9 @@ def update_cache(system, format, path, excluded_properties=[]):
     if not all(isinstance(x, str) for x in excluded_properties):
         raise TypeError("'excluded_properties' must be a list of 'str' types.")
 
+    if not isinstance(skip_water, bool):
+        raise TypeError("'skip_water' must be of type 'bool'.")
+
     # Convert to an absolute path.
     path = _os.path.abspath(path)
 
@@ -237,7 +256,12 @@ def update_cache(system, format, path, excluded_properties=[]):
     hash = _get_md5_hash(path)
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
+    key = (
+        system._sire_object.uid().toString(),
+        format,
+        str(set(excluded_properties)),
+        str(skip_water),
+    )
 
     # Update the cache.
     _cache[key] = (system, path, hash)

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -197,6 +197,9 @@ def check_cache(
             _shutil.copyfile(path, new_path)
         except _shutil.SameFileError:
             pass
+        except:
+            del _cache[key]
+            return False
 
         return ext
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -65,8 +65,8 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
         self._num_atoms += value[0].nAtoms()
         if self._max_atoms > 0:
             if self._num_atoms > self._max_atoms:
-                item = self.popitem(False)
-                self._num_atoms -= item[0].nAtoms()
+                key, value = self.popitem(False)
+                self._num_atoms -= value[0].nAtoms()
 
 
 # Initialise a "cache" dictionary. This maps a key of the system UID, file format

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -76,7 +76,9 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
 _cache = _FixedSizeOrderedDict()
 
 
-def check_cache(system, format, filebase, property_map={}, excluded_properties=[]):
+def check_cache(
+    system, format, filebase, property_map={}, excluded_properties=[], skip_water=True
+):
     """
     Check whether a Sire system has previously been written to the specified format.
 
@@ -100,6 +102,9 @@ def check_cache(system, format, filebase, property_map={}, excluded_properties=[
     excluded_properties : [str]
         A list of properties to exclude when comparing systems when checking
         the file cache.
+
+    skip_water : bool
+        Whether to skip water molecules when comparing systems.
 
     Returns
     -------
@@ -128,6 +133,9 @@ def check_cache(system, format, filebase, property_map={}, excluded_properties=[
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'.")
 
+    if not isinstance(skip_water, bool):
+        raise TypeError("'skip_water' must be of type 'bool'.")
+
     # Create the key.
     key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
 
@@ -146,6 +154,7 @@ def check_cache(system, format, filebase, property_map={}, excluded_properties=[
         excluded_properties=excluded_properties,
         property_map0=property_map,
         property_map1=property_map,
+        skip_water=skip_water,
     ):
         cache_valid = False
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -1102,7 +1102,7 @@ def _check_cache(system, format, filebase, property_map={}, excluded_properties=
         raise TypeError("'property_map' must be of type 'dict'.")
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(excluded_properties))
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
 
     # Get the existing file path and MD5 hash from the cache.
     try:
@@ -1202,7 +1202,7 @@ def _update_cache(system, format, path, excluded_properties=[]):
     hash = _get_md5_hash(path)
 
     # Create the key.
-    key = (system._sire_object.uid().toString(), format, str(excluded_properties))
+    key = (system._sire_object.uid().toString(), format, str(set(excluded_properties)))
 
     # Update the cache.
     _file_cache[key] = (system, path, hash)

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -530,9 +530,7 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
     return _System(system)
 
 
-def saveMolecules(
-    filebase, system, fileformat, property_map={}, excluded_properties=[]
-):
+def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
     """
     Save a molecular system to file.
 
@@ -554,10 +552,6 @@ def saveMolecules(
         A dictionary that maps system "properties" to their user
         defined values. This allows the user to refer to properties
         with their own naming scheme, e.g. { "charge" : "my-charge" }
-
-    excluded_properties : [str]
-        A list of properties to exclude when comparing systems when checking
-        the file cache.
 
     Returns
     -------
@@ -661,12 +655,6 @@ def saveMolecules(
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'")
 
-    # Validate the excluded property_map.
-    if not isinstance(excluded_properties, (list, tuple)):
-        raise TypeError("'excluded_properties' must be a list of 'str' types.")
-    if not all(isinstance(x, str) for x in excluded_properties):
-        raise TypeError("'excluded_properties' must be a list of 'str' types.")
-
     # Copy the map.
     _property_map = property_map.copy()
 
@@ -692,7 +680,7 @@ def saveMolecules(
             format,
             filebase,
             property_map=property_map,
-            excluded_properties=excluded_properties,
+            **kwargs,
         )
         if ext:
             files.append(_os.path.abspath(filebase + ext))
@@ -763,9 +751,7 @@ def saveMolecules(
             files += file
 
             # If this is a new file, then add it to the cache.
-            _update_cache(
-                system, format, file[0], excluded_properties=excluded_properties
-            )
+            _update_cache(system, format, file[0], **kwargs)
 
         except Exception as e:
             msg = "Failed to save system to format: '%s'" % format

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -469,8 +469,9 @@ class System(_SireWrapper):
         ):
             return False
 
-        # Invert the first property map.
+        # Invert the property maps.
         inv_prop_map0 = {v: k for k, v in property_map0.items()}
+        inv_prop_map1 = {v: k for k, v in property_map1.items()}
 
         # Add some additional properties to the excluded list. These are
         # used for internal metadata to aid object recovery.
@@ -480,8 +481,12 @@ class System(_SireWrapper):
         def _object_compare(object0, object1):
             """Helper function to check whether two Sire objects are the same."""
 
+            # Store the two sets of properties.
+            props0 = object0.propertyKeys()
+            props1 = object1.propertyKeys()
+
             # Loop over all properties of object0.
-            for p0 in object0.propertyKeys():
+            for p0 in props0:
                 # Get the actual property name.
                 name0 = inv_prop_map0.get(p0, p0)
 
@@ -515,6 +520,14 @@ class System(_SireWrapper):
                     # Property is missing, so the objects differ.
                     else:
                         return False
+
+            # Now check that there aren't any additional properties in object1
+            # that aren't excluded.
+            for p1 in props1:
+                name1 = inv_prop_map1.get(p1, p1)
+                # This is a property unique to object1, so they differ.
+                if not name1 in _excluded_properties and name1 not in props0:
+                    return False
 
             # If we get this far, then the objects are the same.
             return True

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -469,8 +469,9 @@ class System(_SireWrapper):
         ):
             return False
 
-        # Invert the first property map.
+        # Invert the property maps.
         inv_prop_map0 = {v: k for k, v in property_map0.items()}
+        inv_prop_map1 = {v: k for k, v in property_map1.items()}
 
         # Add some additional properties to the excluded list. These are
         # used for internal metadata to aid object recovery.
@@ -480,8 +481,12 @@ class System(_SireWrapper):
         def _object_compare(object0, object1):
             """Helper function to check whether two Sire objects are the same."""
 
+            # Store the two sets of properties.
+            props0 = object0.propertyKeys()
+            props1 = object1.propertyKeys()
+
             # Loop over all properties of object0.
-            for p0 in object0.propertyKeys():
+            for p0 in props0:
                 # Get the actual property name.
                 name0 = inv_prop_map0.get(p0, p0)
 
@@ -515,6 +520,14 @@ class System(_SireWrapper):
                     # Property is missing, so the objects differ.
                     else:
                         return False
+
+            # Now check that there aren't any additional properties in object1
+            # that aren't excluded.
+            for p1 in props1:
+                name1 = inv_prop_map1.get(p1, p1)
+                # This is a property unique to object1, so they differ.
+                if not name1 in _excluded_properties and name1 not in props0:
+                    return False
 
             # If we get this far, then the objects are the same.
             return True

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -58,9 +58,9 @@ class System(_SireWrapper):
         ----------
 
         system : Sire.System.System, :class:`System <BioSimSpace._SireWrappers.System>`, \
-                Sire.Mol._Mol.Molecule, :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, \
-                :class:`Molecules <BioSimSpace._SireWrappers.Molecules>` \
-                [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
+                 Sire.Mol._Mol.Molecule, :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, \
+                 :class:`Molecules <BioSimSpace._SireWrappers.Molecules>` \
+                 [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
             A Sire or BioSimSpace System object, a Sire or BioSimSpace Molecule object,
             a BioSimSpace Molecules object, or a list of BioSimSpace molecule objects.
         """
@@ -693,7 +693,8 @@ class System(_SireWrapper):
         self._mol_nums = self._sire_object.molNums()
 
     def updateMolecule(self, index, molecule):
-        """Updated the molecule at the given index.
+        """
+        Update the molecule at the given index.
 
         Parameters
         ----------

--- a/test/IO/test_file_cache.py
+++ b/test/IO/test_file_cache.py
@@ -13,7 +13,7 @@ def test_file_cache():
     """
 
     # Clear the file cache.
-    BSS.IO._io._file_cache = {}
+    BSS.IO._file_cache._cache = {}
 
     # Load the molecular system.
     s = BSS.IO.readMolecules(["test/input/ala.crd", "test/input/ala.top"])
@@ -26,13 +26,13 @@ def test_file_cache():
     BSS.IO.saveMolecules(f"{tmp_path}/tmp", s, ["pdb", "prm7"])
 
     # Check that the file cache has two entries.
-    assert len(BSS.IO._io._file_cache) == 2
+    assert len(BSS.IO._file_cache._cache) == 2
 
     # Write to PDB and GroTop format. The PDB from the cache should be reused.
     BSS.IO.saveMolecules(f"{tmp_path}/tmp2", s, ["pdb", "grotop"])
 
     # Check that the file cache has three entries, i.e. only the GroTop was added.
-    assert len(BSS.IO._io._file_cache) == 3
+    assert len(BSS.IO._file_cache._cache) == 3
 
     # The directory should now contain 4 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 4
@@ -43,7 +43,7 @@ def test_file_cache():
     BSS.IO.saveMolecules(f"{tmp_path}/tmp3", s, ["pdb", "grotop"])
 
     # Check that the file cache still has three entries.
-    assert len(BSS.IO._io._file_cache) == 3
+    assert len(BSS.IO._file_cache._cache) == 3
 
     # The directory should now contain 5 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 5
@@ -58,7 +58,7 @@ def test_file_cache():
     BSS.IO.saveMolecules(f"{tmp_path}/tmp4", s, ["pdb", "gro87"])
 
     # Check that the file cache still has three entries.
-    assert len(BSS.IO._io._file_cache) == 4
+    assert len(BSS.IO._file_cache._cache) == 4
 
     # The directory should now contain 7 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 7

--- a/test/Sandpit/Exscientia/IO/test_file_cache.py
+++ b/test/Sandpit/Exscientia/IO/test_file_cache.py
@@ -13,7 +13,7 @@ def test_file_cache():
     """
 
     # Clear the file cache.
-    BSS.IO._io._file_cache = {}
+    BSS.IO._file_cache._cache = {}
 
     # Load the molecular system.
     s = BSS.IO.readMolecules(["test/input/ala.crd", "test/input/ala.top"])
@@ -26,13 +26,13 @@ def test_file_cache():
     BSS.IO.saveMolecules(f"{tmp_path}/tmp", s, ["pdb", "prm7"])
 
     # Check that the file cache has two entries.
-    assert len(BSS.IO._io._file_cache) == 2
+    assert len(BSS.IO._file_cache._cache) == 2
 
     # Write to PDB and GroTop format. The PDB from the cache should be reused.
     BSS.IO.saveMolecules(f"{tmp_path}/tmp2", s, ["pdb", "grotop"])
 
     # Check that the file cache has three entries, i.e. only the GroTop was added.
-    assert len(BSS.IO._io._file_cache) == 3
+    assert len(BSS.IO._file_cache._cache) == 3
 
     # The directory should now contain 4 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 4
@@ -43,7 +43,7 @@ def test_file_cache():
     BSS.IO.saveMolecules(f"{tmp_path}/tmp3", s, ["pdb", "grotop"])
 
     # Check that the file cache still has three entries.
-    assert len(BSS.IO._io._file_cache) == 3
+    assert len(BSS.IO._file_cache._cache) == 3
 
     # The directory should now contain 5 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 5
@@ -58,7 +58,7 @@ def test_file_cache():
     BSS.IO.saveMolecules(f"{tmp_path}/tmp4", s, ["pdb", "gro87"])
 
     # Check that the file cache still has three entries.
-    assert len(BSS.IO._io._file_cache) == 4
+    assert len(BSS.IO._file_cache._cache) == 4
 
     # The directory should now contain 7 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 7

--- a/test/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -323,3 +323,25 @@ def test_molecule_replace(system):
         assert num0 == num1
     for num0, num1 in zip(mol_nums0[4:], mol_nums1[4:]):
         assert num0 == num1
+
+
+def test_isSame(system):
+    # Make sure that the isSame method works correctly.
+
+    # Make a copy of the system.
+    other = system.copy()
+
+    # Assert they are the same, making sure it is invariant to the order.
+    assert system.isSame(other)
+    assert other.isSame(system)
+
+    # Translate the other system.
+    other.translate(3 * [BSS.Units.Length.angstrom])
+
+    # Assert that they are different.
+    assert not system.isSame(other)
+    assert not other.isSame(system)
+
+    # Assert that they are the same, apart from their coordinates.
+    assert system.isSame(other, excluded_properties=["coordinates"])
+    assert other.isSame(system, excluded_properties=["coordinates"])

--- a/test/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -345,3 +345,14 @@ def test_isSame(system):
     # Assert that they are the same, apart from their coordinates.
     assert system.isSame(other, excluded_properties=["coordinates"])
     assert other.isSame(system, excluded_properties=["coordinates"])
+
+    # Now delete a property.
+    other._sire_object.removeProperty("space")
+
+    # Assert that they are different.
+    assert not system.isSame(other, excluded_properties=["coordinates"])
+    assert not other.isSame(system, excluded_properties=["coordinates"])
+
+    # Assert that they are the same, apart from their coordinates and space.
+    assert system.isSame(other, excluded_properties=["coordinates", "space"])
+    assert other.isSame(system, excluded_properties=["coordinates", "space"])

--- a/test/_SireWrappers/test_system.py
+++ b/test/_SireWrappers/test_system.py
@@ -323,3 +323,25 @@ def test_molecule_replace(system):
         assert num0 == num1
     for num0, num1 in zip(mol_nums0[4:], mol_nums1[4:]):
         assert num0 == num1
+
+
+def test_isSame(system):
+    # Make sure that the isSame method works correctly.
+
+    # Make a copy of the system.
+    other = system.copy()
+
+    # Assert they are the same, making sure it is invariant to the order.
+    assert system.isSame(other)
+    assert other.isSame(system)
+
+    # Translate the other system.
+    other.translate(3 * [BSS.Units.Length.angstrom])
+
+    # Assert that they are different.
+    assert not system.isSame(other)
+    assert not other.isSame(system)
+
+    # Assert that they are the same, apart from their coordinates.
+    assert system.isSame(other, excluded_properties=["coordinates"])
+    assert other.isSame(system, excluded_properties=["coordinates"])

--- a/test/_SireWrappers/test_system.py
+++ b/test/_SireWrappers/test_system.py
@@ -345,3 +345,14 @@ def test_isSame(system):
     # Assert that they are the same, apart from their coordinates.
     assert system.isSame(other, excluded_properties=["coordinates"])
     assert other.isSame(system, excluded_properties=["coordinates"])
+
+    # Now delete a property.
+    other._sire_object.removeProperty("space")
+
+    # Assert that they are different.
+    assert not system.isSame(other, excluded_properties=["coordinates"])
+    assert not other.isSame(system, excluded_properties=["coordinates"])
+
+    # Assert that they are the same, apart from their coordinates and space.
+    assert system.isSame(other, excluded_properties=["coordinates", "space"])
+    assert other.isSame(system, excluded_properties=["coordinates", "space"])


### PR DESCRIPTION
# Does this pull request introduce new functionality?

This pull request adds the `BioSimSpace._SireWrappers.System.isSame` method, to allow system comparisons based on _properties_. This allows a user to compare two systems based on a set of common properties, excluding any that are required, e.g. `coordinates` , `space`, and `velocity` wanting to just just compare topologies. The method has some basic system checks, i.e. UID, number of molecules, number of atoms, number of residues, which are always performed to quickly reject non-comparable systems.

To compare a `system` to `other`:

```python
import BioSImSpace as BSS

files = BSS.IO.expand(
    BSS.tutorialUrl(),
    ["ala.crd", "ala.top"],
    ".bz2"
)

system = BSS.IO.readMolecules(files)

# Make a copy of the system.
other = system.copy()

# Assert they are the same, making sure it is invariant to the order.
assert system.isSame(other)
assert other.isSame(system)

# Translate the other system.
other.translate(3 * [BSS.Units.Length.angstrom])

# Assert that they are different.
assert not system.isSame(other)
assert not other.isSame(system)

# Assert that they are the same, apart from their coordinates.
assert system.isSame(other, excluded_properties=["coordinates"])
assert other.isSame(system, excluded_properties=["coordinates"])

# Now delete a property.
other._sire_object.removeProperty("space")

# Assert that they are different.
assert not system.isSame(other, excluded_properties=["coordinates"])
assert not other.isSame(system, excluded_properties=["coordinates"])

# Assert that they are the same, apart from their coordinates and space.
assert system.isSame(other, excluded_properties=["coordinates", "space"])
assert other.isSame(system, excluded_properties=["coordinates", "space"])
```

To speed things up, I've also added the option to `skip_water`, i.e. if you know that the systems use the same water topology.

With this in place, we now have the ability to perform per-format file caching, using a set of excluded property keys for a given format. The existing file cache code has been refactored and updated to use the `isSame` functionality behind the scenes when comparing systems. The cache key is now the system UID, the set of excluded properties, whether to ignore water molecules, and the chosen format. This value is the last system used to write to the matching key, the path to the file that was written, and its MD5 checksum. The cache uses a simple fixed-sized dictionary with a rough 2GB, which is based on the total number of atoms stored. This can be optimised at later date, or we could expose an environment variable to allow users to set the size limit in their scripts. (In practice, I don't think the cache will get large for a typical script.)

To confirm that things are working as expected I ran a full hydration free energy setup and checked the resulting cache:

```python
import BioSimSpace as BSS

m0 = BSS.IO.readMolecules("molecules/ethane.pdb")[0]
m1 = BSS.IO.readMolecules("molecules/methanol.pdb")[0]

m0 = BSS.Parameters.gaff(m0).getMolecule()
m1 = BSS.Parameters.gaff(m1).getMolecule()

mapping = BSS.Align.matchAtoms(m0, m1)
merged = BSS.Align.merge(m0, m1, mapping)

solvated = BSS.Solvent.tip3p(molecule=merged, box=3 * [5 * BSS.Units.Length.nanometer])

p = BSS.Protocol.FreeEnergy()
free_nrg = BSS.FreeEnergy.Relative(solvated, p, engine="gromacs", `work_dir="free")`

BSS.IO._file_cache._cache
_FixedSizeOrderedDict([(('{05758435-945f-4d74-acac-78d08a7b21cd}',
                         'PDB',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmpy90w2gb5/tmp.pdb',
                         '6302349bac84167d8d9711bad0af80eb')),
                       (('{4cdc49bc-f763-446d-b06d-1055222f214b}',
                         'PDB',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmpigj09fl0/antechamber.pdb',
                         '6302349bac84167d8d9711bad0af80eb')),
                       (('{36d6bb97-1ae2-45e5-a7b3-7f01fc4ce648}',
                         'PDB',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmp7sk0nfih/tmp.pdb',
                         '19613ec5a20f7e99936f36abe2bba62a')),
                       (('{5a92a925-3b77-405b-97f6-5f7516354432}',
                         'PDB',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmpklc3ipy4/antechamber.pdb',
                         '19613ec5a20f7e99936f36abe2bba62a')),
                       (('{9bcc7b74-fde7-48fc-bd2f-007c1eb9292f}',
                         'PDB',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmpa_hzmd22/tmp0.pdb',
                         '6302349bac84167d8d9711bad0af80eb')),
                       (('{f1c52df4-5fca-4773-8e2c-c1fd6ee39c89}',
                         'PDB',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmpa_hzmd22/tmp1.pdb',
                         '19613ec5a20f7e99936f36abe2bba62a')),
                       (('{59e0d301-0bac-404a-8a18-46d8797c5d94}',
                         'Gro87',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=1>,
                         '/tmp/tmpt8d7g4mk/input.gro',
                         'ff65fa2b29e231ea55a0796355210046')),
                       (('{3546a07d-e02c-4c12-a764-e5cc4c2af49f}',
                         'Gro87',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=4052>,
                         '/tmp/tmpt8d7g4mk/solvated.gro',
                         '3b7f17e1e81019db8380e5be7f7b57e0')),
                       (('{3546a07d-e02c-4c12-a764-e5cc4c2af49f}',
                         'GroTop',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=4052>,
                         '/tmp/tmpt8d7g4mk/solvated.top',
                         'ab9576151bedc6860ad6f16cdddeb72b')),
                       (('{aadef6b5-7176-4078-b8bb-32cdf753c044}',
                         'Gro87',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=4052>,
                         '/home/lester/Code/openbiosim/biosimspace/demo/free/lambda_0.0000/gromacs.gro',
                         'b2718324ab90b1b7633ca64921d01c4a')),
                       (('{aadef6b5-7176-4078-b8bb-32cdf753c044}',
                         'GroTop',
                         'set()',
                         'True'),
                        (<BioSimSpace.System: nMolecules=4052>,
                         '/home/lester/Code/openbiosim/biosimspace/demo/free/lambda_0.0000/gromacs.top',
                         'ba093c5a90b41d89246fb75e6ed10b12'))])
```

In this example, `FreeEnergy.Relative` sets up processes for 11 lambda windows. From the cache you can see that GROMACS coordinate and topology files have only been written for the lambda=0 window, and have been re-used for all 10 other windows (confirmed by checking the files exist, and are the same).

To take advantage of the caching a user can update the use of `BioSimSpace.IO.saveMolecules` wherever approprate, e.g. during the setup stage of a particular process. They just need to pass in `excluded_options` as an additional keyword argument.

Things to do:

* Test performance. I imagine this should be okay given that we skip water molecules. If it's too slow for large systems, then it would be easy to re-write in the C++ layer and wrap.
* The fixed-size cache is pretty basic but I think it should work well for most needs. I don't want to spend to much time optimising this until I get some real-world feedback.

@xiki-tempula: Just tagging you in so that you are aware of progress. No need to review at this stage. I'll back-port into `michellab` once this is complete.

# Checklist:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y] This is currently internal functionality so isn't directly exposed to the user.
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods