### PR TITLE
Reinstate s3 streaming support

### DIFF
--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -27,6 +27,7 @@ directory of the GitHub repository.
    index_Protocol
    index_Sandpit
    index_Solvent
+   index_Stream
    index_Trajectory
    index_Types
    index_Units

--- a/doc/source/api/index_Stream.rst
+++ b/doc/source/api/index_Stream.rst
@@ -1,0 +1,12 @@
+.. _ref-Stream:
+
+BioSimSpace.Stream
+==================
+
+The *Stream* package contains tools for streaming wrapped Sire objects, i.e.
+objects from :ref:`ref-SireWrappers`.
+
+.. automodule:: BioSimSpace.Stream
+
+.. toctree::
+   :maxdepth: 1

--- a/python/BioSimSpace/Sandpit/Exscientia/Stream/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Stream/__init__.py
@@ -41,8 +41,10 @@ file.
 
    import BioSimSpace as BSS
 
+   files = BSS.IO.expand(BSS.tutorialUrl(), ["ala.top", "ala.crd"], ".bz2")
+
    # Load a molecular system.
-   system0 = BSS.IO.readMolecules(["ala.rst7", "ala.prm7"])
+   system0 = BSS.IO.readMolecules(files)
 
    # Stream to file.
    BSS.Stream.save(system0, "system")

--- a/python/BioSimSpace/Sandpit/Exscientia/Stream/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Stream/__init__.py
@@ -20,22 +20,38 @@
 #####################################################################
 
 """
-.. currentmodule:: BioSimSpace._Exceptions
+.. currentmodule:: BioSimSpace.Stream
 
-Classes
-=======
+Functions
+=========
 
 .. autosummary::
     :toctree: generated/
 
-    AlignmentError
-    AnalysisError
-    ConversionError
-    IncompatibleError
-    MissingSoftwareError
-    ParameterisationError
-    StreamError
-    ThirdPartyError
+    save
+    load
+
+Examples
+========
+
+Stream a :class:`System <BioSimSpace._SireWrappers.System>` object to and from
+file.
+
+.. code-block:: python
+
+   import BioSimSpace as BSS
+
+   # Load a molecular system.
+   system0 = BSS.IO.readMolecules(["ala.rst7", "ala.prm7"])
+
+   # Stream to file.
+   BSS.Stream.save(system0, "system")
+
+   # Alternatively, stream the system object directly.
+   system0.save("system")
+
+   # Stream from file.
+   system1 = BSS.Stream.load("system.s3")
 """
 
-from ._exceptions import *
+from ._stream import *

--- a/python/BioSimSpace/Sandpit/Exscientia/Stream/_stream.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Stream/_stream.py
@@ -1,0 +1,120 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2023
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""
+Functionality for streaming wrapped Sire objects.
+"""
+
+__author__ = "Lester Hedges"
+__email__ = "lester.hedges@gmail.com"
+
+__all__ = ["save", "load"]
+
+import os as _os
+
+from sire.legacy import Mol as _SireMol
+from sire.legacy import Stream as _SireStream
+from sire.legacy import System as _SireSystem
+
+from .. import _isVerbose
+from .._Exceptions import StreamError as _StreamError
+from .._SireWrappers._sire_wrapper import SireWrapper as _SireWrapper
+from .. import _SireWrappers
+
+
+def save(sire_object, filebase):
+    """Stream a wrapped Sire object to file.
+
+    Parameters
+    ----------
+
+    sire_object : :class:`System <BioSimSpace._SireWrappers.SireWrapper>`
+        A wrapped Sire object.
+
+    filebase : str
+        The base name of the binary output file.
+    """
+
+    # Validate input.
+
+    if not isinstance(sire_object, _SireWrapper) and not isinstance(
+        sire_object, _SireWrappers.SearchResult
+    ):
+        raise TypeError(
+            "'sire_object' must be of type 'BioSimSpace._SireWrappers.SireWrapper'."
+        )
+
+    if type(filebase) is not str:
+        raise TypeError("'filebase' must be of type 'str'.")
+
+    try:
+        _SireStream.save(sire_object._sire_object, f"{filebase}.s3")
+    except Exception as e:
+        msg = f"Failed to stream {sire_object} to file '{filebase}.s3'."
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None
+
+
+def load(file):
+    """Stream a wrapped Sire object from file.
+
+    Parameters
+    ----------
+
+    file : str
+        The path to the binary file containing the streamed object.
+    """
+
+    # Validate input.
+
+    if not _os.path.isfile(file):
+        raise TypeError(f"The binary file '{file}' doesn't exist!")
+
+    # Try to load the object.
+
+    try:
+        # Stream from file.
+        sire_object = _SireStream.load(file)
+
+        # Construct the wrapped object.
+        if isinstance(sire_object, _SireSystem.System):
+            return _SireWrappers.System(sire_object)
+        elif isinstance(sire_object, _SireMol.Molecule):
+            return _SireWrappers.Molecule(sire_object)
+        elif isinstance(sire_object, _SireMol.MoleculeGroup):
+            return _SireWrappers.Molecules(sire_object)
+        elif isinstance(sire_object, _SireMol.Residue):
+            return _SireWrappers.Residue(sire_object)
+        elif isinstance(sire_object, _SireMol.Atom):
+            return _SireWrappers.Atom(sire_object)
+        elif "Selector" in sire_object.__class__.__name__:
+            return _SireWrappers.SearchResult(sire_object)
+        else:
+            raise _StreamError(f"Unable to stream object of type {type(sire_object)}.")
+
+    except Exception as e:
+        msg = f"Failed to stream {object} from file '{file}'."
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None

--- a/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/__init__.py
@@ -34,6 +34,7 @@ Classes
     IncompatibleError
     MissingSoftwareError
     ParameterisationError
+    StreamError
     ThirdPartyError
 """
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/_exceptions.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/_exceptions.py
@@ -31,6 +31,7 @@ __all__ = [
     "IncompatibleError",
     "MissingSoftwareError",
     "ParameterisationError",
+    "StreamError",
     "ThirdPartyError",
 ]
 
@@ -63,6 +64,12 @@ class MissingSoftwareError(Exception):
 
 class ParameterisationError(Exception):
     """Exception thrown when molecular parameterisation fails."""
+
+    pass
+
+
+class StreamError(Exception):
+    """Exception thrown when streaming fails."""
 
     pass
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_sire_wrapper.py
@@ -271,6 +271,21 @@ class SireWrapper:
 
         return box_min, box_max
 
+    def save(self, filebase):
+        """
+        Stream a wrapped Sire object to file.
+
+        Parameters
+        ----------
+
+        sire_object : :class:`System <BioSimSpace._SireWrappers.SireWrapper>`
+            A wrapped Sire object.
+
+        filebase : str
+            The base name of the binary output file.
+        """
+        _save(self, filebase)
+
     def _getSireObject(self):
         """
         Return the underlying Sire object.
@@ -338,3 +353,7 @@ class SireWrapper:
 
         # Return the AABox for the coordinates.
         return _SireVol.AABox(coord)
+
+
+# Import at bottom of module to avoid circular dependency.
+from BioSimSpace.Stream import save as _save

--- a/python/BioSimSpace/Sandpit/Exscientia/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "Process",
     "Protocol",
     "Solvent",
+    "Stream",
     "Trajectory",
     "Types",
     "Units",
@@ -238,6 +239,7 @@ from . import Parameters
 from . import Process
 from . import Protocol
 from . import Solvent
+from . import Stream
 from . import Trajectory
 from . import Types
 from . import Units

--- a/python/BioSimSpace/Stream/__init__.py
+++ b/python/BioSimSpace/Stream/__init__.py
@@ -41,8 +41,10 @@ file.
 
    import BioSimSpace as BSS
 
+   files = BSS.IO.expand(BSS.tutorialUrl(), ["ala.top", "ala.crd"], ".bz2")
+
    # Load a molecular system.
-   system0 = BSS.IO.readMolecules(["ala.rst7", "ala.prm7"])
+   system0 = BSS.IO.readMolecules(files)
 
    # Stream to file.
    BSS.Stream.save(system0, "system")

--- a/python/BioSimSpace/Stream/__init__.py
+++ b/python/BioSimSpace/Stream/__init__.py
@@ -20,22 +20,38 @@
 #####################################################################
 
 """
-.. currentmodule:: BioSimSpace._Exceptions
+.. currentmodule:: BioSimSpace.Stream
 
-Classes
-=======
+Functions
+=========
 
 .. autosummary::
     :toctree: generated/
 
-    AlignmentError
-    AnalysisError
-    ConversionError
-    IncompatibleError
-    MissingSoftwareError
-    ParameterisationError
-    StreamError
-    ThirdPartyError
+    save
+    load
+
+Examples
+========
+
+Stream a :class:`System <BioSimSpace._SireWrappers.System>` object to and from
+file.
+
+.. code-block:: python
+
+   import BioSimSpace as BSS
+
+   # Load a molecular system.
+   system0 = BSS.IO.readMolecules(["ala.rst7", "ala.prm7"])
+
+   # Stream to file.
+   BSS.Stream.save(system0, "system")
+
+   # Alternatively, stream the system object directly.
+   system0.save("system")
+
+   # Stream from file.
+   system1 = BSS.Stream.load("system.s3")
 """
 
-from ._exceptions import *
+from ._stream import *

--- a/python/BioSimSpace/Stream/_stream.py
+++ b/python/BioSimSpace/Stream/_stream.py
@@ -1,0 +1,120 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2023
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""
+Functionality for streaming wrapped Sire objects.
+"""
+
+__author__ = "Lester Hedges"
+__email__ = "lester.hedges@gmail.com"
+
+__all__ = ["save", "load"]
+
+import os as _os
+
+from sire.legacy import Mol as _SireMol
+from sire.legacy import Stream as _SireStream
+from sire.legacy import System as _SireSystem
+
+from .. import _isVerbose
+from .._Exceptions import StreamError as _StreamError
+from .._SireWrappers._sire_wrapper import SireWrapper as _SireWrapper
+from .. import _SireWrappers
+
+
+def save(sire_object, filebase):
+    """Stream a wrapped Sire object to file.
+
+    Parameters
+    ----------
+
+    sire_object : :class:`System <BioSimSpace._SireWrappers.SireWrapper>`
+        A wrapped Sire object.
+
+    filebase : str
+        The base name of the binary output file.
+    """
+
+    # Validate input.
+
+    if not isinstance(sire_object, _SireWrapper) and not isinstance(
+        sire_object, _SireWrappers.SearchResult
+    ):
+        raise TypeError(
+            "'sire_object' must be of type 'BioSimSpace._SireWrappers.SireWrapper'."
+        )
+
+    if type(filebase) is not str:
+        raise TypeError("'filebase' must be of type 'str'.")
+
+    try:
+        _SireStream.save(sire_object._sire_object, f"{filebase}.s3")
+    except Exception as e:
+        msg = f"Failed to stream {sire_object} to file '{filebase}.s3'."
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None
+
+
+def load(file):
+    """Stream a wrapped Sire object from file.
+
+    Parameters
+    ----------
+
+    file : str
+        The path to the binary file containing the streamed object.
+    """
+
+    # Validate input.
+
+    if not _os.path.isfile(file):
+        raise TypeError(f"The binary file '{file}' doesn't exist!")
+
+    # Try to load the object.
+
+    try:
+        # Stream from file.
+        sire_object = _SireStream.load(file)
+
+        # Construct the wrapped object.
+        if isinstance(sire_object, _SireSystem.System):
+            return _SireWrappers.System(sire_object)
+        elif isinstance(sire_object, _SireMol.Molecule):
+            return _SireWrappers.Molecule(sire_object)
+        elif isinstance(sire_object, _SireMol.MoleculeGroup):
+            return _SireWrappers.Molecules(sire_object)
+        elif isinstance(sire_object, _SireMol.Residue):
+            return _SireWrappers.Residue(sire_object)
+        elif isinstance(sire_object, _SireMol.Atom):
+            return _SireWrappers.Atom(sire_object)
+        elif "Selector" in sire_object.__class__.__name__:
+            return _SireWrappers.SearchResult(sire_object)
+        else:
+            raise _StreamError(f"Unable to stream object of type {type(sire_object)}.")
+
+    except Exception as e:
+        msg = f"Failed to stream {object} from file '{file}'."
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None

--- a/python/BioSimSpace/_Exceptions/_exceptions.py
+++ b/python/BioSimSpace/_Exceptions/_exceptions.py
@@ -31,6 +31,7 @@ __all__ = [
     "IncompatibleError",
     "MissingSoftwareError",
     "ParameterisationError",
+    "StreamError",
     "ThirdPartyError",
 ]
 
@@ -63,6 +64,12 @@ class MissingSoftwareError(Exception):
 
 class ParameterisationError(Exception):
     """Exception thrown when molecular parameterisation fails."""
+
+    pass
+
+
+class StreamError(Exception):
+    """Exception thrown when streaming fails."""
 
     pass
 

--- a/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
@@ -271,6 +271,21 @@ class SireWrapper:
 
         return box_min, box_max
 
+    def save(self, filebase):
+        """
+        Stream a wrapped Sire object to file.
+
+        Parameters
+        ----------
+
+        sire_object : :class:`System <BioSimSpace._SireWrappers.SireWrapper>`
+            A wrapped Sire object.
+
+        filebase : str
+            The base name of the binary output file.
+        """
+        _save(self, filebase)
+
     def _getSireObject(self):
         """
         Return the underlying Sire object.
@@ -338,3 +353,7 @@ class SireWrapper:
 
         # Return the AABox for the coordinates.
         return _SireVol.AABox(coord)
+
+
+# Import at bottom of module to avoid circular dependency.
+from BioSimSpace.Stream import save as _save

--- a/python/BioSimSpace/__init__.py
+++ b/python/BioSimSpace/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "Process",
     "Protocol",
     "Solvent",
+    "Stream",
     "Trajectory",
     "Types",
     "Units",
@@ -246,6 +247,7 @@ from . import Parameters
 from . import Process
 from . import Protocol
 from . import Solvent
+from . import Stream
 from . import Trajectory
 from . import Types
 from . import Units

--- a/test/Sandpit/Exscientia/Stream/test_stream.py
+++ b/test/Sandpit/Exscientia/Stream/test_stream.py
@@ -1,0 +1,136 @@
+import BioSimSpace.Sandpit.Exscientia as BSS
+
+import os
+import pytest
+
+
+@pytest.fixture
+def system(scope="session"):
+    return BSS.IO.readMolecules(["test/input/ala.top", "test/input/ala.crd"])
+
+
+def test_system(system):
+    """Test streaming of a Sire system."""
+
+    # Stream to file.
+    BSS.Stream.save(system, "test")
+
+    # Stream from file.
+    s = BSS.Stream.load("test.s3")
+
+    # Check that both systems contain the same number of molecules.
+    assert system.nMolecules() == s.nMolecules()
+
+    # Check that the molecules in both systems contain the same number
+    # of residues and atoms.
+    for m0, m1 in zip(system, s):
+        assert m0.nResidues() == m1.nResidues()
+        assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_molecule(system):
+    """Test streaming of a Sire molecule."""
+
+    # Extract the first molecule.
+    m0 = system[0]
+
+    # Stream to file.
+    BSS.Stream.save(m0, "test")
+
+    # Stream from file.
+    m1 = BSS.Stream.load("test.s3")
+
+    # Check that the molecules contain the same number of residues and atoms.
+    assert m0.nResidues() == m1.nResidues()
+    assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_molecules(system):
+    """Test streaming of a Sire molecule group."""
+
+    # Stream to file.
+    BSS.Stream.save(system.getMolecules(), "test")
+
+    # Stream from file.
+    m = BSS.Stream.load("test.s3")
+
+    # Check that the system contain the same number of molecules as the
+    # molecule group.
+    assert system.nMolecules() == len(m)
+
+    # Check that the molecules in the system and molecule group contain the
+    # same number of residues and atoms.
+    for m0, m1 in zip(system, m):
+        assert m0.nResidues() == m1.nResidues()
+        assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_residue(system):
+    """Test streaming of a Sire residue."""
+
+    # Extract the first residue of the first molecule.
+    r0 = system[0].getResidues()[0]
+
+    # Stream to file.
+    BSS.Stream.save(r0, "test")
+
+    # Stream from file.
+    r1 = BSS.Stream.load("test.s3")
+
+    # Check that the residues contain the same number of atoms.
+    assert r0.nAtoms() == r1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_atom(system):
+    """Test streaming of a Sire atom."""
+
+    # Extract the first atom of the first molecule.
+    a0 = system[0].getAtoms()[0]
+
+    # Stream to file.
+    BSS.Stream.save(a0, "test")
+
+    # Stream from file.
+    a1 = BSS.Stream.load("test.s3")
+
+    # Check that the atom elements are the same.
+    assert a0.element() == a1.element()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_select_result(system):
+    """Test streaming of a Sire select result."""
+
+    # Search for all carbon atoms.
+    s0 = system.search("element C")
+
+    # Stream to file.
+    BSS.Stream.save(s0, "test")
+
+    # Stream from file.
+    s1 = BSS.Stream.load("test.s3")
+
+    # Check that the number of search results is the same.
+    assert len(s0.atoms()) == len(s1.atoms())
+
+    # Check that the results have the same element and index.
+    for a0, a1 in zip(s0.atoms(), s1.atoms()):
+        assert a0.index() == a1.index()
+        assert a0.element() == a1.element()
+
+    # Remove the test file.
+    os.remove("test.s3")

--- a/test/Sandpit/Exscientia/Stream/test_stream.py
+++ b/test/Sandpit/Exscientia/Stream/test_stream.py
@@ -9,6 +9,12 @@ def system(scope="session"):
     return BSS.IO.readMolecules(["test/input/ala.top", "test/input/ala.crd"])
 
 
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    yield
+    os.remove("test.s3")
+
+
 def test_system(system):
     """Test streaming of a Sire system."""
 
@@ -27,9 +33,6 @@ def test_system(system):
         assert m0.nResidues() == m1.nResidues()
         assert m0.nAtoms() == m1.nAtoms()
 
-    # Remove the test file.
-    os.remove("test.s3")
-
 
 def test_molecule(system):
     """Test streaming of a Sire molecule."""
@@ -46,9 +49,6 @@ def test_molecule(system):
     # Check that the molecules contain the same number of residues and atoms.
     assert m0.nResidues() == m1.nResidues()
     assert m0.nAtoms() == m1.nAtoms()
-
-    # Remove the test file.
-    os.remove("test.s3")
 
 
 def test_molecules(system):
@@ -70,9 +70,6 @@ def test_molecules(system):
         assert m0.nResidues() == m1.nResidues()
         assert m0.nAtoms() == m1.nAtoms()
 
-    # Remove the test file.
-    os.remove("test.s3")
-
 
 def test_residue(system):
     """Test streaming of a Sire residue."""
@@ -88,9 +85,6 @@ def test_residue(system):
 
     # Check that the residues contain the same number of atoms.
     assert r0.nAtoms() == r1.nAtoms()
-
-    # Remove the test file.
-    os.remove("test.s3")
 
 
 def test_atom(system):
@@ -108,10 +102,8 @@ def test_atom(system):
     # Check that the atom elements are the same.
     assert a0.element() == a1.element()
 
-    # Remove the test file.
-    os.remove("test.s3")
 
-
+@pytest.mark.xfail(reason="Sire streaming for Selector<T> types is not yet exposed.")
 def test_select_result(system):
     """Test streaming of a Sire select result."""
 
@@ -131,6 +123,3 @@ def test_select_result(system):
     for a0, a1 in zip(s0.atoms(), s1.atoms()):
         assert a0.index() == a1.index()
         assert a0.element() == a1.element()
-
-    # Remove the test file.
-    os.remove("test.s3")

--- a/test/Stream/test_stream.py
+++ b/test/Stream/test_stream.py
@@ -9,6 +9,12 @@ def system(scope="session"):
     return BSS.IO.readMolecules(["test/input/ala.top", "test/input/ala.crd"])
 
 
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    yield
+    os.remove("test.s3")
+
+
 def test_system(system):
     """Test streaming of a Sire system."""
 
@@ -27,9 +33,6 @@ def test_system(system):
         assert m0.nResidues() == m1.nResidues()
         assert m0.nAtoms() == m1.nAtoms()
 
-    # Remove the test file.
-    os.remove("test.s3")
-
 
 def test_molecule(system):
     """Test streaming of a Sire molecule."""
@@ -46,9 +49,6 @@ def test_molecule(system):
     # Check that the molecules contain the same number of residues and atoms.
     assert m0.nResidues() == m1.nResidues()
     assert m0.nAtoms() == m1.nAtoms()
-
-    # Remove the test file.
-    os.remove("test.s3")
 
 
 def test_molecules(system):
@@ -70,9 +70,6 @@ def test_molecules(system):
         assert m0.nResidues() == m1.nResidues()
         assert m0.nAtoms() == m1.nAtoms()
 
-    # Remove the test file.
-    os.remove("test.s3")
-
 
 def test_residue(system):
     """Test streaming of a Sire residue."""
@@ -88,9 +85,6 @@ def test_residue(system):
 
     # Check that the residues contain the same number of atoms.
     assert r0.nAtoms() == r1.nAtoms()
-
-    # Remove the test file.
-    os.remove("test.s3")
 
 
 def test_atom(system):
@@ -108,10 +102,8 @@ def test_atom(system):
     # Check that the atom elements are the same.
     assert a0.element() == a1.element()
 
-    # Remove the test file.
-    os.remove("test.s3")
 
-
+@pytest.mark.xfail(reason="Sire streaming for Selector<T> types is not yet exposed.")
 def test_select_result(system):
     """Test streaming of a Sire select result."""
 
@@ -131,6 +123,3 @@ def test_select_result(system):
     for a0, a1 in zip(s0.atoms(), s1.atoms()):
         assert a0.index() == a1.index()
         assert a0.element() == a1.element()
-
-    # Remove the test file.
-    os.remove("test.s3")

--- a/test/Stream/test_stream.py
+++ b/test/Stream/test_stream.py
@@ -1,0 +1,136 @@
+import BioSimSpace as BSS
+
+import os
+import pytest
+
+
+@pytest.fixture
+def system(scope="session"):
+    return BSS.IO.readMolecules(["test/input/ala.top", "test/input/ala.crd"])
+
+
+def test_system(system):
+    """Test streaming of a Sire system."""
+
+    # Stream to file.
+    BSS.Stream.save(system, "test")
+
+    # Stream from file.
+    s = BSS.Stream.load("test.s3")
+
+    # Check that both systems contain the same number of molecules.
+    assert system.nMolecules() == s.nMolecules()
+
+    # Check that the molecules in both systems contain the same number
+    # of residues and atoms.
+    for m0, m1 in zip(system, s):
+        assert m0.nResidues() == m1.nResidues()
+        assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_molecule(system):
+    """Test streaming of a Sire molecule."""
+
+    # Extract the first molecule.
+    m0 = system[0]
+
+    # Stream to file.
+    BSS.Stream.save(m0, "test")
+
+    # Stream from file.
+    m1 = BSS.Stream.load("test.s3")
+
+    # Check that the molecules contain the same number of residues and atoms.
+    assert m0.nResidues() == m1.nResidues()
+    assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_molecules(system):
+    """Test streaming of a Sire molecule group."""
+
+    # Stream to file.
+    BSS.Stream.save(system.getMolecules(), "test")
+
+    # Stream from file.
+    m = BSS.Stream.load("test.s3")
+
+    # Check that the system contain the same number of molecules as the
+    # molecule group.
+    assert system.nMolecules() == len(m)
+
+    # Check that the molecules in the system and molecule group contain the
+    # same number of residues and atoms.
+    for m0, m1 in zip(system, m):
+        assert m0.nResidues() == m1.nResidues()
+        assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_residue(system):
+    """Test streaming of a Sire residue."""
+
+    # Extract the first residue of the first molecule.
+    r0 = system[0].getResidues()[0]
+
+    # Stream to file.
+    BSS.Stream.save(r0, "test")
+
+    # Stream from file.
+    r1 = BSS.Stream.load("test.s3")
+
+    # Check that the residues contain the same number of atoms.
+    assert r0.nAtoms() == r1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_atom(system):
+    """Test streaming of a Sire atom."""
+
+    # Extract the first atom of the first molecule.
+    a0 = system[0].getAtoms()[0]
+
+    # Stream to file.
+    BSS.Stream.save(a0, "test")
+
+    # Stream from file.
+    a1 = BSS.Stream.load("test.s3")
+
+    # Check that the atom elements are the same.
+    assert a0.element() == a1.element()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+
+def test_select_result(system):
+    """Test streaming of a Sire select result."""
+
+    # Search for all carbon atoms.
+    s0 = system.search("element C")
+
+    # Stream to file.
+    BSS.Stream.save(s0, "test")
+
+    # Stream from file.
+    s1 = BSS.Stream.load("test.s3")
+
+    # Check that the number of search results is the same.
+    assert len(s0.atoms()) == len(s1.atoms())
+
+    # Check that the results have the same element and index.
+    for a0, a1 in zip(s0.atoms(), s1.atoms()):
+        assert a0.index() == a1.index()
+        assert a0.element() == a1.element()
+
+    # Remove the test file.
+    os.remove("test.s3")


### PR DESCRIPTION
## Checklist

This PR reinstates the `BioSimSpace.Stream` sub-package, allowing streaming to/from the Sire `s3` format for wrapped Sire objects. Objects also have a `save` method to allow direct saving to `s3`.

While I could use functionality from `BioSimSpace.Convert` to create BioSimSpace objects from the Sire objects creating by loading an `s3`, I do this manually to also support wrapped `SelectorMol` and `Selector<T>` types (via `BioSimSpace._SireWrappers.SearchResult`). Tests for streaming to/from this type are currently marked as `xfail` since streaming for the certain Sire type, e.g.. `Selector<T>` , hasn't yet been exposed. These tests can be unmarked at a later date.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods