### PR TITLE
Fix OpenMM minimisation

### DIFF
--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -334,7 +334,9 @@ class OpenMM(_process.Process):
             self.addToConfig(
                 "    simulation.context.setPeriodicBoxVectors(*inpcrd.boxVectors)"
             )
-            self.addToConfig(f"simulation.minimizeEnergy({self._protocol.getSteps()})")
+            self.addToConfig(
+                f"simulation.minimizeEnergy(maxIterations={self._protocol.getSteps()})"
+            )
 
             # Add the reporters.
             self.addToConfig("\n# Add reporters.")

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -334,7 +334,9 @@ class OpenMM(_process.Process):
             self.addToConfig(
                 "    simulation.context.setPeriodicBoxVectors(*inpcrd.boxVectors)"
             )
-            self.addToConfig(f"simulation.minimizeEnergy({self._protocol.getSteps()})")
+            self.addToConfig(
+                f"simulation.minimizeEnergy(maxIterations={self._protocol.getSteps()})"
+            )
 
             # Add the reporters.
             self.addToConfig("\n# Add reporters.")


### PR DESCRIPTION
This PR ensures that the number of steps is passed to `simulation.minimizeEnergy` using the `maxIterations` keyword. This had been omitted, meaning that the number of steps was being used as the tolerance (I think).

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]


## Suggested reviewers:
@chryswoods