### PR TITLE
Fix issue #81

### DIFF
--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -151,7 +151,7 @@ def check_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
-        str(system._mol_nums),
+        _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
         str(skip_water),
     )
@@ -268,7 +268,7 @@ def update_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
-        str(system._mol_nums),
+        _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
         str(skip_water),
     )
@@ -294,3 +294,10 @@ def _get_md5_hash(path):
             hash.update(chunk)
 
     return hash.hexdigest()
+
+
+def _compress_molnum_key(str):
+    """
+    Internal helper function to compress the MolNum list section of the key.
+    """
+    return str.replace("MolNum(", "").replace(")", "")

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -151,6 +151,7 @@ def check_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
+        str(system._mol_nums),
         str(set(excluded_properties)),
         str(skip_water),
     )
@@ -267,6 +268,7 @@ def update_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
+        str(system._mol_nums),
         str(set(excluded_properties)),
         str(skip_water),
     )

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -68,6 +68,11 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
                 key, value = self.popitem(False)
                 self._num_atoms -= value[0].nAtoms()
 
+    def __delitem__(self, key):
+        value = self[key]
+        self._num_atoms -= value[0].nAtoms()
+        _collections.OrderedDict.__delitem__(self, key)
+
 
 # Initialise a "cache" dictionary. This maps a key of the system UID, file format
 # and excluded properties a value of the system and file path. When saving to a

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -155,16 +155,11 @@ def check_cache(
         str(skip_water),
     )
 
-    print(f"\nChecking cache for key: {key}")
-
     # Get the existing file path and MD5 hash from the cache.
     try:
         (prev_system, path, original_hash) = _cache[key]
     except:
-        print("No key found!")
         return False
-
-    print(f"Key matches: {prev_system}, {path}, {original_hash}")
 
     # Whether the cache entry is still valid.
     cache_valid = True
@@ -177,24 +172,20 @@ def check_cache(
         property_map1=property_map,
         skip_water=skip_water,
     ):
-        print("System has been updated. Cache is invalid!")
         cache_valid = False
 
     # Make sure the file still exists.
     if not _os.path.exists(path):
-        print("File no longer exists. Cache is invalid!")
         cache_valid = False
     # Make sure the MD5 sum is still the same.
     else:
         current_hash = _get_md5_hash(path)
         if current_hash != original_hash:
-            print("File MD5 mismatch. Cache is invalid!")
             cache_valid = False
 
     # If the cache isn't valid, delete the entry and return False.
     if not cache_valid:
         if key in _cache:
-            print("Deleting key from cache.")
             del _cache[key]
         return False
 
@@ -208,13 +199,10 @@ def check_cache(
 
         # Copy the file to the new location.
         try:
-            print(f"Copying existing file {path} --> {new_path}")
             _shutil.copyfile(path, new_path)
         except _shutil.SameFileError:
-            print(f"Copy failed. Same file already exists at new path.")
             pass
         except:
-            print(f"Copy failed. Removing cache entry.")
             del _cache[key]
             return False
 
@@ -285,8 +273,6 @@ def update_cache(
 
     # Update the cache.
     _cache[key] = (system.copy(), path, hash)
-
-    print(f"\nUpdated cache: key = {key}, value = {system}, {path}, {hash}")
 
 
 def _get_md5_hash(path):

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -155,11 +155,16 @@ def check_cache(
         str(skip_water),
     )
 
+    print(f"\nChecking cache for key: {key}")
+
     # Get the existing file path and MD5 hash from the cache.
     try:
         (prev_system, path, original_hash) = _cache[key]
     except:
+        print("No key found!")
         return False
+
+    print(f"Key matches: {prev_system}, {path}, {original_hash}")
 
     # Whether the cache entry is still valid.
     cache_valid = True
@@ -172,20 +177,24 @@ def check_cache(
         property_map1=property_map,
         skip_water=skip_water,
     ):
+        print("System has been updated. Cache is invalid!")
         cache_valid = False
 
     # Make sure the file still exists.
     if not _os.path.exists(path):
+        print("File no longer exists. Cache is invalid!")
         cache_valid = False
     # Make sure the MD5 sum is still the same.
     else:
         current_hash = _get_md5_hash(path)
         if current_hash != original_hash:
+            print("File MD5 mismatch. Cache is invalid!")
             cache_valid = False
 
     # If the cache isn't valid, delete the entry and return False.
     if not cache_valid:
         if key in _cache:
+            print("Deleting key from cache.")
             del _cache[key]
         return False
 
@@ -199,10 +208,13 @@ def check_cache(
 
         # Copy the file to the new location.
         try:
+            print(f"Copying existing file {path} --> {new_path}")
             _shutil.copyfile(path, new_path)
         except _shutil.SameFileError:
+            print(f"Copy failed. Same file already exists at new path.")
             pass
         except:
+            print(f"Copy failed. Removing cache entry.")
             del _cache[key]
             return False
 
@@ -272,7 +284,9 @@ def update_cache(
     )
 
     # Update the cache.
-    _cache[key] = (system, path, hash)
+    _cache[key] = (system.copy(), path, hash)
+
+    print(f"\nUpdated cache: key = {key}, value = {system}, {path}, {hash}")
 
 
 def _get_md5_hash(path):

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -151,7 +151,7 @@ def check_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
-        str(system._mol_nums),
+        _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
         str(skip_water),
     )
@@ -268,7 +268,7 @@ def update_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
-        str(system._mol_nums),
+        _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
         str(skip_water),
     )
@@ -294,3 +294,10 @@ def _get_md5_hash(path):
             hash.update(chunk)
 
     return hash.hexdigest()
+
+
+def _compress_molnum_key(str):
+    """
+    Internal helper function to compress the MolNum list section of the key.
+    """
+    return str.replace("MolNum(", "").replace(")", "")

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -151,6 +151,7 @@ def check_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
+        str(system._mol_nums),
         str(set(excluded_properties)),
         str(skip_water),
     )
@@ -267,6 +268,7 @@ def update_cache(
     key = (
         system._sire_object.uid().toString(),
         format,
+        str(system._mol_nums),
         str(set(excluded_properties)),
         str(skip_water),
     )

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -68,6 +68,11 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
                 key, value = self.popitem(False)
                 self._num_atoms -= value[0].nAtoms()
 
+    def __delitem__(self, key):
+        value = self[key]
+        self._num_atoms -= value[0].nAtoms()
+        _collections.OrderedDict.__delitem__(self, key)
+
 
 # Initialise a "cache" dictionary. This maps a key of the system UID, file format
 # and excluded properties a value of the system and file path. When saving to a

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -155,16 +155,11 @@ def check_cache(
         str(skip_water),
     )
 
-    print(f"\nChecking cache for key: {key}")
-
     # Get the existing file path and MD5 hash from the cache.
     try:
         (prev_system, path, original_hash) = _cache[key]
     except:
-        print("No key found!")
         return False
-
-    print(f"Key matches: {prev_system}, {path}, {original_hash}")
 
     # Whether the cache entry is still valid.
     cache_valid = True
@@ -177,24 +172,20 @@ def check_cache(
         property_map1=property_map,
         skip_water=skip_water,
     ):
-        print("System has been updated. Cache is invalid!")
         cache_valid = False
 
     # Make sure the file still exists.
     if not _os.path.exists(path):
-        print("File no longer exists. Cache is invalid!")
         cache_valid = False
     # Make sure the MD5 sum is still the same.
     else:
         current_hash = _get_md5_hash(path)
         if current_hash != original_hash:
-            print("File MD5 mismatch. Cache is invalid!")
             cache_valid = False
 
     # If the cache isn't valid, delete the entry and return False.
     if not cache_valid:
         if key in _cache:
-            print("Deleting key from cache.")
             del _cache[key]
         return False
 
@@ -208,13 +199,10 @@ def check_cache(
 
         # Copy the file to the new location.
         try:
-            print(f"Copying existing file {path} --> {new_path}")
             _shutil.copyfile(path, new_path)
         except _shutil.SameFileError:
-            print(f"Copy failed. Same file already exists at new path.")
             pass
         except:
-            print(f"Copy failed. Removing cache entry.")
             del _cache[key]
             return False
 
@@ -285,8 +273,6 @@ def update_cache(
 
     # Update the cache.
     _cache[key] = (system.copy(), path, hash)
-
-    print(f"\nUpdated cache: key = {key}, value = {system}, {path}, {hash}")
 
 
 def _get_md5_hash(path):

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -155,11 +155,16 @@ def check_cache(
         str(skip_water),
     )
 
+    print(f"\nChecking cache for key: {key}")
+
     # Get the existing file path and MD5 hash from the cache.
     try:
         (prev_system, path, original_hash) = _cache[key]
     except:
+        print("No key found!")
         return False
+
+    print(f"Key matches: {prev_system}, {path}, {original_hash}")
 
     # Whether the cache entry is still valid.
     cache_valid = True
@@ -172,20 +177,24 @@ def check_cache(
         property_map1=property_map,
         skip_water=skip_water,
     ):
+        print("System has been updated. Cache is invalid!")
         cache_valid = False
 
     # Make sure the file still exists.
     if not _os.path.exists(path):
+        print("File no longer exists. Cache is invalid!")
         cache_valid = False
     # Make sure the MD5 sum is still the same.
     else:
         current_hash = _get_md5_hash(path)
         if current_hash != original_hash:
+            print("File MD5 mismatch. Cache is invalid!")
             cache_valid = False
 
     # If the cache isn't valid, delete the entry and return False.
     if not cache_valid:
         if key in _cache:
+            print("Deleting key from cache.")
             del _cache[key]
         return False
 
@@ -199,10 +208,13 @@ def check_cache(
 
         # Copy the file to the new location.
         try:
+            print(f"Copying existing file {path} --> {new_path}")
             _shutil.copyfile(path, new_path)
         except _shutil.SameFileError:
+            print(f"Copy failed. Same file already exists at new path.")
             pass
         except:
+            print(f"Copy failed. Removing cache entry.")
             del _cache[key]
             return False
 
@@ -272,7 +284,9 @@ def update_cache(
     )
 
     # Update the cache.
-    _cache[key] = (system, path, hash)
+    _cache[key] = (system.copy(), path, hash)
+
+    print(f"\nUpdated cache: key = {key}, value = {system}, {path}, {hash}")
 
 
 def _get_md5_hash(path):

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -471,6 +471,10 @@ class System(_SireWrapper):
         ):
             return False
 
+        # Make sure that the molecule numbers in the system match.
+        if self._mol_nums != other._mol_nums:
+            return False
+
         # Invert the property maps.
         inv_prop_map0 = {v: k for k, v in property_map0.items()}
         inv_prop_map1 = {v: k for k, v in property_map1.items()}

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -471,6 +471,10 @@ class System(_SireWrapper):
         ):
             return False
 
+        # Make sure that the molecule numbers in the system match.
+        if self._mol_nums != other._mol_nums:
+            return False
+
         # Invert the property maps.
         inv_prop_map0 = {v: k for k, v in property_map0.items()}
         inv_prop_map1 = {v: k for k, v in property_map1.items()}

--- a/tests/IO/test_file_cache.py
+++ b/tests/IO/test_file_cache.py
@@ -1,9 +1,25 @@
 import BioSimSpace as BSS
 
+from BioSimSpace._Utils import _try_import, _have_imported
+
 import glob
 import os
 import pytest
 import tempfile
+
+# Make sure AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
+
+# Make sure openff is installed.
+_openff = _try_import("openff")
+has_openff = _have_imported(_openff)
 
 
 def test_file_cache():
@@ -79,3 +95,40 @@ def test_file_cache():
 
     # Make sure the number of atoms in the cache was decremented.
     assert BSS.IO._file_cache._cache._num_atoms == total_atoms - num_atoms
+
+
+@pytest.mark.skipif(
+    has_amber is False or has_openff is False,
+    reason="Requires AMBER and OpenFF to be installed",
+)
+def test_file_cache_mol_nuums():
+    """
+    Make sure that systems can be cached if they have the same UID, but
+    contain different MolNUms.
+    """
+
+    # Clear the file cache.
+    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
+
+    # Create an initial system.
+    system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()
+
+    # Create two different 5 atom molecules.
+    mol0 = BSS.Parameters.openff_unconstrained_2_0_0("C").getMolecule()
+    mol1 = BSS.Parameters.openff_unconstrained_2_0_0("CF").getMolecule()
+
+    # Create two new systems by adding the different molecules to the original
+    # system. These will have the same UID, but different molecule numbers.
+    system0 = system + mol0
+    system1 = system + mol1
+
+    # Create a temporary working directory.
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_path = tmp_dir.name
+
+    # Write the two systems to PDB format.
+    BSS.IO.saveMolecules(f"{tmp_path}/tmp0", system0, "pdb")
+    BSS.IO.saveMolecules(f"{tmp_path}/tmp1", system1, "pdb")
+
+    # The cache shold have two entries.
+    assert len(BSS.IO._file_cache._cache) == 2

--- a/tests/IO/test_file_cache.py
+++ b/tests/IO/test_file_cache.py
@@ -13,7 +13,7 @@ def test_file_cache():
     """
 
     # Clear the file cache.
-    BSS.IO._file_cache._cache = {}
+    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
 
     # Load the molecular system.
     s = BSS.IO.readMolecules(["tests/input/ala.crd", "tests/input/ala.top"])
@@ -62,3 +62,20 @@ def test_file_cache():
 
     # The directory should now contain 7 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 7
+
+    # Now delete a key and check that the number of atoms is decremented.
+
+    # Get the first key.
+    key = list(BSS.IO._file_cache._cache.keys())[0]
+
+    # Store the number of atoms for this key.
+    num_atoms = BSS.IO._file_cache._cache[key][0].nAtoms()
+
+    # Store the total number of atoms in the cache.
+    total_atoms = BSS.IO._file_cache._cache._num_atoms
+
+    # Delete the key.
+    del BSS.IO._file_cache._cache[key]
+
+    # Make sure the number of atoms in the cache was decremented.
+    assert BSS.IO._file_cache._cache._num_atoms == total_atoms - num_atoms

--- a/tests/Process/test_openmm.py
+++ b/tests/Process/test_openmm.py
@@ -2,7 +2,18 @@ import BioSimSpace as BSS
 
 from BioSimSpace._Utils import _try_import, _have_imported
 
+import os
 import pytest
+
+# Make sure AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
 
 # Make sure GROMACS is installed.
 has_gromacs = BSS._gmx_exe is not None
@@ -90,8 +101,8 @@ def test_production(system, restraint):
 
 
 @pytest.mark.skipif(
-    has_gromacs is False or has_openff is False,
-    reason="Requires GROMACS and OpenFF to be installed",
+    has_amber is False or has_gromacs is False or has_openff is False,
+    reason="Requires AMBER, GROMACS, and OpenFF to be installed",
 )
 def test_rhombic_dodecahedron():
     """Test that OpenMM can load and run rhombic dodecahedral triclinic spaces."""

--- a/tests/Sandpit/Exscientia/IO/test_file_cache.py
+++ b/tests/Sandpit/Exscientia/IO/test_file_cache.py
@@ -13,7 +13,7 @@ def test_file_cache():
     """
 
     # Clear the file cache.
-    BSS.IO._file_cache._cache = {}
+    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
 
     # Load the molecular system.
     s = BSS.IO.readMolecules(["tests/input/ala.crd", "tests/input/ala.top"])
@@ -62,3 +62,20 @@ def test_file_cache():
 
     # The directory should now contain 7 files.
     assert len(glob.glob(f"{tmp_path}/*")) == 7
+
+    # Now delete a key and check that the number of atoms is decremented.
+
+    # Get the first key.
+    key = list(BSS.IO._file_cache._cache.keys())[0]
+
+    # Store the number of atoms for this key.
+    num_atoms = BSS.IO._file_cache._cache[key][0].nAtoms()
+
+    # Store the total number of atoms in the cache.
+    total_atoms = BSS.IO._file_cache._cache._num_atoms
+
+    # Delete the key.
+    del BSS.IO._file_cache._cache[key]
+
+    # Make sure the number of atoms in the cache was decremented.
+    assert BSS.IO._file_cache._cache._num_atoms == total_atoms - num_atoms

--- a/tests/Sandpit/Exscientia/Process/test_openmm.py
+++ b/tests/Sandpit/Exscientia/Process/test_openmm.py
@@ -2,7 +2,18 @@ import BioSimSpace.Sandpit.Exscientia as BSS
 
 from BioSimSpace.Sandpit.Exscientia._Utils import _try_import, _have_imported
 
+import os
 import pytest
+
+# Make sure AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
 
 # Make sure GROMACS is installed.
 has_gromacs = BSS._gmx_exe is not None
@@ -83,8 +94,8 @@ def test_production(system):
 
 
 @pytest.mark.skipif(
-    has_gromacs is False or has_openff is False,
-    reason="Requires GROMACS and OpenFF to be installed",
+    has_amber is False or has_gromacs is False or has_openff is False,
+    reason="Requires AMBER, GROMACS, and OpenFF to be installed",
 )
 def test_rhombic_dodecahedron():
     """Test that OpenMM can load and run rhombic dodecahedral triclinic spaces."""

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -1,6 +1,6 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
 
-from BioSimSpace._Utils import _try_import, _have_imported
+from BioSimSpace.Sandpit.Exscientia._Utils import _try_import, _have_imported
 
 import math
 import os

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -378,6 +378,9 @@ def test_isSame(system):
     reason="Requires AMBER and OpenFF to be installed",
 )
 def test_isSame_mol_nums():
+    # Make sure that isSame works when two systems have the same UID,
+    # but contain different MolNums.
+
     # Create an initial system.
     system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()
 

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -1,7 +1,24 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
 
+from BioSimSpace._Utils import _try_import, _have_imported
+
 import math
+import os
 import pytest
+
+# Make sure AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
+
+# Make sure openff is installed.
+_openff = _try_import("openff")
+has_openff = _have_imported(_openff)
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -354,6 +371,27 @@ def test_isSame(system):
     # Assert that they are the same, apart from their coordinates and space.
     assert system.isSame(other, excluded_properties=["coordinates", "space"])
     assert other.isSame(system, excluded_properties=["coordinates", "space"])
+
+
+@pytest.mark.skipif(
+    has_amber is False or has_openff is False,
+    reason="Requires AMBER and OpenFF to be installed",
+)
+def test_isSame_mol_nums():
+    # Create an initial system.
+    system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()
+
+    # Create two different 5 atom molecules.
+    mol0 = BSS.Parameters.openff_unconstrained_2_0_0("C").getMolecule()
+    mol1 = BSS.Parameters.openff_unconstrained_2_0_0("CF").getMolecule()
+
+    # Create two new systems by adding the different molecules to the original
+    # system. These will have the same UID, but different molecule numbers.
+    system0 = system + mol0
+    system1 = system + mol1
+
+    # Assert that the two systems are different.
+    assert not system0.isSame(system1)
 
 
 def test_velocity_removal():

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -379,6 +379,9 @@ def test_isSame(system):
     reason="Requires AMBER and OpenFF to be installed",
 )
 def test_isSame_mol_nums():
+    # Make sure that isSame works when two systems have the same UID,
+    # but contain different MolNums.
+
     # Create an initial system.
     system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()
 

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -1,7 +1,25 @@
 import BioSimSpace as BSS
 
+from BioSimSpace._Utils import _try_import, _have_imported
+
 import math
+import os
 import pytest
+
+# Make sure AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
+
+# Make sure openff is installed.
+_openff = _try_import("openff")
+has_openff = _have_imported(_openff)
+
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -354,6 +372,26 @@ def test_isSame(system):
     # Assert that they are the same, apart from their coordinates and space.
     assert system.isSame(other, excluded_properties=["coordinates", "space"])
     assert other.isSame(system, excluded_properties=["coordinates", "space"])
+
+
+@pytest.mark.skipif(
+    has_amber is False or has_openff is False,
+    reason="Requires AMBER and OpenFF to be installed",
+)
+def test_isSame_mol_nums():
+    # Create an initial system.
+    system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()
+
+    # Create two different 5 atom molecules.
+    mol0 = BSS.Parameters.openff_unconstrained_2_0_0("C").getMolecule()
+    mol1 = BSS.Parameters.openff_unconstrained_2_0_0("CF").getMolecule()
+
+    # Create two new systems by adding the different molecules to the original
+    # system. These will have the same UID, but different molecule numbers.
+    system0 = system + mol0
+    system1 = system + mol1
+
+    assert not system0.isSame(system1)
 
 
 def test_velocity_removal():


### PR DESCRIPTION
This PR closes #81.

* We now compare the `MolNum` list when comparing two systems using the `isSame` method. This catches situations where systems with the same UID contain different molecules, e.g. when they have been edited in some way, e.g. by adding a new molecule. Previously, the comparison would fail if two systems happened to contain the same number of molecules, residues, and atoms, but had _different_ molecules.
* I have also added the `MolNum` list to the file cache key, so that systems with the same UID but different molecules can be cached.
* I've added tests for both new pieces of functionality.
* While debugging I found and fixed two small bugs in the file cache. I had forgotten to decrement the total number of atoms in the cache when an entry was removed and had also forgotten to store a _copy_ of the system in the cache.

## Checklist:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods