### PR TITLE
Fix issue #92

### DIFF
--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -34,6 +34,7 @@ import os as _os
 import re as _re
 import time as _time
 import shutil as _shutil
+import tempfile as _tempfile
 import timeit as _timeit
 import warnings as _warnings
 
@@ -401,12 +402,19 @@ class Amber(_process.Process):
             else:
                 is_lambda1 = False
 
-            # Create a new molecular system from the restart file.
-            new_system = _System(
-                _SireIO.MoleculeParser.read(
-                    [restart, self._top_file], self._property_map
+            # Copy the restart file to a temporary location. Sire streams from
+            # binary files with the same path, so we need to ensure that a new
+            # stream is created each time.
+            with _tempfile.TemporaryDirectory() as tmp_dir:
+                tmp_file = f"{tmp_dir}/{self._name}.crd"
+                _shutil.copyfile(restart, tmp_file)
+
+                # Create a new molecular system from the restart file.
+                new_system = _System(
+                    _SireIO.MoleculeParser.read(
+                        [tmp_file, self._top_file], self._property_map
+                    )
                 )
-            )
 
             # Create a copy of the existing system object.
             old_system = self._system.copy()


### PR DESCRIPTION
This PR closes #92. While the underlying issue has been fixed by the new trajectory parsing code in Sire, this update makes sure that binary AMBER rst files are always read using a unique file path to avoid issues with streaming, i.e. where it assumed that _more_ data would be added to the existing file. (Here AMBER simply overwrites the same file name with the current coordinates.)

Note that I can't use `TemporaryFile` since it doesn't have full cross-platform support, since there are not guarantees on the number of times that the file can be opened/closed on Windows.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods