### PR TITLE
Don't downcast molecules to single residues and atoms. [closes #16]

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_search_result.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_search_result.py
@@ -141,15 +141,7 @@ class SearchResult:
                 return _Residue(result)
             # Molecule.
             elif isinstance(result, _Sire.Mol._Mol.Molecule):
-                # If the molecule contains a single atom, then convert to an atom.
-                if result.nAtoms() == 1:
-                    return _Atom(result.atom())
-                # If there's a single residue, the convert to a residue.
-                elif result.nResidues() == 1:
-                    return _Residue(result.residue())
-                # Otherwise, append the molecule.
-                else:
-                    return _Molecule(result)
+                return _Molecule(result)
             # Bond
             elif isinstance(result, _Sire.MM._MM.Bond):
                 return _Bond(result)

--- a/python/BioSimSpace/_SireWrappers/_search_result.py
+++ b/python/BioSimSpace/_SireWrappers/_search_result.py
@@ -141,15 +141,7 @@ class SearchResult:
                 return _Residue(result)
             # Molecule.
             elif isinstance(result, _Sire.Mol._Mol.Molecule):
-                # If the molecule contains a single atom, then convert to an atom.
-                if result.nAtoms() == 1:
-                    return _Atom(result.atom())
-                # If there's a single residue, the convert to a residue.
-                elif result.nResidues() == 1:
-                    return _Residue(result.residue())
-                # Otherwise, append the molecule.
-                else:
-                    return _Molecule(result)
+                return _Molecule(result)
             # Bond
             elif isinstance(result, _Sire.MM._MM.Bond):
                 return _Bond(result)

--- a/test/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -71,7 +71,7 @@ def test_atom_reindexing(system):
 
 def test_residue_reindexing(system):
     # Search for all waters by residue name.
-    results = system.search("resname WAT")
+    results = system.search("resname WAT").residues()
 
     # There are 3 residues in the alanine-dipeptide, then one in each water
     # molecule. This means that residue indexing should start at 3 and
@@ -89,7 +89,7 @@ def test_residue_reindexing(system):
 
 def test_molecule_reindexing(system):
     # Search for all waters by residue name.
-    results = system.search("resname WAT")
+    results = system.search("resname WAT").molecules()
 
     # There are 631 molecules in the system: an alanine-dipeptide, followed by
     # 630 water molecules. This means that molecule indexing should start at 1
@@ -103,7 +103,7 @@ def test_molecule_reindexing(system):
     # As such, we convert each result to a molecule.
     for residue in results:
         # Ensure the absolute index matches.
-        assert system.getIndex(residue.toMolecule()) == index
+        assert system.getIndex(residue) == index
 
         index += 1
 

--- a/test/_SireWrappers/test_system.py
+++ b/test/_SireWrappers/test_system.py
@@ -71,7 +71,7 @@ def test_atom_reindexing(system):
 
 def test_residue_reindexing(system):
     # Search for all waters by residue name.
-    results = system.search("resname WAT")
+    results = system.search("resname WAT").residues()
 
     # There are 3 residues in the alanine-dipeptide, then one in each water
     # molecule. This means that residue indexing should start at 3 and
@@ -89,7 +89,7 @@ def test_residue_reindexing(system):
 
 def test_molecule_reindexing(system):
     # Search for all waters by residue name.
-    results = system.search("resname WAT")
+    results = system.search("resname WAT").molecules()
 
     # There are 631 molecules in the system: an alanine-dipeptide, followed by
     # 630 water molecules. This means that molecule indexing should start at 1
@@ -103,7 +103,7 @@ def test_molecule_reindexing(system):
     # As such, we convert each result to a molecule.
     for residue in results:
         # Ensure the absolute index matches.
-        assert system.getIndex(residue.toMolecule()) == index
+        assert system.getIndex(residue) == index
 
         index += 1
 


### PR DESCRIPTION
This pull request fixes issue #16

With the Sire search updates for the 2023 release we now have `.molecules()`, `.residues()`, etc methods on the search result to cast to the required object type. However, we still retained the existing code that would (potentially) downcast object types on extraction with `__getitem__`. For example, single residue molecules were converted to residues, single atom molecules were converted to atoms, etc. Now we want the user to do this directly by calling the appropriate method, e.g. `.residues()`. This oversight caused issues in the `isSame` method of `BioSimSpace._SireWrappers.System`, where non-water molecules were compared based on their properties. If a molecule only had a single residue, then it would be returned as a residue and `.propertyKeys()` would return an empty list, rather than the required molecular properties. The result was that systems were compared as equal, when in reality they weren't, e.g. different coordinates.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods