### PR TITLE
Allow readMolecules to work with a tuple of files

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -420,6 +420,9 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
             raise TypeError("'files' must be a list of 'str' types.")
         if len(files) == 0:
             raise ValueError("The list of input files is empty!")
+        # Convert tuple to list.
+        if isinstance(files, tuple):
+            files = list(files)
     else:
         raise TypeError("'files' must be of type 'str', or a list of 'str' types.")
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -420,6 +420,9 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
             raise TypeError("'files' must be a list of 'str' types.")
         if len(files) == 0:
             raise ValueError("The list of input files is empty!")
+        # Convert tuple to list.
+        if isinstance(files, tuple):
+            files = list(files)
     else:
         raise TypeError("'files' must be of type 'str', or a list of 'str' types.")
 

--- a/test/IO/test_tuple.py
+++ b/test/IO/test_tuple.py
@@ -1,0 +1,5 @@
+import BioSimSpace as BSS
+
+def test_tuple():
+    """Check that we can read from a tuple of files."""
+    BSS.IO.readMolecules(("test/input/ala.crd", "test/input/ala.top"))

--- a/test/Sandpit/Exscientia/IO/test_tuple.py
+++ b/test/Sandpit/Exscientia/IO/test_tuple.py
@@ -1,0 +1,5 @@
+import BioSimSpace.Sandpit.Exscientia as BSS
+
+def test_tuple():
+    """Check that we can read from a tuple of files."""
+    BSS.IO.readMolecules(("test/input/ala.crd", "test/input/ala.top"))


### PR DESCRIPTION
This pull request closes #37. Previously we could read from a list of tuple of files, now I need to convert a tuple to a list before passing through to the new Sire load functionality.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
 @chryswoods