### PR TITLE
Add ability to pass extra keyword arguments to LOMAP

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -116,6 +116,7 @@ def generateNetwork(
     links_file=None,
     property_map={},
     n_edges_forced=None,
+    **kwargs,
 ):
     """
     Generate a perturbation network using Lead Optimisation Mappper (LOMAP).
@@ -171,6 +172,10 @@ def generateNetwork(
         will remove the bottom n edges parsed from the LOMAP output file.
         This last option is discouraged as it can cause network cycle
         breakage and disconnecting of ligands/clusters from the network.
+
+    **kwargs : dict
+        A dictionary of keyword arguments to pass through to LOMAP. These
+        will take precedence over any default values that are set.
 
     Returns
     -------
@@ -404,19 +409,24 @@ def generateNetwork(
     else:
         lf = None
 
+    # Create a dictionary of default keyword arguments.
+    default_kwargs = {
+        "name": f"{work_dir}/outputs/lomap",
+        "links_file": lf,
+        "output": True,
+        "output_no_graph": True,
+        "output_no_images": True,
+        "threed": True,
+        "max3d": 3.0,
+        "time": 3,
+        "parallel": 10,
+    }
+
+    # Combine with **kwargs, with those taking precendence.
+    total_kwargs = {**default_kwargs, **kwargs}
+
     # Create the DBMolecules object.
-    db_mol = _lomap.DBMolecules(
-        f"{work_dir}/inputs",
-        name=f"{work_dir}/outputs/lomap",
-        links_file=lf,
-        output=True,
-        output_no_graph=True,
-        output_no_images=True,
-        threed=True,
-        max3d=3.0,
-        time=3,
-        parallel=10,
-    )
+    db_mol = _lomap.DBMolecules(f"{work_dir}/inputs", **total_kwargs)
 
     # Create the similarity matrices.
     strict, loose = db_mol.build_matrices()

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_align.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_align.py
@@ -116,6 +116,7 @@ def generateNetwork(
     links_file=None,
     property_map={},
     n_edges_forced=None,
+    **kwargs,
 ):
     """
     Generate a perturbation network using Lead Optimisation Mappper (LOMAP).
@@ -171,6 +172,10 @@ def generateNetwork(
         will remove the bottom n edges parsed from the LOMAP output file.
         This last option is discouraged as it can cause network cycle
         breakage and disconnecting of ligands/clusters from the network.
+
+    **kwargs : dict
+        A dictionary of keyword arguments to pass through to LOMAP. These
+        will take precedence over any default values that are set.
 
     Returns
     -------
@@ -404,19 +409,24 @@ def generateNetwork(
     else:
         lf = None
 
+    # Create a dictionary of default keyword arguments.
+    default_kwargs = {
+        "name": f"{work_dir}/outputs/lomap",
+        "links_file": lf,
+        "output": True,
+        "output_no_graph": True,
+        "output_no_images": True,
+        "threed": True,
+        "max3d": 3.0,
+        "time": 3,
+        "parallel": 10,
+    }
+
+    # Combine with **kwargs, with those taking precendence.
+    total_kwargs = {**default_kwargs, **kwargs}
+
     # Create the DBMolecules object.
-    db_mol = _lomap.DBMolecules(
-        f"{work_dir}/inputs",
-        name=f"{work_dir}/outputs/lomap",
-        links_file=lf,
-        output=True,
-        output_no_graph=True,
-        output_no_images=True,
-        threed=True,
-        max3d=3.0,
-        time=3,
-        parallel=10,
-    )
+    db_mol = _lomap.DBMolecules(f"{work_dir}/inputs", **total_kwargs)
 
     # Create the similarity matrices.
     strict, loose = db_mol.build_matrices()


### PR DESCRIPTION
This is a small update to allow users to pass extra arguments (or override defaults) through to LOMAP, which is used as the backend in `BioSImSpace.Align.generateNetwork`. The PR closes #13.

Note that this option is intended for _power users_, so we can't assume that all of the extra options that are specified will work perfectly with the logic in the rest of the function, e.g. plotting of the network (if requested), etc. I plan to see what issues come up over time and adjust the logic accordingly, e.g. saying that Y won't work if you've specified X, etc.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

@chryswoods