### PR TITLE
This fixes the Gro87/GRO87 and GroTop/GROTOP issues.

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -675,7 +675,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
         # Warn the user if any molecules are parameterised with a force field
         # that uses geometric combining rules. While we can write this to file
         # the information is lost on read.
-        if format == "PRM7":
+        if format.upper() == "PRM7":
             # Get the name of the "forcefield" property.
             forcefield = _property_map.get("forcefield", "forcefield")
 
@@ -700,13 +700,13 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
             # Make sure AMBER and GROMACS files have the expected water topology
             # and save GROMACS files with an extension such that they can be run
             # directly by GROMACS without needing to be renamed.
-            if format == "PRM7":
+            if format.upper() == "PRM7":
                 system_copy = system.copy()
                 system_copy._set_water_topology("AMBER", _property_map)
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )
-            elif format == "GroTop":
+            elif format.upper() == "GROTOP":
                 system_copy = system.copy()
                 system_copy._set_water_topology("GROMACS", _property_map)
                 file = _SireIO.MoleculeParser.save(
@@ -715,7 +715,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
                 new_file = file.replace("grotop", "top")
                 _os.rename(file, new_file)
                 file = [new_file]
-            elif format == "Gro87":
+            elif format.upper() == "GRO87":
                 # Write to 3dp by default, unless greater precision is
                 # requested by the user.
                 if "precision" not in _property_map:

--- a/python/BioSimSpace/MD/_md.py
+++ b/python/BioSimSpace/MD/_md.py
@@ -61,6 +61,7 @@ _file_extensions = {
     "PRM7,RST7": ["AMBER", "GROMACS", "OPENMM", "SOMD"],
     "PRM7,RST": ["AMBER", "GROMACS", "OPENMM", "SOMD"],
     "GroTop,Gro87": ["GROMACS", "AMBER", "OPENMM", "SOMD"],
+    "GROTOP,GRO87": ["GROMACS", "AMBER", "OPENMM", "SOMD"],
     "PSF,PDB": ["NAMD"],
 }
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -700,13 +700,13 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
             # Make sure AMBER and GROMACS files have the expected water topology
             # and save GROMACS files with an extension such that they can be run
             # directly by GROMACS without needing to be renamed.
-            if format == "PRM7":
+            if format.upper() == "PRM7":
                 system_copy = system.copy()
                 system_copy._set_water_topology("AMBER", _property_map)
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )
-            elif format == "GroTop":
+            elif format.upper() == "GROTOP":
                 system_copy = system.copy()
                 system_copy._set_water_topology("GROMACS", _property_map)
                 file = _SireIO.MoleculeParser.save(
@@ -715,7 +715,7 @@ def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):
                 new_file = file.replace("grotop", "top")
                 _os.rename(file, new_file)
                 file = [new_file]
-            elif format == "Gro87":
+            elif format.upper() == "GRO87":
                 # Write to 3dp by default, unless greater precision is
                 # requested by the user.
                 if "precision" not in _property_map:

--- a/python/BioSimSpace/Sandpit/Exscientia/MD/_md.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/MD/_md.py
@@ -62,6 +62,7 @@ _file_extensions = {
     "PRM7,RST7": ["AMBER", "GROMACS", "OPENMM", "SOMD"],
     "PRM7,RST": ["AMBER", "GROMACS", "OPENMM", "SOMD"],
     "GroTop,Gro87": ["GROMACS", "AMBER", "OPENMM", "SOMD"],
+    "GROTOP,GRO87": ["GROMACS", "AMBER", "OPENMM", "SOMD"],
     "PSF,PDB": ["NAMD"],
 }
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -908,7 +908,7 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
             else:
                 raise IOError(msg) from None
 
-    elif "GroTop" in formats:
+    elif "GroTop" in formats or "GROTOP" in formats:
         try:
             top = _SireIO.GroTop(reference._sire_object)
             top.writeToFile(top_file)

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -908,7 +908,7 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
             else:
                 raise IOError(msg) from None
 
-    elif "GroTop" in formats:
+    elif "GroTop" in formats or "GROTOP" in formats:
         try:
             top = _SireIO.GroTop(reference._sire_object)
             top.writeToFile(top_file)


### PR DESCRIPTION
This pull request includes the changes needed to allow BioSimSpace to work with the `Gro87` and `GroTop` parsers in both new sire (when they are called `GRO87` and `GROTOP`) and old sire (when they are called `Gro87` and `GroTOP`).

I've kept support for both names for now, just to ease transition. We can remove support for the older name some time in the future (e.g. `2023.4`?)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

All of the tests pass locally with the latest version of `feature_polish` (including the excluded atom fix)
