### PR TITLE
Fix molecule name when SMILES starts with "[" character

### DIFF
--- a/python/BioSimSpace/Convert/_convert.py
+++ b/python/BioSimSpace/Convert/_convert.py
@@ -105,7 +105,7 @@ def smiles(
         # need to ensure that it doesn't start with an [ character,
         # which would break GROMACS.
         if smiles_string.startswith("["):
-            name = f"name:{smiles_string}"
+            name = f"smiles:{smiles_string}"
             edit_mol = molecule._sire_object.edit()
             edit_mol = edit_mol.rename(name).molecule()
             molecule._sire_object = edit_mol.commit()

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -353,8 +353,15 @@ class OpenForceField(_protocol.Protocol):
             # this will be missing.
 
             # Rename the molecule with the original SMILES string.
+            # Since the name is written to topology file formats, we
+            # need to ensure that it doesn't start with an [ character,
+            # which would break GROMACS.
+            name = molecule
+            if name.startswith("["):
+                name = f"name:{name}"
+
             edit_mol = new_mol._sire_object.edit()
-            edit_mol = edit_mol.rename(molecule).molecule()
+            edit_mol = edit_mol.rename(name).molecule()
 
             # Rename the residue LIG.
             resname = _SireMol.ResName("LIG")

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -358,7 +358,7 @@ class OpenForceField(_protocol.Protocol):
             # which would break GROMACS.
             name = molecule
             if name.startswith("["):
-                name = f"name:{name}"
+                name = f"smiles:{name}"
 
             edit_mol = new_mol._sire_object.edit()
             edit_mol = edit_mol.rename(name).molecule()

--- a/python/BioSimSpace/Parameters/_process.py
+++ b/python/BioSimSpace/Parameters/_process.py
@@ -142,6 +142,9 @@ class Process:
                 _warnings.warn(
                     "Attempting to parameterise a molecule without hydrogen atoms!"
                 )
+        # Strip whitespace from SMILES strings.
+        else:
+            molecule = molecule.replace(" ", "")
 
         # Set attributes.
         self._molecule = molecule

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
@@ -105,7 +105,7 @@ def smiles(
         # need to ensure that it doesn't start with an [ character,
         # which would break GROMACS.
         if smiles_string.startswith("["):
-            name = f"name:{smiles_string}"
+            name = f"smiles:{smiles_string}"
             edit_mol = molecule._sire_object.edit()
             edit_mol = edit_mol.rename(name).molecule()
             molecule._sire_object = edit_mol.commit()

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -353,8 +353,15 @@ class OpenForceField(_protocol.Protocol):
             # this will be missing.
 
             # Rename the molecule with the original SMILES string.
+            # Since the name is written to topology file formats, we
+            # need to ensure that it doesn't start with an [ character,
+            # which would break GROMACS.
+            name = molecule
+            if name.startswith("["):
+                name = f"name:{name}"
+
             edit_mol = new_mol._sire_object.edit()
-            edit_mol = edit_mol.rename(molecule).molecule()
+            edit_mol = edit_mol.rename(name).molecule()
 
             # Rename the residue LIG.
             resname = _SireMol.ResName("LIG")

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -358,7 +358,7 @@ class OpenForceField(_protocol.Protocol):
             # which would break GROMACS.
             name = molecule
             if name.startswith("["):
-                name = f"name:{name}"
+                name = f"smiles:{name}"
 
             edit_mol = new_mol._sire_object.edit()
             edit_mol = edit_mol.rename(name).molecule()

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
@@ -142,6 +142,9 @@ class Process:
                 _warnings.warn(
                     "Attempting to parameterise a molecule without hydrogen atoms!"
                 )
+        # Strip whitespace from SMILES strings.
+        else:
+            molecule = molecule.replace(" ", "")
 
         # Set attributes.
         self._molecule = molecule

--- a/test/Convert/test_convert.py
+++ b/test/Convert/test_convert.py
@@ -77,3 +77,17 @@ def test_atom(system):
     bss_atom = BSS.Convert.toBioSimSpace(sire_atom)
 
     assert isinstance(bss_atom, BSS._SireWrappers.Atom)
+
+
+def test_molecule_rename():
+    """
+    Test that a parameterised molecule generated from a SMILES string
+    starting with the "[" character is renamed with a "name:" prefix
+    so that it can be parsed by gmx when used in a GROMACS topology file.
+    """
+
+    # Create the parameterised molecule.
+    mol = BSS.Convert.smiles("[C@@H](C(F)(F)F)(OC(F)F)Cl")
+
+    # Make sure the name is correct.
+    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Convert/test_convert.py
+++ b/test/Convert/test_convert.py
@@ -82,7 +82,7 @@ def test_atom(system):
 def test_molecule_rename():
     """
     Test that a parameterised molecule generated from a SMILES string
-    starting with the "[" character is renamed with a "name:" prefix
+    starting with the "[" character is renamed with a "smiles:" prefix
     so that it can be parsed by gmx when used in a GROMACS topology file.
     """
 
@@ -90,4 +90,4 @@ def test_molecule_rename():
     mol = BSS.Convert.smiles("[C@@H](C(F)(F)F)(OC(F)F)Cl")
 
     # Make sure the name is correct.
-    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"
+    assert mol._sire_object.name().value() == "smiles:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Parameters/test_parameters.py
+++ b/test/Parameters/test_parameters.py
@@ -21,6 +21,9 @@ if BSS._amber_home is not None:
 else:
     has_tleap = False
 
+# Make sure antechamber is installed.
+has_antechamber = BSS.Parameters._Protocol._amber._antechamber_exe is not None
+
 
 @pytest.fixture(scope="session")
 def molecule():
@@ -48,7 +51,10 @@ def test_disulphide(molecule, ff):
     assert len(bonds) == 4
 
 
-@pytest.mark.skipif(has_openff is False, reason="Requires OpenFF to be installed.")
+@pytest.mark.skipif(
+    has_antechamber is False or has_openff is False,
+    reason="Requires AmberTools/antechamber and OpenFF to be installed.",
+)
 def test_molecule_rename():
     """
     Test that a parameterised molecule generated from a SMILES string

--- a/test/Parameters/test_parameters.py
+++ b/test/Parameters/test_parameters.py
@@ -1,7 +1,12 @@
 import BioSimSpace as BSS
+from BioSimSpace._Utils import _try_import, _have_imported
 
 import os
 import pytest
+
+# Make sure openff is installed.
+_openff = _try_import("openff")
+has_openff = _have_imported(_openff)
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -41,3 +46,20 @@ def test_disulphide(molecule, ff):
     # Check that the bond parameters are present in the molecule.
     bonds = molecule.search("bonds from element S to element S")
     assert len(bonds) == 4
+
+
+@pytest.mark.skipif(has_openff is False, reason="Requires OpenFF to be installed.")
+def test_molecule_rename():
+    """
+    Test that a parameterised molecule generated from a SMILES string
+    starting with the "[" character is renamed with a "name:" prefix
+    so that it can be parsed by gmx when used in a GROMACS topology file.
+    """
+
+    # Create the parameterised molecule.
+    mol = BSS.Parameters.openff_unconstrained_2_0_0(
+        "[C@@H](C(F)(F)F)(OC(F)F)Cl"
+    ).getMolecule()
+
+    # Make sure the name is correct.
+    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Parameters/test_parameters.py
+++ b/test/Parameters/test_parameters.py
@@ -58,7 +58,7 @@ def test_disulphide(molecule, ff):
 def test_molecule_rename():
     """
     Test that a parameterised molecule generated from a SMILES string
-    starting with the "[" character is renamed with a "name:" prefix
+    starting with the "[" character is renamed with a "smiles:" prefix
     so that it can be parsed by gmx when used in a GROMACS topology file.
     """
 
@@ -68,4 +68,4 @@ def test_molecule_rename():
     ).getMolecule()
 
     # Make sure the name is correct.
-    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"
+    assert mol._sire_object.name().value() == "smiles:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Sandpit/Exscientia/Convert/test_convert.py
+++ b/test/Sandpit/Exscientia/Convert/test_convert.py
@@ -77,3 +77,17 @@ def test_atom(system):
     bss_atom = BSS.Convert.toBioSimSpace(sire_atom)
 
     assert isinstance(bss_atom, BSS._SireWrappers.Atom)
+
+
+def test_molecule_rename():
+    """
+    Test that a parameterised molecule generated from a SMILES string
+    starting with the "[" character is renamed with a "name:" prefix
+    so that it can be parsed by gmx when used in a GROMACS topology file.
+    """
+
+    # Create the parameterised molecule.
+    mol = BSS.Convert.smiles("[C@@H](C(F)(F)F)(OC(F)F)Cl")
+
+    # Make sure the name is correct.
+    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Sandpit/Exscientia/Convert/test_convert.py
+++ b/test/Sandpit/Exscientia/Convert/test_convert.py
@@ -82,7 +82,7 @@ def test_atom(system):
 def test_molecule_rename():
     """
     Test that a parameterised molecule generated from a SMILES string
-    starting with the "[" character is renamed with a "name:" prefix
+    starting with the "[" character is renamed with a "smiles:" prefix
     so that it can be parsed by gmx when used in a GROMACS topology file.
     """
 
@@ -90,4 +90,4 @@ def test_molecule_rename():
     mol = BSS.Convert.smiles("[C@@H](C(F)(F)F)(OC(F)F)Cl")
 
     # Make sure the name is correct.
-    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"
+    assert mol._sire_object.name().value() == "smiles:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/test/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -21,6 +21,9 @@ if BSS._amber_home is not None:
 else:
     has_tleap = False
 
+# Make sure antechamber is installed.
+has_antechamber = BSS.Parameters._Protocol._amber._antechamber_exe is not None
+
 
 @pytest.fixture(scope="session")
 def molecule():
@@ -48,7 +51,10 @@ def test_disulphide(molecule, ff):
     assert len(bonds) == 4
 
 
-@pytest.mark.skipif(has_openff is False, reason="Requires OpenFF to be installed.")
+@pytest.mark.skipif(
+    has_antechamber is False or has_openff is False,
+    reason="Requires AmberTools/antechamber and OpenFF to be installed.",
+)
 def test_molecule_rename():
     """
     Test that a parameterised molecule generated from a SMILES string

--- a/test/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/test/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -58,7 +58,7 @@ def test_disulphide(molecule, ff):
 def test_molecule_rename():
     """
     Test that a parameterised molecule generated from a SMILES string
-    starting with the "[" character is renamed with a "name:" prefix
+    starting with the "[" character is renamed with a "smiles:" prefix
     so that it can be parsed by gmx when used in a GROMACS topology file.
     """
 
@@ -68,4 +68,4 @@ def test_molecule_rename():
     ).getMolecule()
 
     # Make sure the name is correct.
-    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"
+    assert mol._sire_object.name().value() == "smiles:[C@@H](C(F)(F)F)(OC(F)F)Cl"

--- a/test/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/test/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -1,7 +1,12 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia._Utils import _try_import, _have_imported
 
 import os
 import pytest
+
+# Make sure openff is installed.
+_openff = _try_import("openff")
+has_openff = _have_imported(_openff)
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -41,3 +46,20 @@ def test_disulphide(molecule, ff):
     # Check that the bond parameters are present in the molecule.
     bonds = molecule.search("bonds from element S to element S")
     assert len(bonds) == 4
+
+
+@pytest.mark.skipif(has_openff is False, reason="Requires OpenFF to be installed.")
+def test_molecule_rename():
+    """
+    Test that a parameterised molecule generated from a SMILES string
+    starting with the "[" character is renamed with a "name:" prefix
+    so that it can be parsed by gmx when used in a GROMACS topology file.
+    """
+
+    # Create the parameterised molecule.
+    mol = BSS.Parameters.openff_unconstrained_2_0_0(
+        "[C@@H](C(F)(F)F)(OC(F)F)Cl"
+    ).getMolecule()
+
+    # Make sure the name is correct.
+    assert mol._sire_object.name().value() == "name:[C@@H](C(F)(F)F)(OC(F)F)Cl"


### PR DESCRIPTION
This PR fixes a bug caused by molecules generated from SMILES strings with a `[ ... ]` parenthesis block at the start. Since the SMILES string is used as the molecule name (for provenance) it is written out to several topology formats. This causes issues for GROMACS, where `gmx` interprets the name as a section specifier. 

As a simple fix, in cases where molecules are generated from SMILES strings, either via parameterisation, or directly using `BioSimSpace.Convert.smiles`, we check the SMILES string and add a prefix of `smiles:` if it starts with the "[" character. Ultimately we might be able to move this logic into the topology parsers themselves, but this should work for the use cases we require.

I've added tests to confirm that the molecule is renamed correctly and also taken the opportunity to replace code to create molecules from SMILES strings with our new internal functionality.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods