### PR TITLE
Re-add pre-minimisation to SOMD free-energy protocol configuration

### DIFF
--- a/python/BioSimSpace/_Config/_somd.py
+++ b/python/BioSimSpace/_Config/_somd.py
@@ -242,6 +242,8 @@ class Somd(_Config):
 
         # Free energies.
         if isinstance(self._protocol, _Protocol.FreeEnergyProduction):
+            # Perform a pre-minimisation.
+            protocol_dict["minimise"] = True
             # Handle hydrogen perturbations.
             protocol_dict["constraint"] = "hbonds-notperturbed"
             # Write gradients every 250 steps.


### PR DESCRIPTION
This PR closes #58. This wasn't essential, since the system is generally already minimised/equilibrated, but it seems to prevent some stability issues, presumably due to steric clashes due to fixed-precision loading from file, especially on GPU. A similar thing is seen for OpenMM, where it is often preferable to always run a short minimisation prior to any simulation.

## Checklist:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods