### PR TITLE
Improve disulphide handling

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -47,15 +47,6 @@ import sys as _sys
 import subprocess as _subprocess
 import warnings as _warnings
 
-# Wrap the import of PyPDB since it imports Matplotlib, which will fail if
-# we don't have a display running.
-try:
-    import pypdb as _pypdb
-
-    _has_pypdb = True
-except:
-    _has_pypdb = False
-
 # Flag that we've not yet raised a warning about GROMACS not being installed.
 _has_gmx_warned = False
 
@@ -259,10 +250,6 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
     >>> system = BSS.IO.readPDB("file.pdb", pdb4amber=True)
     """
 
-    if not _has_pypdb:
-        _warnings.warn("BioSimSpace.IO: PyPDB could not be imported on this system.")
-        return None
-
     if not isinstance(id, str):
         raise TypeError("'id' must be of type 'str'")
 
@@ -290,30 +277,23 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
 
     # ID from the Protein Data Bank.
     else:
-        if not _has_pypdb:
-            _warnings.warn(
-                "BioSimSpace.IO: PyPDB could not be imported on this system."
-            )
-            return None
-
         # Strip any whitespace from the PDB ID and convert to upper case.
         id = id.replace(" ", "").upper()
 
-        # Attempt to download the PDB file. (Compression is currently broken!)
-        with _warnings.catch_warnings(record=True) as w:
-            pdb_string = _pypdb.get_pdb_file(id, filetype="pdb", compression=False)
-            if w:
-                raise IOError("Retrieval failed, invalid PDB ID: %s" % id)
-
-        # Create the name of the PDB file.
-        pdb_file = "%s/%s.pdb" % (work_dir, id)
-
-        # Now write the PDB string to file.
-        with open(pdb_file, "w") as file:
-            file.write(pdb_string)
+        # Use Sire to download the PDB.
+        try:
+            system = _patch_sire_load(id, directory=str(work_dir))
+        except:
+            raise IOError("Retrieval failed, invalid PDB ID: %s" % id)
 
         # Store the absolute path of the file.
-        pdb_file = _os.path.abspath(pdb_file)
+        pdb_file = f"{work_dir}/{id}"
+
+        # Save to PDB format.
+        saveMolecules(pdb_file, _System(system), "pdb")
+
+        # Add the extension.
+        pdb_file += ".pdb"
 
     # Process the file with pdb4amber.
     if pdb4amber:

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -672,6 +672,9 @@ class AmberProtein(_protocol.Protocol):
         # Create a list to store the LEaP bond record strings.
         bond_records = []
 
+        # Whether a warning has already been raised.
+        have_warned = False
+
         # Loop over the disulphide bonds and generate the records.
         for bond in disulphides:
             # Get the atoms in the bond.
@@ -679,15 +682,30 @@ class AmberProtein(_protocol.Protocol):
             atom1 = bond.atom1()
 
             # Extract the residue numbers associated with the atoms.
-            res0 = atom0.residue().number().value()
-            res1 = atom1.residue().number().value()
+            num0 = atom0.residue().number().value()
+            num1 = atom1.residue().number().value()
+
+            # Extract the residue indices associated with the atoms.
+            # (Make sure these are one-indexed.)
+            idx0 = atom0.residue().index().value() + 1
+            idx1 = atom1.residue().index().value() + 1
+
+            # If the residue numbers don't match the indices, then warn the user
+            # since the molecule will require renumbering before passing to LEaP.
+            if not have_warned:
+                if idx0 != num0 or idx1 != num1:
+                    _warnings.warn(
+                        "Residue numbers are out of order. Use "
+                        "'sire.legacy.IO.renumberConstituents' correct numbering."
+                    )
+                    have_warned = True
 
             # Extract the atom names.
             name0 = atom0.name().value()
             name1 = atom1.name().value()
 
             # Create the record.
-            record = f"bond mol.{res0}.{name0} mol.{res1}.{name1}"
+            record = f"bond mol.{idx0}.{name0} mol.{idx1}.{name1}"
 
             # Append to the list.
             bond_records.append(record)
@@ -757,6 +775,9 @@ class AmberProtein(_protocol.Protocol):
         # Create a list to store the LEaP bond record strings.
         bond_records = []
 
+        # Whether a warning has already been raised.
+        have_warned = False
+
         # Loop over the bonds and generate the records.
         for atom0, atom1 in bonds:
             # Extract the Sire objects.
@@ -764,15 +785,30 @@ class AmberProtein(_protocol.Protocol):
             atom1 = atom1._sire_object
 
             # Extract the residue numbers associated with the atoms.
-            res0 = atom0.residue().number().value()
-            res1 = atom1.residue().number().value()
+            num0 = atom0.residue().number().value()
+            num1 = atom1.residue().number().value()
+
+            # Extract the residue indices associated with the atoms.
+            # (Make sure these are one-indexed.)
+            idx0 = atom0.residue().index().value() + 1
+            idx1 = atom1.residue().index().value() + 1
+
+            # If the residue numbers don't match the indices, then warn the user
+            # since the molecule will require renumbering before passing to LEaP.
+            if not have_warned:
+                if idx0 != num0 or idx1 != num1:
+                    _warnings.warn(
+                        "Residue numbers are out of order. Use "
+                        "'sire.legacy.IO.renumberConstituents' correct numbering."
+                    )
+                    have_warned = True
 
             # Extract the atom names.
             name0 = atom0.name().value()
             name1 = atom1.name().value()
 
             # Create the record.
-            record = f"bond mol.{res0}.{name0} mol.{res1}.{name1}"
+            record = f"bond mol.{idx0}.{name0} mol.{idx1}.{name1}"
 
             # Append to the list.
             bond_records.append(record)

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -47,15 +47,6 @@ import sys as _sys
 import subprocess as _subprocess
 import warnings as _warnings
 
-# Wrap the import of PyPDB since it imports Matplotlib, which will fail if
-# we don't have a display running.
-try:
-    import pypdb as _pypdb
-
-    _has_pypdb = True
-except:
-    _has_pypdb = False
-
 # Flag that we've not yet raised a warning about GROMACS not being installed.
 _has_gmx_warned = False
 
@@ -259,10 +250,6 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
     >>> system = BSS.IO.readPDB("file.pdb", pdb4amber=True)
     """
 
-    if not _has_pypdb:
-        _warnings.warn("BioSimSpace.IO: PyPDB could not be imported on this system.")
-        return None
-
     if not isinstance(id, str):
         raise TypeError("'id' must be of type 'str'")
 
@@ -290,30 +277,23 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
 
     # ID from the Protein Data Bank.
     else:
-        if not _has_pypdb:
-            _warnings.warn(
-                "BioSimSpace.IO: PyPDB could not be imported on this system."
-            )
-            return None
-
         # Strip any whitespace from the PDB ID and convert to upper case.
         id = id.replace(" ", "").upper()
 
-        # Attempt to download the PDB file. (Compression is currently broken!)
-        with _warnings.catch_warnings(record=True) as w:
-            pdb_string = _pypdb.get_pdb_file(id, filetype="pdb", compression=False)
-            if w:
-                raise IOError("Retrieval failed, invalid PDB ID: %s" % id)
-
-        # Create the name of the PDB file.
-        pdb_file = "%s/%s.pdb" % (work_dir, id)
-
-        # Now write the PDB string to file.
-        with open(pdb_file, "w") as file:
-            file.write(pdb_string)
+        # Use Sire to download the PDB.
+        try:
+            system = _patch_sire_load(id, directory=str(work_dir))
+        except:
+            raise IOError("Retrieval failed, invalid PDB ID: %s" % id)
 
         # Store the absolute path of the file.
-        pdb_file = _os.path.abspath(pdb_file)
+        pdb_file = f"{work_dir}/{id}"
+
+        # Save to PDB format.
+        saveMolecules(pdb_file, _System(system), "pdb")
+
+        # Add the extension.
+        pdb_file += ".pdb"
 
     # Process the file with pdb4amber.
     if pdb4amber:

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -672,6 +672,9 @@ class AmberProtein(_protocol.Protocol):
         # Create a list to store the LEaP bond record strings.
         bond_records = []
 
+        # Whether a warning has already been raised.
+        have_warned = False
+
         # Loop over the disulphide bonds and generate the records.
         for bond in disulphides:
             # Get the atoms in the bond.
@@ -679,15 +682,30 @@ class AmberProtein(_protocol.Protocol):
             atom1 = bond.atom1()
 
             # Extract the residue numbers associated with the atoms.
-            res0 = atom0.residue().number().value()
-            res1 = atom1.residue().number().value()
+            num0 = atom0.residue().number().value()
+            num1 = atom1.residue().number().value()
+
+            # Extract the residue indices associated with the atoms.
+            # (Make sure these are one-indexed.)
+            idx0 = atom0.residue().index().value() + 1
+            idx1 = atom1.residue().index().value() + 1
+
+            # If the residue numbers don't match the indices, then warn the user
+            # since the molecule will require renumbering before passing to LEaP.
+            if not have_warned:
+                if idx0 != num0 or idx1 != num1:
+                    _warnings.warn(
+                        "Residue numbers are out of order. Use "
+                        "'sire.legacy.IO.renumberConstituents' correct numbering."
+                    )
+                    have_warned = True
 
             # Extract the atom names.
             name0 = atom0.name().value()
             name1 = atom1.name().value()
 
             # Create the record.
-            record = f"bond mol.{res0}.{name0} mol.{res1}.{name1}"
+            record = f"bond mol.{idx0}.{name0} mol.{idx1}.{name1}"
 
             # Append to the list.
             bond_records.append(record)
@@ -757,6 +775,9 @@ class AmberProtein(_protocol.Protocol):
         # Create a list to store the LEaP bond record strings.
         bond_records = []
 
+        # Whether a warning has already been raised.
+        have_warned = False
+
         # Loop over the bonds and generate the records.
         for atom0, atom1 in bonds:
             # Extract the Sire objects.
@@ -764,15 +785,30 @@ class AmberProtein(_protocol.Protocol):
             atom1 = atom1._sire_object
 
             # Extract the residue numbers associated with the atoms.
-            res0 = atom0.residue().number().value()
-            res1 = atom1.residue().number().value()
+            num0 = atom0.residue().number().value()
+            num1 = atom1.residue().number().value()
+
+            # Extract the residue indices associated with the atoms.
+            # (Make sure these are one-indexed.)
+            idx0 = atom0.residue().index().value() + 1
+            idx1 = atom1.residue().index().value() + 1
+
+            # If the residue numbers don't match the indices, then warn the user
+            # since the molecule will require renumbering before passing to LEaP.
+            if not have_warned:
+                if idx0 != num0 or idx1 != num1:
+                    _warnings.warn(
+                        "Residue numbers are out of order. Use "
+                        "'sire.legacy.IO.renumberConstituents' correct numbering."
+                    )
+                    have_warned = True
 
             # Extract the atom names.
             name0 = atom0.name().value()
             name1 = atom1.name().value()
 
             # Create the record.
-            record = f"bond mol.{res0}.{name0} mol.{res1}.{name1}"
+            record = f"bond mol.{idx0}.{name0} mol.{idx1}.{name1}"
 
             # Append to the list.
             bond_records.append(record)

--- a/python/setup.py
+++ b/python/setup.py
@@ -123,7 +123,6 @@ finally:
             "py3dmol",
             "pydot",
             "pygtail",
-            "pypdb",
             "pyyaml",
             "rdkit",
             "sire",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ parmed
 py3dmol
 pydot
 pygtail
-pypdb
 pyyaml
 rdkit
 watchdog

--- a/test/Parameters/test_parameters.py
+++ b/test/Parameters/test_parameters.py
@@ -1,7 +1,5 @@
 import BioSimSpace as BSS
 
