### PR TITLE
Increase SOMD cut-off since it uses reaction field.

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -647,7 +647,7 @@ class ConfigFactory:
             protocol_dict["cutoff type"] = "cutoffnonperiodic"  # No periodic box.
         else:
             protocol_dict["cutoff type"] = "cutoffperiodic"  # Periodic box.
-        protocol_dict["cutoff distance"] = "8 angstrom"  # Non-bonded cut-off.
+        protocol_dict["cutoff distance"] = "10 angstrom"  # Non-bonded cut-off.
 
         # Restraints.
         if (

--- a/python/BioSimSpace/_Config/_somd.py
+++ b/python/BioSimSpace/_Config/_somd.py
@@ -182,7 +182,7 @@ class Somd(_Config):
             # Periodic box.
             protocol_dict["cutoff type"] = "cutoffperiodic"
         # Non-bonded cut-off.
-        protocol_dict["cutoff distance"] = "8 angstrom"
+        protocol_dict["cutoff distance"] = "10 angstrom"
 
         # Restraints.
         if (


### PR DESCRIPTION
When introducing the `BioSimSpace.Config` sub-package I took the opportunity to standardise some configuration options between the various engines, taking inspiration from the Exscientia sandpit. In doing so, I now realise that I had incorrectly lowered the non-bonded cut-off used by SOMD, which should be larger since it uses the reaction field method (by default). I've reverted this to the default value of 10 Angstrom.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods