### PR TITLE
Fix issue #98

### DIFF
--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -292,7 +292,7 @@ def test_set_box(system):
 
     # Store the expected box dimensions and angles.
     expected_box = [30, 30, 30] * BSS.Units.Length.angstrom
-    expected_angles = [109.4712, 70.5288, 70.5288] * BSS.Units.Angle.degree
+    expected_angles = [70.5288, 109.4712, 70.5288] * BSS.Units.Angle.degree
 
     # Check that the box dimensions match.
     for b0, b1 in zip(box, expected_box):

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -293,7 +293,7 @@ def test_set_box(system):
 
     # Store the expected box dimensions and angles.
     expected_box = [30, 30, 30] * BSS.Units.Length.angstrom
-    expected_angles = [109.4712, 70.5288, 70.5288] * BSS.Units.Angle.degree
+    expected_angles = [70.5288, 109.4712, 70.5288] * BSS.Units.Angle.degree
 
     # Check that the box dimensions match.
     for b0, b1 in zip(box, expected_box):


### PR DESCRIPTION
This PR closes #98 by updating the expected box angles used in a test to those that are now generated by the triclinic lattice reduction following [this](https://github.com/OpenBioSim/sire/pull/68) fix. While I could generate the values automatically using [BioSimSpace.Box](https://biosimspace.openbiosim.org/api/index_Box.html), I'd rather have them written in so that it's easier for a user to debug. (Also, these box parameters weren't generated using functionality from that sub-package.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
 @chryswoods