-from sire.legacy.IO import renumberConstituents
-
 import os
 import pytest
 
@@ -62,12 +60,9 @@ def test_disulphide_renumber(molecule1, ff="ff14SB"):
     # tLEaP input script.
     molecule = getattr(BSS.Parameters, ff)(molecule1).getMolecule()
 
-    renumbered_molecule = renumberConstituents(molecule1.toSystem()._sire_object)[0]
-    renumbered_molecule = BSS._SireWrappers.Molecule(renumbered_molecule)
-
-    # Check that we actually generate records for four disulphide bonds.
+    # Check that we actually generate records for eight disulphide bonds.
     bonds = BSS.Parameters._Protocol.AmberProtein._get_disulphide_bonds(
-        renumbered_molecule._sire_object
+        molecule1._sire_object
     )
     assert len(bonds) == 8
 

--- a/test/Parameters/test_parameters.py
+++ b/test/Parameters/test_parameters.py
@@ -1,5 +1,7 @@
 import BioSimSpace as BSS
 
+from sire.legacy.IO import renumberConstituents
+
 import os
 import pytest
 
@@ -18,26 +20,57 @@ else:
 
 
 @pytest.fixture(scope="session")
-def molecule():
+def molecule0():
     return BSS.IO.readMolecules(f"{url}/4LYT_Fixed.pdb.bz2")[0]
+
+
+@pytest.fixture(scope="session")
+def molecule1():
+    return BSS.IO.readMolecules(f"{url}/3G8K_Fixed.pdb.bz2")[0]
 
 
 @pytest.mark.skipif(has_tleap is False, reason="Requires tLEaP to be installed.")
 @pytest.mark.parametrize("ff", BSS.Parameters.amberProteinForceFields())
-def test_disulphide(molecule, ff):
+def test_disulphide(molecule0, ff):
     """Test parameterisation in the presence of disulphide bridges."""
 
     # Try to parameterise with the named force field. If working, this should
     # auto-detect disulphide bonds and add the appropriate bond records to the
     # tLEaP input script.
-    molecule = getattr(BSS.Parameters, ff)(molecule).getMolecule()
+    molecule = getattr(BSS.Parameters, ff)(molecule0).getMolecule()
 
     # Check that we actually generate records for four disulphide bonds.
     bonds = BSS.Parameters._Protocol.AmberProtein._get_disulphide_bonds(
-        molecule._sire_object
+        molecule0._sire_object
     )
     assert len(bonds) == 4
 
     # Check that the bond parameters are present in the molecule.
     bonds = molecule.search("bonds from element S to element S")
     assert len(bonds) == 4
+
+
+@pytest.mark.skipif(has_tleap is False, reason="Requires tLEaP to be installed.")
+def test_disulphide_renumber(molecule1, ff="ff14SB"):
+    """
+    Test parameterisation in the presence of disulphide bridges using a
+    multi-chain PDB with duplicate residue numbering
+    """
+
+    # Try to parameterise with the named force field. If working, this should
+    # auto-detect disulphide bonds and add the appropriate bond records to the
+    # tLEaP input script.
+    molecule = getattr(BSS.Parameters, ff)(molecule1).getMolecule()
+
+    renumbered_molecule = renumberConstituents(molecule1.toSystem()._sire_object)[0]
+    renumbered_molecule = BSS._SireWrappers.Molecule(renumbered_molecule)
+
+    # Check that we actually generate records for four disulphide bonds.
+    bonds = BSS.Parameters._Protocol.AmberProtein._get_disulphide_bonds(
+        renumbered_molecule._sire_object
+    )
+    assert len(bonds) == 8
+
+    # Check that the bond parameters are present in the molecule.
+    bonds = molecule.search("bonds from element S to element S")
+    assert len(bonds) == 8

--- a/test/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/test/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -1,7 +1,5 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
 
-from sire.legacy.IO import renumberConstituents
-
 import os
 import pytest
 
@@ -62,12 +60,9 @@ def test_disulphide_renumber(molecule1, ff="ff14SB"):
     # tLEaP input script.
     molecule = getattr(BSS.Parameters, ff)(molecule1).getMolecule()
 
-    renumbered_molecule = renumberConstituents(molecule1.toSystem()._sire_object)[0]
-    renumbered_molecule = BSS._SireWrappers.Molecule(renumbered_molecule)
-
-    # Check that we actually generate records for four disulphide bonds.
+    # Check that we actually generate records for eight disulphide bonds.
     bonds = BSS.Parameters._Protocol.AmberProtein._get_disulphide_bonds(
-        renumbered_molecule._sire_object
+        molecule1._sire_object
     )
     assert len(bonds) == 8
 

--- a/test/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/test/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -1,5 +1,7 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
 
+from sire.legacy.IO import renumberConstituents
+
 import os
 import pytest
 
@@ -18,26 +20,57 @@ else:
 
 
 @pytest.fixture(scope="session")
-def molecule():
+def molecule0():
     return BSS.IO.readMolecules(f"{url}/4LYT_Fixed.pdb.bz2")[0]
+
+
+@pytest.fixture(scope="session")
+def molecule1():
+    return BSS.IO.readMolecules(f"{url}/3G8K_Fixed.pdb.bz2")[0]
 
 
 @pytest.mark.skipif(has_tleap is False, reason="Requires tLEaP to be installed.")
 @pytest.mark.parametrize("ff", BSS.Parameters.amberProteinForceFields())
-def test_disulphide(molecule, ff):
+def test_disulphide(molecule0, ff):
     """Test parameterisation in the presence of disulphide bridges."""
 
     # Try to parameterise with the named force field. If working, this should
     # auto-detect disulphide bonds and add the appropriate bond records to the
     # tLEaP input script.
-    molecule = getattr(BSS.Parameters, ff)(molecule).getMolecule()
+    molecule = getattr(BSS.Parameters, ff)(molecule0).getMolecule()
 
     # Check that we actually generate records for four disulphide bonds.
     bonds = BSS.Parameters._Protocol.AmberProtein._get_disulphide_bonds(
-        molecule._sire_object
+        molecule0._sire_object
     )
     assert len(bonds) == 4
 
     # Check that the bond parameters are present in the molecule.
     bonds = molecule.search("bonds from element S to element S")
     assert len(bonds) == 4
+
+
+@pytest.mark.skipif(has_tleap is False, reason="Requires tLEaP to be installed.")
+def test_disulphide_renumber(molecule1, ff="ff14SB"):
+    """
+    Test parameterisation in the presence of disulphide bridges using a
+    multi-chain PDB with duplicate residue numbering
+    """
+
+    # Try to parameterise with the named force field. If working, this should
+    # auto-detect disulphide bonds and add the appropriate bond records to the
+    # tLEaP input script.
+    molecule = getattr(BSS.Parameters, ff)(molecule1).getMolecule()
+
+    renumbered_molecule = renumberConstituents(molecule1.toSystem()._sire_object)[0]
+    renumbered_molecule = BSS._SireWrappers.Molecule(renumbered_molecule)
+
+    # Check that we actually generate records for four disulphide bonds.
+    bonds = BSS.Parameters._Protocol.AmberProtein._get_disulphide_bonds(
+        renumbered_molecule._sire_object
+    )
+    assert len(bonds) == 8
+
+    # Check that the bond parameters are present in the molecule.
+    bonds = molecule.search("bonds from element S to element S")
+    assert len(bonds) == 8


### PR DESCRIPTION
This PR closes [this](https://github.com/michellab/BioSimSpace/issues/368) issue by improving disulphide detection during parameterisation. We can now handle situations where a PDB contains multiple chains using the same residue numbers. This is achieved by renumbering the residues prior to writing input for `LEaP`. The original numbering is preserved to the user, since the `LEaP` output is mapped back into the original molecule.

Existing unit tests for disulphide detection still pass with this update. It has also been tested on an extended input set by external users at Evotech and Exscientia.

(closes #michellab/BioSimSpace#368)

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods