### PR TITLE
Update CI for new release process

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -1,12 +1,10 @@
-name: Release Main
+name: Release Devel
 
 on:
   workflow_dispatch:
-    inputs:
-      upload_packages:
-        description: "Upload packages to anaconda (yes/no)?"
-        required: true
-        default: "no"
+  push:
+    branches: [ devel ]
+
 jobs:
   build:
     name: build (${{ matrix.python-version }}, ${{ matrix.platform.name }})
@@ -20,6 +18,18 @@ jobs:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+        exclude:
+          # Exclude all but the latest Python from all but Linux
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.8"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.8"
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.9"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.9"
     environment:
       name: biosimspace-build
     defaults:
@@ -38,8 +48,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
 #
-      - name: Clone the main branch
-        run: git clone -b main https://github.com/openbiosim/biosimspace
+      - name: Clone the devel branch
+        run: git clone -b devel https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
         run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
@@ -51,11 +61,10 @@ jobs:
         run: mkdir ${{ github.workspace }}/build
 #
       - name: Build Conda package using mamba build
-        run: conda mambabuild -c conda-forge -c openbiosim/label/main ${{ github.workspace }}/biosimspace/recipes/biosimspace
+        run: conda mambabuild -c conda-forge -c openbiosim/label/dev ${{ github.workspace }}/biosimspace/recipes/biosimspace
 #
       - name: Upload Conda package
         run: python ${{ github.workspace }}/biosimspace/actions/upload_package.py
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          ANACONDA_LABEL: main
-        if: github.event.inputs.upload_packages == 'yes'
+          ANACONDA_LABEL: dev

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,12 +1,9 @@
-name: Release Main
+name: Pull-Request
 
 on:
-  workflow_dispatch:
-    inputs:
-      upload_packages:
-        description: "Upload packages to anaconda (yes/no)?"
-        required: true
-        default: "no"
+  pull_request:
+    branches: [devel, main]
+
 jobs:
   build:
     name: build (${{ matrix.python-version }}, ${{ matrix.platform.name }})
@@ -20,6 +17,19 @@ jobs:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+        exclude:
+          # Exclude all but the latest Python from all
+          # but Linux
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.8"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.8"
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.9"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.9"
     environment:
       name: biosimspace-build
     defaults:
@@ -28,6 +38,7 @@ jobs:
     env:
       SIRE_DONT_PHONEHOME: 1
       SIRE_SILENT_PHONEHOME: 1
+      REPO: "${{ github.event.pull_request.head.repo.full_name || github.repository }}"
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -38,8 +49,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
 #
-      - name: Clone the main branch
-        run: git clone -b main https://github.com/openbiosim/biosimspace
+      - name: Clone the feature branch
+        run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }}
 #
       - name: Setup Conda
         run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
@@ -50,12 +61,10 @@ jobs:
       - name: Prepare build location
         run: mkdir ${{ github.workspace }}/build
 #
-      - name: Build Conda package using mamba build
+      - name: Build Conda package using mamba build using main channel
+        if: ${{ github.base_ref == 'main' }}
         run: conda mambabuild -c conda-forge -c openbiosim/label/main ${{ github.workspace }}/biosimspace/recipes/biosimspace
 #
-      - name: Upload Conda package
-        run: python ${{ github.workspace }}/biosimspace/actions/upload_package.py
-        env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          ANACONDA_LABEL: main
-        if: github.event.inputs.upload_packages == 'yes'
+      - name: Build Conda package using mamba build using dev channel
+        if: ${{ github.base_ref != 'main' }}
+        run: conda mambabuild -c conda-forge -c openbiosim/label/dev ${{ github.workspace }}/biosimspace/recipes/biosimspace

--- a/actions/upload_package.py
+++ b/actions/upload_package.py
@@ -16,6 +16,12 @@ if "ANACONDA_TOKEN" in os.environ:
 else:
     conda_token = "TEST"
 
+# Get the anaconda channel labels.
+if "ANACONDA_LABEL" in os.environ:
+    conda_label = os.environ["ANACONDA_LABEL"]
+else:
+    conda_label = "dev"
+
 # get the root conda directory
 conda = os.environ["CONDA"]
 
@@ -50,17 +56,8 @@ gitdir = os.path.join(srcdir, ".git")
 
 tag = run_cmd(f"git --git-dir={gitdir} --work-tree={srcdir} tag --contains")
 
-# If the tag is not empty, then set the label to main (this is a release)
-if tag is not None and tag.lstrip().rstrip() != "":
-    print(f"\nTag {tag} is set. This is a 'main' release.")
-    label = "--label main --label dev"
-else:
-    # this is a development release
-    print("\nNo tag is set. This is a 'devel' release.")
-    label = "--label dev"
-
 # Upload the packages to the openbiosim channel on Anaconda Cloud.
-cmd = f"anaconda --token {conda_token} upload --user openbiosim {label} --force {packages}"
+cmd = f"anaconda --token {conda_token} upload --user openbiosim --label {conda_label} --force {packages}"
 
 print(f"\nUpload command:\n\n{cmd}\n")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,7 +39,7 @@ if not os.getenv("BSS_CONDA_INSTALL"):
         )
 
     # Check the Sire version.
-    if int(sire.legacy.__version__.replace(".", "")) < min_ver_int:
+    if int(sire.legacy.__version__.replace(".", "").replace("dev", "")) < min_ver_int:
         raise ImportError("BioSimSpace requires Sire version '%s' or above." % min_ver)
 
 from setuptools import setup, find_packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 # BioSimSpace runtime requirements.
 
-sire ~=2023.2.0
+# main
+# sire~=2023.2.2
+
+# devel
+sire==2023.3.0.dev
 
 configargparse
 ipywidgets<8


### PR DESCRIPTION
This PR mirrors the CI changes to Sire, as required for the new release process. Since, unlike Sire, BioSimSpace is not a standalone package, i.e. it requires Sire as a base, there are a few subtle differences:

* The label of the `openbiosim` channel used during a build matches the branch against which the build is based, i.e. the `main` label for `main`, and `dev` for `devel`.
* Packages built against a particular branch are only pushed to the channel label associated with this branch, i.e. same as above, `main` for `main` and `dev` for `devel`. This is because so we can guarantee compatibility between packages with a given label. Versioning _should_ make this okay regardless, but this will ensure we don't have any headaches.

Assuming this works, I'll merge into `devel` and `main`. It's possible that I might need to fix minor issues with the CI scripts for the first builds there, but hopefully things are okay since I followed the same procedure as Sire.

I've also update the `setup.py` file for BioSimSpace so that it can handle `.dev` packages when making version comparisons.

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods