### PR TITLE
Add fkcombu as dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -109,6 +109,7 @@ finally:
         # Create a list of the conda dependencies.
         conda_deps = [
             "configargparse",
+            "fkcombu",
             "pygtail",
             "pyyaml",
             "watchdog",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sire ~=2023.1.0
 
 configargparse
 kcombu_bss
+fkcombu
 ipywidgets<8
 lomap2
 networkx


### PR DESCRIPTION
Hi,

I found that tests were failing as fkcombu was not installed after running `python setup.py install` - this PR fixes that.

Thanks.