### PR TITLE
Fix issue #86

### DIFF
--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
@@ -846,51 +846,10 @@ def makeFunnel(
     # for solvent molecules directly, since it allows for dry binding sites.
 
     # If the ligand is a Molecule, then assume the binding site is the ligand
-    # center of mass. We do this manually since Sire's built-in evaluator doesn't
-    # take into consideration molecules spanning the periodic boundary.
+    # center of mass.
     if isinstance(ligand, _Molecule):
-        # Get the "mass" property from the user map.
-        mass_prop = property_map.get("mass", "mass")
-        if mass_prop not in ligand._sire_object.propertyKeys():
-            raise _IncompatibleError("The system contains no atomic mass information!")
-
-        # Get the "coordinate" property from the user map.
-        coord_prop = property_map.get("coordinates", "coordinates")
-        if coord_prop not in ligand._sire_object.propertyKeys():
-            raise _IncompatibleError("The system contains no atomic coordinates!")
-
-        # Get the first atom in the ligand.
-        atom = ligand.getAtoms()[0]
-
-        # The sum of the atom masses.
-        total_mass = atom._sire_object.property(mass_prop).value()
-
-        # Reference coordinate.
-        ref_coord = atom._sire_object.property(coord_prop)
-
-        # Initialise the center-of-mass.
-        com = total_mass * atom._sire_object.property(coord_prop)
-
-        # Sum over the rest of the atoms.
-        for atom in ligand.getAtoms()[1:]:
-            # Get the mass and update the total.
-            mass = atom._sire_object.property(mass_prop).value()
-            total_mass += mass
-
-            # Get the coordinate and add to the reference coord using the
-            # its distance from the reference in the minimum image convention.
-            coord = atom._sire_object.property(coord_prop)
-            coord = ref_coord + _SireVector(space.calcDistVector(ref_coord, coord))
-
-            # Update the center of mass.
-            com += mass * coord
-
-        # Normalise.
-        com /= total_mass
-
-        binding_site = _Coordinate(
-            _Length(com.x(), "A"), _Length(com.y(), "A"), _Length(com.z(), "A")
-        )
+        com = ligand._getCenterOfMass(space=space, property_map=property_map)
+        binding_site = _Coordinate(*com)
 
     # Set up the grid.
 

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -2392,12 +2392,26 @@ class Gromacs(_process.Process):
             # need to recompute it next time.
             self._mapping = mapping
 
-            # Update the box information in the original system.
-            if "space" in new_system._sire_object.propertyKeys():
+            # Get the "space" property name from the property map.
+            space_prop = self._property_map.get("space", "space")
+
+            # Update the box information in the original system. Only do this if
+            # the original system contains space information, since it will have
+            # been added in order to run vacuum simulations.
+            if (
+                space_prop in old_system._sire_object.propertyKeys()
+                and space_prop in new_system._sire_object.propertyKeys()
+            ):
                 box = new_system._sire_object.property("space")
                 old_system._sire_object.setProperty(
                     self._property_map.get("space", "space"), box
                 )
+
+            # If this is a vacuum simulation, then translate the centre of mass
+            # of the system back to the origin.
+            if not space_prop in old_system._sire_object.propertyKeys():
+                com = new_system._getCenterOfMass()
+                old_system.translate([-x for x in com])
 
             return old_system
 
@@ -2489,12 +2503,26 @@ class Gromacs(_process.Process):
                 # need to recompute it next time.
                 self._mapping = mapping
 
-                # Update the box information in the original system.
-                if "space" in new_system._sire_object.propertyKeys():
+                # Get the "space" property name from the property map.
+                space_prop = self._property_map.get("space", "space")
+
+                # Update the box information in the original system. Only do this if
+                # the original system contains space information, since it will have
+                # been added in order to run vacuum simulations.
+                if (
+                    space_prop in old_system._sire_object.propertyKeys()
+                    and space_prop in new_system._sire_object.propertyKeys()
+                ):
                     box = new_system._sire_object.property("space")
                     old_system._sire_object.setProperty(
                         self._property_map.get("space", "space"), box
                     )
+
+                # If this is a vacuum simulation, then translate the centre of mass
+                # of the system back to the origin.
+                if not space_prop in old_system._sire_object.propertyKeys():
+                    com = new_system._getCenterOfMass()
+                    old_system.translate([-x for x in com])
 
                 return old_system
 

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -2193,7 +2193,7 @@ class Gromacs(_process.Process):
                     units.append(_Units.Length.nanometer)
                     # kg/m^3 cannot be parsed as there is no mass unit.
                     _warnings.warn(
-                        "Unit {unit} cannot be parsed, record the unit as unitless."
+                        f"Unit {unit} cannot be parsed, record the unit as unitless."
                     )
         return units
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
@@ -846,51 +846,10 @@ def makeFunnel(
     # for solvent molecules directly, since it allows for dry binding sites.
 
     # If the ligand is a Molecule, then assume the binding site is the ligand
-    # center of mass. We do this manually since Sire's built-in evaluator doesn't
-    # take into consideration molecules spanning the periodic boundary.
+    # center of mass.
     if isinstance(ligand, _Molecule):
-        # Get the "mass" property from the user map.
-        mass_prop = property_map.get("mass", "mass")
-        if mass_prop not in ligand._sire_object.propertyKeys():
-            raise _IncompatibleError("The system contains no atomic mass information!")
-
-        # Get the "coordinate" property from the user map.
-        coord_prop = property_map.get("coordinates", "coordinates")
-        if coord_prop not in ligand._sire_object.propertyKeys():
-            raise _IncompatibleError("The system contains no atomic coordinates!")
-
-        # Get the first atom in the ligand.
-        atom = ligand.getAtoms()[0]
-
-        # The sum of the atom masses.
-        total_mass = atom._sire_object.property(mass_prop).value()
-
-        # Reference coordinate.
-        ref_coord = atom._sire_object.property(coord_prop)
-
-        # Initialise the center-of-mass.
-        com = total_mass * atom._sire_object.property(coord_prop)
-
-        # Sum over the rest of the atoms.
-        for atom in ligand.getAtoms()[1:]:
-            # Get the mass and update the total.
-            mass = atom._sire_object.property(mass_prop).value()
-            total_mass += mass
-
-            # Get the coordinate and add to the reference coord using the
-            # its distance from the reference in the minimum image convention.
-            coord = atom._sire_object.property(coord_prop)
-            coord = ref_coord + _SireVector(space.calcDistVector(ref_coord, coord))
-
-            # Update the center of mass.
-            com += mass * coord
-
-        # Normalise.
-        com /= total_mass
-
-        binding_site = _Coordinate(
-            _Length(com.x(), "A"), _Length(com.y(), "A"), _Length(com.z(), "A")
-        )
+        com = ligand._getCenterOfMass(space=space, property_map=property_map)
+        binding_site = _Coordinate(*com)
 
     # Set up the grid.
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2454,7 +2454,7 @@ class Gromacs(_process.Process):
             # If this is a vacuum simulation, then translate the centre of mass
             # of the system back to the origin.
             if not space_prop in old_system._sire_object.propertyKeys():
-                com = new_system._getCenterOfMass()
+                com = old_system._getCenterOfMass()
                 old_system.translate([-x for x in com])
 
             return old_system

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2245,7 +2245,7 @@ class Gromacs(_process.Process):
                     units.append(_Units.Length.nanometer)
                     # kg/m^3 cannot be parsed as there is no mass unit.
                     _warnings.warn(
-                        "Unit {unit} cannot be parsed, record the unit as unitless."
+                        f"Unit {unit} cannot be parsed, record the unit as unitless."
                     )
         return units
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2436,12 +2436,26 @@ class Gromacs(_process.Process):
             # need to recompute it next time.
             self._mapping = mapping
 
-            # Update the box information in the original system.
-            if "space" in new_system._sire_object.propertyKeys():
+            # Get the "space" property name from the property map.
+            space_prop = self._property_map.get("space", "space")
+
+            # Update the box information in the original system. Only do this if
+            # the original system contains space information, since it will have
+            # been added in order to run vacuum simulations.
+            if (
+                space_prop in old_system._sire_object.propertyKeys()
+                and space_prop in new_system._sire_object.propertyKeys()
+            ):
                 box = new_system._sire_object.property("space")
                 old_system._sire_object.setProperty(
                     self._property_map.get("space", "space"), box
                 )
+
+            # If this is a vacuum simulation, then translate the centre of mass
+            # of the system back to the origin.
+            if not space_prop in old_system._sire_object.propertyKeys():
+                com = new_system._getCenterOfMass()
+                old_system.translate([-x for x in com])
 
             return old_system
 
@@ -2533,12 +2547,26 @@ class Gromacs(_process.Process):
                 # need to recompute it next time.
                 self._mapping = mapping
 
-                # Update the box information in the original system.
-                if "space" in new_system._sire_object.propertyKeys():
+                # Get the "space" property name from the property map.
+                space_prop = self._property_map.get("space", "space")
+
+                # Update the box information in the original system. Only do this if
+                # the original system contains space information, since it will have
+                # been added in order to run vacuum simulations.
+                if (
+                    space_prop in old_system._sire_object.propertyKeys()
+                    and space_prop in new_system._sire_object.propertyKeys()
+                ):
                     box = new_system._sire_object.property("space")
                     old_system._sire_object.setProperty(
                         self._property_map.get("space", "space"), box
                     )
+
+                # If this is a vacuum simulation, then translate the centre of mass
+                # of the system back to the origin.
+                if not space_prop in old_system._sire_object.propertyKeys():
+                    com = new_system._getCenterOfMass()
+                    old_system.translate([-x for x in com])
 
                 return old_system
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_sire_wrapper.py
@@ -271,6 +271,133 @@ class SireWrapper:
 
         return box_min, box_max
 
+    def _getCenterOfMass(self, space=None, property_map={}):
+        """
+        Get the center of mass for this object.
+
+        Parameters
+        ----------
+
+        space : sire.legacy.Vol.PeriodicBox, sire.legacy.Vol.TriclinicBox
+            The space associated with the object.
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+
+        Returns
+        -------
+
+        com: [:class:`Length <BioSimSpace.Types.Length>`]
+            The center of mass of the object.
+        """
+
+        if space is None:
+            space_prop = property_map.get("space", "space")
+            try:
+                space = self._sire_object.property("space")
+            except:
+                space = _SireVol.Cartesian()
+        else:
+            if not isinstance(
+                space, (_SireVol.PeriodicBox, _SireVol.TriclinicBox, _SireVol.Cartesian)
+            ):
+                raise TypeError(
+                    "'space' must be of type 'sire.legacy.Vol.PeriodicBox', "
+                    "'sire.legacy.Vol.TriclinicBox', or 'sire.legacy.Vol.Cartesian'"
+                )
+
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'.")
+
+        # Whether this is an atom, molecule or residue, or system.
+        is_atom = False
+        is_mol_res = False
+        is_system = False
+
+        # Get the first atom in the object.
+        try:
+            atom = self[0].getAtoms()[0]
+            is_system = True
+        except:
+            try:
+                atom = self.getAtoms()[0]
+                is_mol_res = True
+            except:
+                atom = self
+                is_atom = True
+
+        # Get the name of the required properties.
+        mass_prop = property_map.get("mass", "mass")
+        coord_prop = property_map.get("coordinates", "coordinates")
+
+        # Intialise the total mass.
+        try:
+            total_mass = atom._sire_object.property(mass_prop).value()
+        except:
+            ValueError("Unable to compute center of mass. Missing 'mass' property!")
+
+        # Store the reference coordinate.
+        try:
+            ref_coord = atom._sire_object.property(coord_prop)
+        except:
+            ValueError(
+                "Unable to compute center of mass. Missing 'coordinates' property!"
+            )
+
+        # Intialise the center of mass.
+        com = total_mass * ref_coord
+
+        # If this is a single atom, then return immediately.
+        if is_atom:
+            return com
+
+        def update_com(atoms, com, total_mass):
+            """
+            Helper function to compute the center of mass of a set of atoms.
+            """
+            for atom in atoms:
+                # Update the total mass.
+                try:
+                    mass = atom._sire_object.property(mass_prop).value()
+                    total_mass += mass
+                except:
+                    ValueError(
+                        "Unable to compute center of mass. Missing 'mass' property!"
+                    )
+
+                # Get the coordinates and add to the reference using the
+                # distance between them using the minimum image convention.
+                try:
+                    coord = atom._sire_object.property(coord_prop)
+                    coord = ref_coord + _SireMaths.Vector(
+                        space.calcDistVector(ref_coord, coord)
+                    )
+                except:
+                    ValueError(
+                        "Unable to compute center of mass. Missing 'coordinates' property!"
+                    )
+
+                # Update the center of mass.
+                com += mass * coord
+
+            return com, total_mass
+
+        # Compute the center of mass for the atoms in all molecules in the system.
+        if is_system:
+            for mol in self:
+                com, total_mass = update_com(mol.getAtoms(), com, total_mass)
+
+        # Computer the center of mass for the atoms in this object.
+        else:
+            com, total_mass = update_com(self.getAtoms(), com, total_mass)
+
+        # Normalise.
+        com /= total_mass
+
+        return [_Units.Length.angstrom * x.value() for x in com]
+
     def save(self, filebase):
         """
         Stream a wrapped Sire object to file.

--- a/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
@@ -271,6 +271,133 @@ class SireWrapper:
 
         return box_min, box_max
 
+    def _getCenterOfMass(self, space=None, property_map={}):
+        """
+        Get the center of mass for this object.
+
+        Parameters
+        ----------
+
+        space : sire.legacy.Vol.PeriodicBox, sire.legacy.Vol.TriclinicBox
+            The space associated with the object.
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+
+        Returns
+        -------
+
+        com: [:class:`Length <BioSimSpace.Types.Length>`]
+            The center of mass of the object.
+        """
+
+        if space is None:
+            space_prop = property_map.get("space", "space")
+            try:
+                space = self._sire_object.property("space")
+            except:
+                space = _SireVol.Cartesian()
+        else:
+            if not isinstance(
+                space, (_SireVol.PeriodicBox, _SireVol.TriclinicBox, _SireVol.Cartesian)
+            ):
+                raise TypeError(
+                    "'space' must be of type 'sire.legacy.Vol.PeriodicBox', "
+                    "'sire.legacy.Vol.TriclinicBox', or 'sire.legacy.Vol.Cartesian'"
+                )
+
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'.")
+
+        # Whether this is an atom, molecule or residue, or system.
+        is_atom = False
+        is_mol_res = False
+        is_system = False
+
+        # Get the first atom in the object.
+        try:
+            atom = self[0].getAtoms()[0]
+            is_system = True
+        except:
+            try:
+                atom = self.getAtoms()[0]
+                is_mol_res = True
+            except:
+                atom = self
+                is_atom = True
+
+        # Get the name of the required properties.
+        mass_prop = property_map.get("mass", "mass")
+        coord_prop = property_map.get("coordinates", "coordinates")
+
+        # Intialise the total mass.
+        try:
+            total_mass = atom._sire_object.property(mass_prop).value()
+        except:
+            ValueError("Unable to compute center of mass. Missing 'mass' property!")
+
+        # Store the reference coordinate.
+        try:
+            ref_coord = atom._sire_object.property(coord_prop)
+        except:
+            ValueError(
+                "Unable to compute center of mass. Missing 'coordinates' property!"
+            )
+
+        # Intialise the center of mass.
+        com = total_mass * ref_coord
+
+        # If this is a single atom, then return immediately.
+        if is_atom:
+            return com
+
+        def update_com(atoms, com, total_mass):
+            """
+            Helper function to compute the center of mass of a set of atoms.
+            """
+            for atom in atoms:
+                # Update the total mass.
+                try:
+                    mass = atom._sire_object.property(mass_prop).value()
+                    total_mass += mass
+                except:
+                    ValueError(
+                        "Unable to compute center of mass. Missing 'mass' property!"
+                    )
+
+                # Get the coordinates and add to the reference using the
+                # distance between them using the minimum image convention.
+                try:
+                    coord = atom._sire_object.property(coord_prop)
+                    coord = ref_coord + _SireMaths.Vector(
+                        space.calcDistVector(ref_coord, coord)
+                    )
+                except:
+                    ValueError(
+                        "Unable to compute center of mass. Missing 'coordinates' property!"
+                    )
+
+                # Update the center of mass.
+                com += mass * coord
+
+            return com, total_mass
+
+        # Compute the center of mass for the atoms in all molecules in the system.
+        if is_system:
+            for mol in self:
+                com, total_mass = update_com(mol.getAtoms(), com, total_mass)
+
+        # Computer the center of mass for the atoms in this object.
+        else:
+            com, total_mass = update_com(self.getAtoms(), com, total_mass)
+
+        # Normalise.
+        com /= total_mass
+
+        return [_Units.Length.angstrom * x.value() for x in com]
+
     def save(self, filebase):
         """
         Stream a wrapped Sire object to file.

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -1,8 +1,13 @@
+import math
+import os
 import numpy as np
 import shutil
 import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+
+from BioSimSpace.Sandpit.Exscientia._Utils import _try_import, _have_imported
+
 from BioSimSpace.Sandpit.Exscientia.Align import decouple
 from BioSimSpace.Sandpit.Exscientia.FreeEnergy import Restraint
 from BioSimSpace.Sandpit.Exscientia.Units.Angle import radian
@@ -13,8 +18,22 @@ from BioSimSpace.Sandpit.Exscientia.Units.Temperature import kelvin
 from BioSimSpace.Sandpit.Exscientia.Units.Time import picosecond
 from BioSimSpace.Sandpit.Exscientia.Units.Volume import nanometer3
 
-# Make sure GROMACS is installed.
+# Check whether AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
+
+# Check whether GROMACS is installed.
 has_gromacs = BSS._gmx_exe is not None
+
+# Make sure openff is installed.
+_openff = _try_import("openff")
+has_openff = _have_imported(_openff)
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -274,3 +293,46 @@ class TestGetRecord:
             np.testing.assert_almost_equal(energy[0] / unit, value, decimal=3)
         else:
             np.testing.assert_almost_equal(energy / unit, value, decimal=3)
+
+
+@pytest.mark.skipif(
+    has_amber is False or has_gromacs is False or has_openff is False,
+    reason="Requires AMBER, GROMACS, and OpenFF to be installed.",
+)
+def test_vacuum_com():
+    """
+    Test to ensure that the center of mass is moved to the origin following
+    vacuum simulation. Because of the need to fake vacuum simulations by
+    using an extremeley large box, molecular coordinates can exceed the
+    format limit used by certain molecular file formats, e.g. AMBER RST7.
+    As such, we translate the center of mass of the system to the origin.
+    """
+
+    # Create a test molecule.
+    mol = BSS.Parameters.openff_unconstrained_2_0_0("CC").getMolecule()
+
+    # Create a short minimisation protocol.
+    protocol = BSS.Protocol.Minimisation(steps=100)
+
+    # Create a process object.
+    process = BSS.Process.Gromacs(mol.toSystem(), protocol)
+
+    # Start the process and wait for it to finish.
+    process.start()
+    process.wait()
+
+    # Make sure it worked.
+    assert not process.isError()
+
+    # Get the minimised system.
+    system = process.getSystem()
+
+    # Make sure it worked.
+    assert system is not None
+
+    # Get the center of mass.
+    com = system._getCenterOfMass()
+
+    # Make sure each component is close to zero.
+    for x in com:
+        assert math.isclose(x.value(), 0, abs_tol=1e-6)


### PR DESCRIPTION
This PR closes #86.

This is a first pass to handle molecular coordinates after vacuum simulation with GROMACS. We implement vacuum simulations by using pseudo-PBC conditions, i.e. running calculations in a near infinite box, as described [here](https://pubmed.ncbi.nlm.nih.gov/29678588), which is works on all version of GROMACS that we support. However, absolute molecular coordinates can end up being _very_ large after simulation, which causes problems when trying to write them to certain formats, i.e. the fixed-width formatting restrictions are violated.

In this PR we compute the center of mass of the _system_ following the simulation, then translate this back to the center of the box. I've needed to take care in the Exscientia Sandpit since they use two approaches read molecular frames for `getSystem`. One uses the trajectory file with wrapped coordinates, the other uses the final gro frame, in which the coordinates are unwrapped. As such, one center of mass calculation needs to use a periodic space, the other does not.

Issues that I anticipate with this approach that we might need to revisit at a later date are:

* For multi-molecule systems a center of mass translation still might end up with large absolute coordinates, e.g. if the molecules aren't close to each other. I doubt this is the typical use case for vacuum simulations, so we'll see if it becomes an issue. Here we might be able to translate molecules independently, forcing some minimum distance between them afterwards.
* This fix doesn't apply for trajectory frames obtained via `getTrajectory`. Something similar could be done here too, but the user would lose the ability to track displacements along a trajectory, etc.
* This might not work if the user sets some config option to change the wrapping during simulation. But with customised simulations a lot of our functionality is a bit hard to guarantee.

Ultimately we might want to expose a `centerMolecules` function or similar, which the user can apply before trying to write to file. This could even be an option within `saveMolecules`? Let me know if you think this would be a better solution, i.e. the user would need to opt-in, rather than us modify something. In this case I feel like they should just expect things to work, though, and it would be annoying if the behaviour was different to other engines. (I'm not sure how they deal with molecules wandering off during vacuum simulations. Perhaps they internally recenter based on the center of mass periodically?)

The center of mass calculation is currently written in Python, but can take advantage of the C++ code once it is implemented there. I've also updated the funnel metadynamics setup code to use the new functionality so as to avoid code duplication. This is tested via tutorial notebook, which I've run independently.

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods