### PR TITLE
Feature Improve Plotting

### DIFF
--- a/python/BioSimSpace/Notebook/_plot.py
+++ b/python/BioSimSpace/Notebook/_plot.py
@@ -510,7 +510,9 @@ def plotContour(x, y, z, xlabel=None, ylabel=None, zlabel=None):
     return _plt.show()
 
 
-def plotOverlapMatrix(overlap):
+def plotOverlapMatrix(overlap, 
+                      continuous_cbar=False, 
+                      color_bar_cutoffs=[0.03, 0.1, 0.3]):
     """
     Plot the overlap matrix from a free-energy perturbation analysis.
 
@@ -519,6 +521,14 @@ def plotOverlapMatrix(overlap):
 
     overlap : List of List of float, or 2D numpy array of float
         The overlap matrix.
+    continuous_cbar : bool, optional, default=False
+        If True, use a continuous colour bar. Otherwise, use a discrete
+        set of values defined by the 'color_bar_cutoffs' argument to 
+        assign a colour to each element in the matrix.
+    color_bar_cutoffs : List of float, optional, default=[0.03, 0.1, 0.3]
+        The cutoffs to use when assigning a colour to each element in the
+        matrix. This is used for both the continuous and discrete color bars.
+        Can not contain more than 3 elements.
     """
 
     # Make sure were running interactively.
@@ -538,6 +548,9 @@ def plotOverlapMatrix(overlap):
     if not isinstance(overlap, (list, tuple, _np.ndarray)):
         raise TypeError("The 'overlap' matrix must be a list of list types, or a numpy array!")
 
+    # Convert to a numpy array - no issues if this is already an array.
+    overlap = _np.array(overlap)
+
     # Store the number of rows.
     num_rows = len(overlap)
 
@@ -550,13 +563,45 @@ def plotOverlapMatrix(overlap):
         if not all(isinstance(x, float) for x in row):
             raise TypeError("The 'overlap' matrix must contain 'float' types!")
 
-    # Convert to a numpy array - no issues if this is already an array.
-    overlap = _np.array(overlap)
+    # Check the colour bar options
+    if not isinstance(continuous_cbar, bool):
+        raise TypeError("The 'continuous_cbar' option must be a boolean!")
+    if not isinstance(color_bar_cutoffs, (list, tuple, _np.ndarray)):
+        raise TypeError("The 'color_bar_cutoffs' option must be a list of floats "
+                        " or a numpy array when 'continuous_cbar' is False!")
+    if not all(isinstance(x, float) for x in color_bar_cutoffs):
+        raise TypeError("The 'color_bar_cutoffs' option must be a list of floats!")
+    if len(color_bar_cutoffs) > 3:
+        raise ValueError("The 'color_bar_cutoffs' option must contain no more than 3 elements!")
 
-    # Set the colour map. We want the color boundaries at 0.025, 0.1, and 0.3.
-    cmap = _colors.ListedColormap(["#FBE8EB", "#88CCEE", "#78C592", "#117733"])
-    bounds=[0, 0.025, 0.1, 0.3, 1.0]
-    norm = _colors.BoundaryNorm(bounds, cmap.N)
+    # Add 0 and 1 to the colour bar cutoffs.
+    if color_bar_cutoffs is not None:
+        color_bounds = [0] + color_bar_cutoffs + [1]
+
+    # Tuple of colours and associated font colours.
+    # The last and first colours are for the top and bottom of the scale
+    # for the continuous colour bar, but are ignored for the discrete bar.
+    all_colors = (("#FBE8EB", "black"), # Lighter pink
+                  ("#FFD3E0", "black"),
+                  ("#88CCEE", "black"),
+                  ("#78C592", "black"),
+                  ("#117733", "white"),
+                  ("#004D00", "white")) # Darker green
+
+    # Set the colour map. 
+    if continuous_cbar:
+        # Create a color map using the extended palette and positions
+        box_colors = [all_colors[i][0] for i in range(len(color_bounds)+1)]
+        cmap = _colors.LinearSegmentedColormap.from_list("CustomMap", list(zip(color_bounds, box_colors)))
+
+        # Normalise the same way each time so that plots are always comparable.
+        norm = _colors.Normalize(vmin=0, vmax=1)
+    else:
+        # Throw away the first and last colours.
+        box_colors = [colors[0] for colors in all_colors[1:-1]]
+        cmap = _colors.ListedColormap([box_colors[i] for i in range(len(color_bounds)-1)])
+        norm = _colors.BoundaryNorm(color_bounds, cmap.N)
+
 
     # Create the figure and axis. Use a default size for fewer than 16 windows,
     # otherwise scale the figure size to the number of windows.
@@ -576,12 +621,30 @@ def plotOverlapMatrix(overlap):
     # Label each cell with the overlap value.
     for i in range(num_rows):
         for j in range(num_rows):
-            # For numbers on the dark green background (> 0.3), use white text.
-            color = "white" if overlap[i][j] > 0.3 else "black"
-            ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=color)
+            # Get the text colour based on the overlap value.
+            overlap_val = overlap[i][j]
+            # Get the index of first color bound greater than the overlap value.
+            for idx, bound in enumerate(color_bounds):
+                if bound > overlap_val:
+                    break
+            text_color = all_colors[1:-1][idx - 1][1]
+            ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=text_color)
 
     # Create a colorbar. Reduce the height of the colorbar to match the figure and remove the border.
-    cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds, shrink=0.7)
+    if continuous_cbar:
+        cbar = ax.figure.colorbar(im,
+                                ax=ax,
+                                cmap=cmap,
+                                norm=norm,
+                                shrink=0.7)
+    else:
+        cbar = ax.figure.colorbar(im, 
+                                ax=ax,
+                                cmap=cmap,
+                                norm=norm,
+                                boundaries=color_bounds,
+                                ticks=color_bounds,
+                                shrink=0.7)
     cbar.outline.set_visible(False)
 
     # Set the axis labels.

--- a/python/BioSimSpace/Notebook/_plot.py
+++ b/python/BioSimSpace/Notebook/_plot.py
@@ -565,8 +565,13 @@ def plotOverlapMatrix(overlap):
     else:
         fig, ax = _plt.subplots(figsize=(num_rows/2, num_rows/2), dpi=300)
 
-    # Create the heatmap.
+    # Create the heatmap. Separate the cells with white lines.
     im = ax.imshow(overlap, cmap=cmap, norm=norm)
+    for i in range(num_rows-1):
+        for j in range(num_rows-1):
+            # Make sure these are on the edges of the cells.
+            ax.axhline(i+0.5, color="white", linewidth=0.5)
+            ax.axvline(j+0.5, color="white", linewidth=0.5)
 
     # Label each cell with the overlap value.
     for i in range(num_rows):
@@ -575,18 +580,27 @@ def plotOverlapMatrix(overlap):
             color = "white" if overlap[i][j] > 0.3 else "black"
             ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=color)
 
-    # Create a colorbar. We want the boundaries to be unevenly spaced, according to their values.
-    cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds)
+    # Create a colorbar. Reduce the height of the colorbar to match the figure.
+    cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds, shrink=0.7)
 
     # Set the axis labels.
+    # Set the x axis at the top of the plot.
     _plt.xlabel(r"$\lambda$ Index")
+    ax.xaxis.set_label_position("top")
     _plt.ylabel(r"$\lambda$ Index")
 
     ticks = [x for x in range(0, num_rows)]
 
     # Set ticks every lambda window.
     _plt.xticks(ticks)
+    ax.xaxis.tick_top()
     _plt.yticks(ticks)
+
+    # Remove the borders.
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["bottom"].set_visible(False)
+    ax.spines["left"].set_visible(False)
 
     # Create a tight layout to trim whitespace.
     fig.tight_layout()

--- a/python/BioSimSpace/Notebook/_plot.py
+++ b/python/BioSimSpace/Notebook/_plot.py
@@ -580,8 +580,9 @@ def plotOverlapMatrix(overlap):
             color = "white" if overlap[i][j] > 0.3 else "black"
             ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=color)
 
-    # Create a colorbar. Reduce the height of the colorbar to match the figure.
+    # Create a colorbar. Reduce the height of the colorbar to match the figure and remove the border.
     cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds, shrink=0.7)
+    cbar.outline.set_visible(False)
 
     # Set the axis labels.
     # Set the x axis at the top of the plot.

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
@@ -565,8 +565,13 @@ def plotOverlapMatrix(overlap):
     else:
         fig, ax = _plt.subplots(figsize=(num_rows/2, num_rows/2), dpi=300)
 
-    # Create the heatmap.
+    # Create the heatmap. Separate the cells with white lines.
     im = ax.imshow(overlap, cmap=cmap, norm=norm)
+    for i in range(num_rows-1):
+        for j in range(num_rows-1):
+            # Make sure these are on the edges of the cells.
+            ax.axhline(i+0.5, color="white", linewidth=0.5)
+            ax.axvline(j+0.5, color="white", linewidth=0.5)
 
     # Label each cell with the overlap value.
     for i in range(num_rows):
@@ -575,18 +580,27 @@ def plotOverlapMatrix(overlap):
             color = "white" if overlap[i][j] > 0.3 else "black"
             ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=color)
 
-    # Create a colorbar. We want the boundaries to be unevenly spaced, according to their values.
-    cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds)
+    # Create a colorbar. Reduce the height of the colorbar to match the figure.
+    cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds, shrink=0.7)
 
     # Set the axis labels.
+    # Set the x axis at the top of the plot.
     _plt.xlabel(r"$\lambda$ Index")
+    ax.xaxis.set_label_position("top")
     _plt.ylabel(r"$\lambda$ Index")
 
     ticks = [x for x in range(0, num_rows)]
 
     # Set ticks every lambda window.
     _plt.xticks(ticks)
+    ax.xaxis.tick_top()
     _plt.yticks(ticks)
+
+    # Remove the borders.
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["bottom"].set_visible(False)
+    ax.spines["left"].set_visible(False)
 
     # Create a tight layout to trim whitespace.
     fig.tight_layout()

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
@@ -580,8 +580,9 @@ def plotOverlapMatrix(overlap):
             color = "white" if overlap[i][j] > 0.3 else "black"
             ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=color)
 
-    # Create a colorbar. Reduce the height of the colorbar to match the figure.
+    # Create a colorbar. Reduce the height of the colorbar to match the figure and remove the border.
     cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds, shrink=0.7)
+    cbar.outline.set_visible(False)
 
     # Set the axis labels.
     # Set the x axis at the top of the plot.

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
@@ -27,6 +27,7 @@ __email__ = "lester.hedges@gmail.com"
 __all__ = ["plot", "plotContour", "plotOverlapMatrix"]
 
 import numpy as _np
+import warnings as _warnings
 
 from warnings import warn as _warn
 from os import environ as _environ
@@ -510,7 +511,9 @@ def plotContour(x, y, z, xlabel=None, ylabel=None, zlabel=None):
     return _plt.show()
 
 
-def plotOverlapMatrix(overlap):
+def plotOverlapMatrix(overlap, 
+                      continuous_cbar=False, 
+                      color_bar_cutoffs=[0.03, 0.1, 0.3]):
     """
     Plot the overlap matrix from a free-energy perturbation analysis.
 
@@ -519,6 +522,14 @@ def plotOverlapMatrix(overlap):
 
     overlap : List of List of float, or 2D numpy array of float
         The overlap matrix.
+    continuous_cbar : bool, optional, default=False
+        If True, use a continuous colour bar. Otherwise, use a discrete
+        set of values defined by the 'color_bar_cutoffs' argument to 
+        assign a colour to each element in the matrix.
+    color_bar_cutoffs : List of float, optional, default=[0.03, 0.1, 0.3]
+        The cutoffs to use when assigning a colour to each element in the
+        matrix. This is used for both the continuous and discrete color bars.
+        Can not contain more than 3 elements.
     """
 
     # Make sure were running interactively.
@@ -538,6 +549,9 @@ def plotOverlapMatrix(overlap):
     if not isinstance(overlap, (list, tuple, _np.ndarray)):
         raise TypeError("The 'overlap' matrix must be a list of list types, or a numpy array!")
 
+    # Convert to a numpy array - no issues if this is already an array.
+    overlap = _np.array(overlap)
+
     # Store the number of rows.
     num_rows = len(overlap)
 
@@ -550,13 +564,45 @@ def plotOverlapMatrix(overlap):
         if not all(isinstance(x, float) for x in row):
             raise TypeError("The 'overlap' matrix must contain 'float' types!")
 
-    # Convert to a numpy array - no issues if this is already an array.
-    overlap = _np.array(overlap)
+    # Check the colour bar options
+    if not isinstance(continuous_cbar, bool):
+        raise TypeError("The 'continuous_cbar' option must be a boolean!")
+    if not isinstance(color_bar_cutoffs, (list, tuple, _np.ndarray)):
+        raise TypeError("The 'color_bar_cutoffs' option must be a list of floats "
+                        " or a numpy array when 'continuous_cbar' is False!")
+    if not all(isinstance(x, float) for x in color_bar_cutoffs):
+        raise TypeError("The 'color_bar_cutoffs' option must be a list of floats!")
+    if len(color_bar_cutoffs) > 3:
+        raise ValueError("The 'color_bar_cutoffs' option must contain no more than 3 elements!")
 
-    # Set the colour map. We want the color boundaries at 0.025, 0.1, and 0.3.
-    cmap = _colors.ListedColormap(["#FBE8EB", "#88CCEE", "#78C592", "#117733"])
-    bounds=[0, 0.025, 0.1, 0.3, 1.0]
-    norm = _colors.BoundaryNorm(bounds, cmap.N)
+    # Add 0 and 1 to the colour bar cutoffs.
+    if color_bar_cutoffs is not None:
+        color_bounds = [0] + color_bar_cutoffs + [1]
+
+    # Tuple of colours and associated font colours.
+    # The last and first colours are for the top and bottom of the scale
+    # for the continuous colour bar, but are ignored for the discrete bar.
+    all_colors = (("#FBE8EB", "black"), # Lighter pink
+                  ("#FFD3E0", "black"),
+                  ("#88CCEE", "black"),
+                  ("#78C592", "black"),
+                  ("#117733", "white"),
+                  ("#004D00", "white")) # Darker green
+
+    # Set the colour map. 
+    if continuous_cbar:
+        # Create a color map using the extended palette and positions
+        box_colors = [all_colors[i][0] for i in range(len(color_bounds)+1)]
+        cmap = _colors.LinearSegmentedColormap.from_list("CustomMap", list(zip(color_bounds, box_colors)))
+
+        # Normalise the same way each time so that plots are always comparable.
+        norm = _colors.Normalize(vmin=0, vmax=1)
+    else:
+        # Throw away the first and last colours.
+        box_colors = [colors[0] for colors in all_colors[1:-1]]
+        cmap = _colors.ListedColormap([box_colors[i] for i in range(len(color_bounds)-1)])
+        norm = _colors.BoundaryNorm(color_bounds, cmap.N)
+
 
     # Create the figure and axis. Use a default size for fewer than 16 windows,
     # otherwise scale the figure size to the number of windows.
@@ -576,12 +622,30 @@ def plotOverlapMatrix(overlap):
     # Label each cell with the overlap value.
     for i in range(num_rows):
         for j in range(num_rows):
-            # For numbers on the dark green background (> 0.3), use white text.
-            color = "white" if overlap[i][j] > 0.3 else "black"
-            ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=color)
+            # Get the text colour based on the overlap value.
+            overlap_val = overlap[i][j]
+            # Get the index of first color bound greater than the overlap value.
+            for idx, bound in enumerate(color_bounds):
+                if bound > overlap_val:
+                    break
+            text_color = all_colors[1:-1][idx - 1][1]
+            ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=text_color)
 
     # Create a colorbar. Reduce the height of the colorbar to match the figure and remove the border.
-    cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, boundaries=bounds, ticks=bounds, shrink=0.7)
+    if continuous_cbar:
+        cbar = ax.figure.colorbar(im,
+                                ax=ax,
+                                cmap=cmap,
+                                norm=norm,
+                                shrink=0.7)
+    else:
+        cbar = ax.figure.colorbar(im, 
+                                ax=ax,
+                                cmap=cmap,
+                                norm=norm,
+                                boundaries=color_bounds,
+                                ticks=color_bounds,
+                                shrink=0.7)
     cbar.outline.set_visible(False)
 
     # Set the axis labels.


### PR DESCRIPTION
# Is this pull request to fix a bug, or to introduce new functionality?
This PR attempts to improve the Notebook plotOverlap function:

a) To be more consistent with Fig 13 in [the best practices guide](https://livecomsjournal.org/index.php/livecoms/article/view/v2i1e18378/963). The main change is to use the same overlap cut-offs as in the best practices paper, which were not being used before. This led to misleading plots like this (despite reasonable overlap for all first off-diagonal windows) (text removed and colour bar added):

![image](https://github.com/OpenBioSim/biosimspace/assets/90148170/c8acdd7d-a6ba-48ba-b74d-51640519b053)

Where points with reasonable overlap would be grouped together with points with very low overlap. A colour bar is also added.

b) To avoid covering the whole plot in text when many windows are supplied. I've checked with 4, 16, and 36 lambda windows and the output looks reasonable in each case:

![image](https://github.com/OpenBioSim/biosimspace/assets/90148170/318224f6-0b3d-4954-94f1-948cc698a32c)
![image](https://github.com/OpenBioSim/biosimspace/assets/90148170/31ff25cd-7788-4dca-9360-05e6dd03139e)
![image](https://github.com/OpenBioSim/biosimspace/assets/90148170/15d5355e-bf76-4c97-af20-429fcc2bfb94)

c) To increase flexibility so that a numpy array (as is returned from the analysis functions) can be passed directly.

This addresses comments [here](https://github.com/OpenBioSim/BioSimSpaceTutorials/issues/8).

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`):y
* I confirm that I have added a test for any new functionality in this pull request: n
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: n
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges

