### PR TITLE
Set default-valued property to avoid issues with zero values

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -805,10 +805,11 @@ class Relative:
         # Initialise list to store the processe
         processes = []
 
-        # Convert to an appropriate AMBER topology. (Required by SOMD for its
-        # FEP setup.)
+        # Convert to an appropriate water topology.
         if self._engine == "SOMD":
             system._set_water_topology("AMBER", property_map=self._property_map)
+        elif self._engine == "GROMACS":
+            system._set_water_topology("GROMACS", property_map=self._property_map)
 
         # Setup all of the simulation processes for each leg.
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -717,7 +717,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
             # Make sure AMBER and GROMACS files have the expected water topology
             # and save GROMACS files with an extension such that they can be run
             # directly by GROMACS without needing to be renamed.
-            if format == "PRM7" or format == "RST7":
+            if format == "PRM7":
                 system_copy = system.copy()
                 system_copy._set_water_topology("AMBER", _property_map)
                 file = _SireIO.MoleculeParser.save(
@@ -725,7 +725,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
                 )
             elif format == "GroTop":
                 system_copy = system.copy()
-                system_copy._set_water_topology("GROMACS")
+                system_copy._set_water_topology("GROMACS", _property_map)
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )[0]

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -826,6 +826,7 @@ class Gromacs(_process.Process):
         if self.isError():
             _warnings.warn("The process exited with an error!")
 
+        self._update_stdout_dict()
         return self._stdout_dict.copy()
 
     def getCurrentRecords(self):

--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -1008,6 +1008,7 @@ class Namd(_process.Process):
         if self.isError():
             _warnings.warn("The process exited with an error!")
 
+        self.stdout(0)
         return self._stdout_dict.copy()
 
     def getCurrentRecords(self):

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1560,6 +1560,7 @@ class OpenMM(_process.Process):
         if self.isError():
             _warnings.warn("The process exited with an error!")
 
+        self._update_stdout_dict()
         return self._stdout_dict.copy()
 
     def getCurrentRecords(self):

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
@@ -208,28 +208,6 @@ def merge(
             atoms1.append(atom)
             atoms1_idx.append(atom.index())
 
-    # Create lists of the actual property names in the molecules.
-    props0 = []
-    props1 = []
-
-    # molecule0
-    for prop in molecule0.propertyKeys():
-        if prop in inv_property_map0:
-            prop = inv_property_map0[prop]
-        props0.append(prop)
-
-    # molecule1
-    for prop in molecule1.propertyKeys():
-        if prop in inv_property_map1:
-            prop = inv_property_map1[prop]
-        props1.append(prop)
-
-    # Determine the common properties between the two molecules.
-    # These are the properties that can be perturbed.
-    shared_props = list(set(props0).intersection(props1))
-    del props0
-    del props1
-
     # Create a new molecule to hold the merged molecule.
     molecule = _SireMol.Molecule("Merged_Molecule")
     # Only part of the ligand is to be merged
@@ -308,6 +286,84 @@ def merge(
 
     # Make the molecule editable.
     edit_mol = molecule.edit()
+
+    # Create lists of the actual property names in the molecules.
+    props0 = []
+    props1 = []
+
+    # molecule0
+    for prop in molecule0.propertyKeys():
+        if prop in inv_property_map0:
+            prop = inv_property_map0[prop]
+        props0.append(prop)
+
+    # molecule1
+    for prop in molecule1.propertyKeys():
+        if prop in inv_property_map1:
+            prop = inv_property_map1[prop]
+        props1.append(prop)
+
+    # Determine the common properties between the two molecules.
+    # These are the properties that can be perturbed.
+    shared_props = list(set(props0).intersection(props1))
+
+    # Now add default properties in each end state. This is required since Sire
+    # removes units from atom properties that are zero valued. By pre-setting
+    # a default property for the entire molecule, we ensure that atom properties
+    # are added with the correct type.
+
+    # Properties to ignore. (These will be handled later.)
+    ignored_props = [
+        "bond",
+        "angle",
+        "dihedral",
+        "improper",
+        "connectivity",
+        "intrascale",
+    ]
+
+    # lambda = 0
+    for prop in props0:
+        if not prop in ignored_props:
+            # This is a perturbable property.
+            if prop in shared_props:
+                name = f"{prop}0"
+            # This property is unique to the lambda = 0 state.
+            else:
+                name = prop
+
+            # Get the property from molecule0.
+            property = molecule0.property(prop)
+
+            # Try to set a default property at the lambda = 0 end state.
+            try:
+                default_prop = type(property)(molecule.info())
+                edit_mol = edit_mol.setProperty(name, default_prop).molecule()
+            except:
+                pass
+
+    # lambda = 1
+    for prop in props1:
+        if not prop in ignored_props:
+            # This is a perturbable property.
+            if prop in shared_props:
+                name = f"{prop}1"
+            # This property is unique to the lambda = 1 state.
+            else:
+                name = prop
+
+            # Get the property from molecule0.
+            property = molecule1.property(prop)
+
+            # Try to set a default property at the lambda = 1 end state.
+            try:
+                default_prop = type(property)(molecule.info())
+                edit_mol = edit_mol.setProperty(name, default_prop).molecule()
+            except:
+                pass
+
+    del props0
+    del props1
 
     # We now add properties to the merged molecule. The properties are used
     # to represent the molecule at two states along the alchemical pathway:

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -1222,10 +1222,11 @@ class Relative:
         # Initialise list to store the processe
         processes = []
 
-        # Convert to an appropriate AMBER topology. (Required by SOMD for its
-        # FEP setup.)
-        if self._engine == "SOMD":
+        # Convert to an appropriate water topology.
+        if self._engine in ["AMBER", "SOMD"]:
             system._set_water_topology("AMBER", property_map=self._property_map)
+        elif self._engine == "GROMACS":
+            system._set_water_topology("GROMACS", property_map=self._property_map)
 
         # Setup all of the simulation processes for each leg.
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -717,7 +717,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
             # Make sure AMBER and GROMACS files have the expected water topology
             # and save GROMACS files with an extension such that they can be run
             # directly by GROMACS without needing to be renamed.
-            if format == "PRM7" or format == "RST7":
+            if format == "PRM7":
                 system_copy = system.copy()
                 system_copy._set_water_topology("AMBER", _property_map)
                 file = _SireIO.MoleculeParser.save(
@@ -725,7 +725,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
                 )
             elif format == "GroTop":
                 system_copy = system.copy()
-                system_copy._set_water_topology("GROMACS")
+                system_copy._set_water_topology("GROMACS", _property_map)
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )[0]

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -872,6 +872,7 @@ class Gromacs(_process.Process):
         if self.isError():
             _warnings.warn("The process exited with an error!")
 
+        self._update_energy_dict()
         return self._energy_dict.copy()
 
     def getCurrentRecords(self):

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
@@ -1003,6 +1003,7 @@ class Namd(_process.Process):
         if self.isError():
             _warnings.warn("The process exited with an error!")
 
+        self.stdout(0)
         return self._stdout_dict.copy()
 
     def getCurrentRecords(self):

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -1560,6 +1560,7 @@ class OpenMM(_process.Process):
         if self.isError():
             _warnings.warn("The process exited with an error!")
 
+        self._update_stdout_dict()
         return self._stdout_dict.copy()
 
     def getCurrentRecords(self):

--- a/python/BioSimSpace/_Config/_amber.py
+++ b/python/BioSimSpace/_Config/_amber.py
@@ -114,7 +114,7 @@ class Amber(_Config):
         # Define some miscellaneous defaults.
         protocol_dict = {
             # Interval between reporting energies.
-            "ntpr": 200,
+            "ntpr": self.reportInterval(),
             # Interval between saving restart files.
             "ntwr": self.restartInterval(),
             # Trajectory sampling frequency.
@@ -152,6 +152,8 @@ class Amber(_Config):
             protocol_dict["maxcyc"] = self.steps()
             # Set the number of steepest descent steps.
             protocol_dict["ncyc"] = num_steep
+            # Report energies every 100 steps.
+            protocol_dict["ntpr"] = 100
         else:
             # Define the timestep
             timestep = self._protocol.getTimeStep().picoseconds().value()


### PR DESCRIPTION
This pull request fixes issue #23. It requires merging of [openbiosim/sire#25](https://github.com/OpenBioSim/sire/pull/25) before it will work. It fixes the issue caused by assigning zero-valued properties, which no-longer have any associated units. This is achieved by initialising properties in the lambda end states using default-valued properties, which are then edited atom-by-atom.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods