### PR TITLE
fix_windows_setup_py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -133,26 +133,15 @@ finally:
 
         print("Checking for dependencies that are already installed...")
 
-        if sys.platform == "win32":
-            conda_exe = os.path.join(bin_dir, "Scripts", "mamba.exe")
-            real_conda_exe = os.path.join(bin_dir, "Scripts", "conda.exe")
+        from shutil import which
+        conda_exe = which("mamba")
+        real_conda_exe = which("conda")
 
-            if not os.path.exists(conda_exe):
-                conda_exe = real_conda_exe
-        else:
-            conda_exe = os.path.join(bin_dir, "mamba")
-            real_conda_exe = os.path.join(bin_dir, "conda")
+        if conda_exe is None or not os.path.exists(conda_exe):
+            conda_exe = real_conda_exe
 
-            if not os.path.exists(conda_exe):
-                # This could be in an environment
-                conda_exe = os.path.join(bin_dir, "..", "..", "..", "bin", "mamba")
-                real_conda_exe = os.path.join(bin_dir, "..", "..", "..", "bin", "conda")
-
-                if not os.path.exists(conda_exe):
-                    if not os.path.exists(real_conda_exe):
-                        real_conda_exe = os.path.join(bin_dir, "conda")
-
-                conda_exe = real_conda_exe
+        if conda_exe is None or not os.path.exists(conda_exe):
+            raise IOError("Unable to install as cannot find conda or mamba!")
 
         for dep in conda_deps:
             if not is_installed(dep, conda=conda_exe):


### PR DESCRIPTION
Updated to use `shutil.which()` to find conda and mamba. This is much more reliable and should work cross-platform. I've checked it works on windows and MacOS. Pretty sure it will work on Windows too.

## If this is to fix a bug...

This pull request fixes issue installing dependencies locally using the setup.py script.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

I've disabled the CI as this wouldn't test the new script.

[ci skip]
