### PR TITLE
Fix issue #82

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -173,8 +173,8 @@ class GeneralUnit(_Type):
 
         # The user has passed a value and a unit.
         if len(args) > 1:
-            value = args[0]
-            unit = args[1]
+            value = _args[0]
+            unit = _args[1]
 
             # Check that the value is valid.
             if type(value) is int:
@@ -185,7 +185,7 @@ class GeneralUnit(_Type):
                 raise TypeError("'value' must be of type 'int' or 'float'")
 
             # Delete the value so we can use the same logic below.
-            del args[0]
+            del _args[0]
 
         if len(_args) == 1:
             # The user has passed a Sire GeneralUnit.

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -173,8 +173,8 @@ class GeneralUnit(_Type):
 
         # The user has passed a value and a unit.
         if len(args) > 1:
-            value = args[0]
-            unit = args[1]
+            value = _args[0]
+            unit = _args[1]
 
             # Check that the value is valid.
             if type(value) is int:
@@ -185,7 +185,7 @@ class GeneralUnit(_Type):
                 raise TypeError("'value' must be of type 'int' or 'float'")
 
             # Delete the value so we can use the same logic below.
-            del args[0]
+            del _args[0]
 
         if len(_args) == 1:
             # The user has passed a Sire GeneralUnit.

--- a/tests/Sandpit/Exscientia/Types/test_general_unit.py
+++ b/tests/Sandpit/Exscientia/Types/test_general_unit.py
@@ -176,3 +176,11 @@ def test_dimensionless_value():
     )
 
     assert value == pytest.approx(418.4)
+
+
+def test_value_and_unit():
+    """
+    Regression test to make sure that a general unit with a value and unit can
+    be parsed correctly.
+    """
+    general_unit = Types._GeneralUnit(2, "kcal per mol / angstrom**2")

--- a/tests/Types/test_general_unit.py
+++ b/tests/Types/test_general_unit.py
@@ -176,3 +176,11 @@ def test_dimensionless_value():
     )
 
     assert value == pytest.approx(418.4)
+
+
+def test_value_and_unit():
+    """
+    Regression test to make sure that a general unit with a value and unit can
+    be parsed correctly.
+    """
+    general_unit = Types._GeneralUnit(2, "kcal per mol / angstrom**2")


### PR DESCRIPTION
This PR closes #82. Here I had forgotten to used the local copy of `args` (which has been conveted to a list) prior to calling `del`. There is some planned refactoring to this module to improve the robustness of the string handling and support formatting for other common unit engines (for units that map to the ones supported by Sire). This is just a quick fix for this issue.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods