### PR TITLE
Update CI for new release process on main

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -1,12 +1,10 @@
-name: Release Main
+name: Release Devel
 
 on:
   workflow_dispatch:
-    inputs:
-      upload_packages:
-        description: "Upload packages to anaconda (yes/no)?"
-        required: true
-        default: "no"
+  push:
+    branches: [ devel ]
+
 jobs:
   build:
     name: build (${{ matrix.python-version }}, ${{ matrix.platform.name }})
@@ -20,6 +18,18 @@ jobs:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+        exclude:
+          # Exclude all but the latest Python from all but Linux
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.8"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.8"
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.9"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.9"
     environment:
       name: biosimspace-build
     defaults:
@@ -38,8 +48,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
 #
-      - name: Clone the main branch
-        run: git clone -b main https://github.com/openbiosim/biosimspace
+      - name: Clone the devel branch
+        run: git clone -b devel https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
         run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
@@ -51,11 +61,10 @@ jobs:
         run: mkdir ${{ github.workspace }}/build
 #
       - name: Build Conda package using mamba build
-        run: conda mambabuild -c conda-forge -c openbiosim/label/main ${{ github.workspace }}/biosimspace/recipes/biosimspace
+        run: conda mambabuild -c conda-forge -c openbiosim/label/dev ${{ github.workspace }}/biosimspace/recipes/biosimspace
 #
       - name: Upload Conda package
         run: python ${{ github.workspace }}/biosimspace/actions/upload_package.py
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          ANACONDA_LABEL: main
-        if: github.event.inputs.upload_packages == 'yes'
+          ANACONDA_LABEL: dev

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,12 +1,9 @@
-name: Release Main
+name: Pull-Request
 
 on:
-  workflow_dispatch:
-    inputs:
-      upload_packages:
-        description: "Upload packages to anaconda (yes/no)?"
-        required: true
-        default: "no"
+  pull_request:
+    branches: [devel, main]
+
 jobs:
   build:
     name: build (${{ matrix.python-version }}, ${{ matrix.platform.name }})
@@ -20,6 +17,19 @@ jobs:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }
           - { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+        exclude:
+          # Exclude all but the latest Python from all
+          # but Linux
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.8"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.8"
+          - platform:
+              { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
+            python-version: "3.9"
+          - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
+            python-version: "3.9"
     environment:
       name: biosimspace-build
     defaults:
@@ -28,6 +38,7 @@ jobs:
     env:
       SIRE_DONT_PHONEHOME: 1
       SIRE_SILENT_PHONEHOME: 1
+      REPO: "${{ github.event.pull_request.head.repo.full_name || github.repository }}"
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -38,8 +49,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
 #
-      - name: Clone the main branch
-        run: git clone -b main https://github.com/openbiosim/biosimspace
+      - name: Clone the feature branch
+        run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }}
 #
       - name: Setup Conda
         run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
@@ -50,12 +61,10 @@ jobs:
       - name: Prepare build location
         run: mkdir ${{ github.workspace }}/build
 #
-      - name: Build Conda package using mamba build
+      - name: Build Conda package using mamba build using main channel
+        if: ${{ github.base_ref == 'main' }}
         run: conda mambabuild -c conda-forge -c openbiosim/label/main ${{ github.workspace }}/biosimspace/recipes/biosimspace
 #
-      - name: Upload Conda package
-        run: python ${{ github.workspace }}/biosimspace/actions/upload_package.py
-        env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          ANACONDA_LABEL: main
-        if: github.event.inputs.upload_packages == 'yes'
+      - name: Build Conda package using mamba build using dev channel
+        if: ${{ github.base_ref != 'main' }}
+        run: conda mambabuild -c conda-forge -c openbiosim/label/dev ${{ github.workspace }}/biosimspace/recipes/biosimspace

--- a/actions/upload_package.py
+++ b/actions/upload_package.py
@@ -16,6 +16,12 @@ if "ANACONDA_TOKEN" in os.environ:
 else:
     conda_token = "TEST"
 
+# Get the anaconda channel labels.
+if "ANACONDA_LABEL" in os.environ:
+    conda_label = os.environ["ANACONDA_LABEL"]
+else:
+    conda_label = "dev"
+
 # get the root conda directory
 conda = os.environ["CONDA"]
 
@@ -50,17 +56,8 @@ gitdir = os.path.join(srcdir, ".git")
 
 tag = run_cmd(f"git --git-dir={gitdir} --work-tree={srcdir} tag --contains")
 
-# If the tag is not empty, then set the label to main (this is a release)
-if tag is not None and tag.lstrip().rstrip() != "":
-    print(f"\nTag {tag} is set. This is a 'main' release.")
-    label = "--label main --label dev"
-else:
-    # this is a development release
-    print("\nNo tag is set. This is a 'devel' release.")
-    label = "--label dev"
-
 # Upload the packages to the openbiosim channel on Anaconda Cloud.
-cmd = f"anaconda --token {conda_token} upload --user openbiosim {label} --force {packages}"
+cmd = f"anaconda --token {conda_token} upload --user openbiosim --label {conda_label} --force {packages}"
 
 print(f"\nUpload command:\n\n{cmd}\n")
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -420,6 +420,9 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
             raise TypeError("'files' must be a list of 'str' types.")
         if len(files) == 0:
             raise ValueError("The list of input files is empty!")
+        # Convert tuple to list.
+        if isinstance(files, tuple):
+            files = list(files)
     else:
         raise TypeError("'files' must be of type 'str', or a list of 'str' types.")
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -420,6 +420,9 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
             raise TypeError("'files' must be a list of 'str' types.")
         if len(files) == 0:
             raise ValueError("The list of input files is empty!")
+        # Convert tuple to list.
+        if isinstance(files, tuple):
+            files = list(files)
     else:
         raise TypeError("'files' must be of type 'str', or a list of 'str' types.")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,7 +39,7 @@ if not os.getenv("BSS_CONDA_INSTALL"):
         )
 
     # Check the Sire version.
-    if int(sire.legacy.__version__.replace(".", "")) < min_ver_int:
+    if int(sire.legacy.__version__.replace(".", "").replace("dev", "")) < min_ver_int:
         raise ImportError("BioSimSpace requires Sire version '%s' or above." % min_ver)
 
 from setuptools import setup, find_packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # BioSimSpace runtime requirements.
 
 # main
-# sire~=2023.2.2
+sire~=2023.2.2
 
 # devel
-sire==2023.3.0.dev
+#sire==2023.3.0.dev
 
 configargparse
 ipywidgets<8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 # BioSimSpace runtime requirements.
 
-sire ~=2023.2.0
+# main
+# sire~=2023.2.2
+
+# devel
+sire==2023.3.0.dev
 
 configargparse
 ipywidgets<8

--- a/test/IO/test_tuple.py
+++ b/test/IO/test_tuple.py
@@ -1,0 +1,5 @@
+import BioSimSpace as BSS
+
+def test_tuple():
+    """Check that we can read from a tuple of files."""
+    BSS.IO.readMolecules(("test/input/ala.crd", "test/input/ala.top"))

--- a/test/Sandpit/Exscientia/IO/test_tuple.py
+++ b/test/Sandpit/Exscientia/IO/test_tuple.py
@@ -1,0 +1,5 @@
+import BioSimSpace.Sandpit.Exscientia as BSS
+
+def test_tuple():
+    """Check that we can read from a tuple of files."""
+    BSS.IO.readMolecules(("test/input/ala.crd", "test/input/ala.top"))


### PR DESCRIPTION
This PR brings the changes from #34 into `main`, updating the CI for the new release process. The only modification is the version of Sire against which BioSImSpace is built, i.e. currently `~=2023.2.2`. I've skipped this CI since this was tested with the `devel` PR. This should be safe to merge once the Sire 2023.2.2 release has been approved and is transferred to the `main` channel.

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

@chryswoods