### PR TITLE
Improve unit parsing using Sire unit grammar

### DIFF
--- a/python/BioSimSpace/Notebook/_plot.py
+++ b/python/BioSimSpace/Notebook/_plot.py
@@ -510,9 +510,9 @@ def plotContour(x, y, z, xlabel=None, ylabel=None, zlabel=None):
     return _plt.show()
 
 
-def plotOverlapMatrix(overlap, 
-                      continuous_cbar=False, 
-                      color_bar_cutoffs=[0.03, 0.1, 0.3]):
+def plotOverlapMatrix(
+    overlap, continuous_cbar=False, color_bar_cutoffs=[0.03, 0.1, 0.3]
+):
     """
     Plot the overlap matrix from a free-energy perturbation analysis.
 
@@ -523,7 +523,7 @@ def plotOverlapMatrix(overlap,
         The overlap matrix.
     continuous_cbar : bool, optional, default=False
         If True, use a continuous colour bar. Otherwise, use a discrete
-        set of values defined by the 'color_bar_cutoffs' argument to 
+        set of values defined by the 'color_bar_cutoffs' argument to
         assign a colour to each element in the matrix.
     color_bar_cutoffs : List of float, optional, default=[0.03, 0.1, 0.3]
         The cutoffs to use when assigning a colour to each element in the
@@ -543,10 +543,12 @@ def plotOverlapMatrix(overlap,
             "to load. Please check your matplotlib installation."
         )
         return None
-    
+
     # Validate the input
     if not isinstance(overlap, (list, tuple, _np.ndarray)):
-        raise TypeError("The 'overlap' matrix must be a list of list types, or a numpy array!")
+        raise TypeError(
+            "The 'overlap' matrix must be a list of list types, or a numpy array!"
+        )
 
     # Convert to a numpy array - no issues if this is already an array.
     overlap = _np.array(overlap)
@@ -567,12 +569,16 @@ def plotOverlapMatrix(overlap,
     if not isinstance(continuous_cbar, bool):
         raise TypeError("The 'continuous_cbar' option must be a boolean!")
     if not isinstance(color_bar_cutoffs, (list, tuple, _np.ndarray)):
-        raise TypeError("The 'color_bar_cutoffs' option must be a list of floats "
-                        " or a numpy array when 'continuous_cbar' is False!")
+        raise TypeError(
+            "The 'color_bar_cutoffs' option must be a list of floats "
+            " or a numpy array when 'continuous_cbar' is False!"
+        )
     if not all(isinstance(x, float) for x in color_bar_cutoffs):
         raise TypeError("The 'color_bar_cutoffs' option must be a list of floats!")
     if len(color_bar_cutoffs) > 3:
-        raise ValueError("The 'color_bar_cutoffs' option must contain no more than 3 elements!")
+        raise ValueError(
+            "The 'color_bar_cutoffs' option must contain no more than 3 elements!"
+        )
 
     # Add 0 and 1 to the colour bar cutoffs.
     if color_bar_cutoffs is not None:
@@ -581,42 +587,47 @@ def plotOverlapMatrix(overlap,
     # Tuple of colours and associated font colours.
     # The last and first colours are for the top and bottom of the scale
     # for the continuous colour bar, but are ignored for the discrete bar.
-    all_colors = (("#FBE8EB", "black"), # Lighter pink
-                  ("#FFD3E0", "black"),
-                  ("#88CCEE", "black"),
-                  ("#78C592", "black"),
-                  ("#117733", "white"),
-                  ("#004D00", "white")) # Darker green
+    all_colors = (
+        ("#FBE8EB", "black"),  # Lighter pink
+        ("#FFD3E0", "black"),
+        ("#88CCEE", "black"),
+        ("#78C592", "black"),
+        ("#117733", "white"),
+        ("#004D00", "white"),
+    )  # Darker green
 
-    # Set the colour map. 
+    # Set the colour map.
     if continuous_cbar:
         # Create a color map using the extended palette and positions
-        box_colors = [all_colors[i][0] for i in range(len(color_bounds)+1)]
-        cmap = _colors.LinearSegmentedColormap.from_list("CustomMap", list(zip(color_bounds, box_colors)))
+        box_colors = [all_colors[i][0] for i in range(len(color_bounds) + 1)]
+        cmap = _colors.LinearSegmentedColormap.from_list(
+            "CustomMap", list(zip(color_bounds, box_colors))
+        )
 
         # Normalise the same way each time so that plots are always comparable.
         norm = _colors.Normalize(vmin=0, vmax=1)
     else:
         # Throw away the first and last colours.
         box_colors = [colors[0] for colors in all_colors[1:-1]]
-        cmap = _colors.ListedColormap([box_colors[i] for i in range(len(color_bounds)-1)])
+        cmap = _colors.ListedColormap(
+            [box_colors[i] for i in range(len(color_bounds) - 1)]
+        )
         norm = _colors.BoundaryNorm(color_bounds, cmap.N)
-
 
     # Create the figure and axis. Use a default size for fewer than 16 windows,
     # otherwise scale the figure size to the number of windows.
     if num_rows < 16:
         fig, ax = _plt.subplots(figsize=(8, 8), dpi=300)
     else:
-        fig, ax = _plt.subplots(figsize=(num_rows/2, num_rows/2), dpi=300)
+        fig, ax = _plt.subplots(figsize=(num_rows / 2, num_rows / 2), dpi=300)
 
     # Create the heatmap. Separate the cells with white lines.
     im = ax.imshow(overlap, cmap=cmap, norm=norm)
-    for i in range(num_rows-1):
-        for j in range(num_rows-1):
+    for i in range(num_rows - 1):
+        for j in range(num_rows - 1):
             # Make sure these are on the edges of the cells.
-            ax.axhline(i+0.5, color="white", linewidth=0.5)
-            ax.axvline(j+0.5, color="white", linewidth=0.5)
+            ax.axhline(i + 0.5, color="white", linewidth=0.5)
+            ax.axvline(j + 0.5, color="white", linewidth=0.5)
 
     # Label each cell with the overlap value.
     for i in range(num_rows):
@@ -628,23 +639,29 @@ def plotOverlapMatrix(overlap,
                 if bound > overlap_val:
                     break
             text_color = all_colors[1:-1][idx - 1][1]
-            ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=text_color)
+            ax.text(
+                j,
+                i,
+                "{:.2f}".format(overlap[i][j]),
+                ha="center",
+                va="center",
+                fontsize=10,
+                color=text_color,
+            )
 
     # Create a colorbar. Reduce the height of the colorbar to match the figure and remove the border.
     if continuous_cbar:
-        cbar = ax.figure.colorbar(im,
-                                ax=ax,
-                                cmap=cmap,
-                                norm=norm,
-                                shrink=0.7)
+        cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, shrink=0.7)
     else:
-        cbar = ax.figure.colorbar(im, 
-                                ax=ax,
-                                cmap=cmap,
-                                norm=norm,
-                                boundaries=color_bounds,
-                                ticks=color_bounds,
-                                shrink=0.7)
+        cbar = ax.figure.colorbar(
+            im,
+            ax=ax,
+            cmap=cmap,
+            norm=norm,
+            boundaries=color_bounds,
+            ticks=color_bounds,
+            shrink=0.7,
+        )
     cbar.outline.set_visible(False)
 
     # Set the axis labels.

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -1738,7 +1738,7 @@ class Gromacs(_process.Process):
         length : :class:`Length <BioSimSpace.Types.Length>`
             The constrained RMSD.
         """
-        return self.getRecord("CONSTRRMSD", time_series, _Units.Length.nanometer, block)
+        return self.getRecord("CONSTRRMSD", time_series, None, block)
 
     def getCurrentConstraintRMSD(self, time_series=False):
         """
@@ -2193,7 +2193,7 @@ class Gromacs(_process.Process):
                 elif unit == "kg/m^3":
                     units.append(_Types._GeneralUnit("kg/m3"))
                 else:
-                    units.append(_Types.GeneralUnit("m/m"))
+                    units.append(1.0)
                     _warnings.warn(
                         f"Unit {unit} cannot be parsed, recording the unit as unitless."
                     )

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
@@ -511,9 +511,9 @@ def plotContour(x, y, z, xlabel=None, ylabel=None, zlabel=None):
     return _plt.show()
 
 
-def plotOverlapMatrix(overlap, 
-                      continuous_cbar=False, 
-                      color_bar_cutoffs=[0.03, 0.1, 0.3]):
+def plotOverlapMatrix(
+    overlap, continuous_cbar=False, color_bar_cutoffs=[0.03, 0.1, 0.3]
+):
     """
     Plot the overlap matrix from a free-energy perturbation analysis.
 
@@ -524,7 +524,7 @@ def plotOverlapMatrix(overlap,
         The overlap matrix.
     continuous_cbar : bool, optional, default=False
         If True, use a continuous colour bar. Otherwise, use a discrete
-        set of values defined by the 'color_bar_cutoffs' argument to 
+        set of values defined by the 'color_bar_cutoffs' argument to
         assign a colour to each element in the matrix.
     color_bar_cutoffs : List of float, optional, default=[0.03, 0.1, 0.3]
         The cutoffs to use when assigning a colour to each element in the
@@ -544,10 +544,12 @@ def plotOverlapMatrix(overlap,
             "to load. Please check your matplotlib installation."
         )
         return None
-    
+
     # Validate the input
     if not isinstance(overlap, (list, tuple, _np.ndarray)):
-        raise TypeError("The 'overlap' matrix must be a list of list types, or a numpy array!")
+        raise TypeError(
+            "The 'overlap' matrix must be a list of list types, or a numpy array!"
+        )
 
     # Convert to a numpy array - no issues if this is already an array.
     overlap = _np.array(overlap)
@@ -568,12 +570,16 @@ def plotOverlapMatrix(overlap,
     if not isinstance(continuous_cbar, bool):
         raise TypeError("The 'continuous_cbar' option must be a boolean!")
     if not isinstance(color_bar_cutoffs, (list, tuple, _np.ndarray)):
-        raise TypeError("The 'color_bar_cutoffs' option must be a list of floats "
-                        " or a numpy array when 'continuous_cbar' is False!")
+        raise TypeError(
+            "The 'color_bar_cutoffs' option must be a list of floats "
+            " or a numpy array when 'continuous_cbar' is False!"
+        )
     if not all(isinstance(x, float) for x in color_bar_cutoffs):
         raise TypeError("The 'color_bar_cutoffs' option must be a list of floats!")
     if len(color_bar_cutoffs) > 3:
-        raise ValueError("The 'color_bar_cutoffs' option must contain no more than 3 elements!")
+        raise ValueError(
+            "The 'color_bar_cutoffs' option must contain no more than 3 elements!"
+        )
 
     # Add 0 and 1 to the colour bar cutoffs.
     if color_bar_cutoffs is not None:
@@ -582,42 +588,47 @@ def plotOverlapMatrix(overlap,
     # Tuple of colours and associated font colours.
     # The last and first colours are for the top and bottom of the scale
     # for the continuous colour bar, but are ignored for the discrete bar.
-    all_colors = (("#FBE8EB", "black"), # Lighter pink
-                  ("#FFD3E0", "black"),
-                  ("#88CCEE", "black"),
-                  ("#78C592", "black"),
-                  ("#117733", "white"),
-                  ("#004D00", "white")) # Darker green
+    all_colors = (
+        ("#FBE8EB", "black"),  # Lighter pink
+        ("#FFD3E0", "black"),
+        ("#88CCEE", "black"),
+        ("#78C592", "black"),
+        ("#117733", "white"),
+        ("#004D00", "white"),
+    )  # Darker green
 
-    # Set the colour map. 
+    # Set the colour map.
     if continuous_cbar:
         # Create a color map using the extended palette and positions
-        box_colors = [all_colors[i][0] for i in range(len(color_bounds)+1)]
-        cmap = _colors.LinearSegmentedColormap.from_list("CustomMap", list(zip(color_bounds, box_colors)))
+        box_colors = [all_colors[i][0] for i in range(len(color_bounds) + 1)]
+        cmap = _colors.LinearSegmentedColormap.from_list(
+            "CustomMap", list(zip(color_bounds, box_colors))
+        )
 
         # Normalise the same way each time so that plots are always comparable.
         norm = _colors.Normalize(vmin=0, vmax=1)
     else:
         # Throw away the first and last colours.
         box_colors = [colors[0] for colors in all_colors[1:-1]]
-        cmap = _colors.ListedColormap([box_colors[i] for i in range(len(color_bounds)-1)])
+        cmap = _colors.ListedColormap(
+            [box_colors[i] for i in range(len(color_bounds) - 1)]
+        )
         norm = _colors.BoundaryNorm(color_bounds, cmap.N)
-
 
     # Create the figure and axis. Use a default size for fewer than 16 windows,
     # otherwise scale the figure size to the number of windows.
     if num_rows < 16:
         fig, ax = _plt.subplots(figsize=(8, 8), dpi=300)
     else:
-        fig, ax = _plt.subplots(figsize=(num_rows/2, num_rows/2), dpi=300)
+        fig, ax = _plt.subplots(figsize=(num_rows / 2, num_rows / 2), dpi=300)
 
     # Create the heatmap. Separate the cells with white lines.
     im = ax.imshow(overlap, cmap=cmap, norm=norm)
-    for i in range(num_rows-1):
-        for j in range(num_rows-1):
+    for i in range(num_rows - 1):
+        for j in range(num_rows - 1):
             # Make sure these are on the edges of the cells.
-            ax.axhline(i+0.5, color="white", linewidth=0.5)
-            ax.axvline(j+0.5, color="white", linewidth=0.5)
+            ax.axhline(i + 0.5, color="white", linewidth=0.5)
+            ax.axvline(j + 0.5, color="white", linewidth=0.5)
 
     # Label each cell with the overlap value.
     for i in range(num_rows):
@@ -629,23 +640,29 @@ def plotOverlapMatrix(overlap,
                 if bound > overlap_val:
                     break
             text_color = all_colors[1:-1][idx - 1][1]
-            ax.text(j, i, "{:.2f}".format(overlap[i][j]), ha="center", va="center", fontsize=10, color=text_color)
+            ax.text(
+                j,
+                i,
+                "{:.2f}".format(overlap[i][j]),
+                ha="center",
+                va="center",
+                fontsize=10,
+                color=text_color,
+            )
 
     # Create a colorbar. Reduce the height of the colorbar to match the figure and remove the border.
     if continuous_cbar:
-        cbar = ax.figure.colorbar(im,
-                                ax=ax,
-                                cmap=cmap,
-                                norm=norm,
-                                shrink=0.7)
+        cbar = ax.figure.colorbar(im, ax=ax, cmap=cmap, norm=norm, shrink=0.7)
     else:
-        cbar = ax.figure.colorbar(im, 
-                                ax=ax,
-                                cmap=cmap,
-                                norm=norm,
-                                boundaries=color_bounds,
-                                ticks=color_bounds,
-                                shrink=0.7)
+        cbar = ax.figure.colorbar(
+            im,
+            ax=ax,
+            cmap=cmap,
+            norm=norm,
+            boundaries=color_bounds,
+            ticks=color_bounds,
+            shrink=0.7,
+        )
     cbar.outline.set_visible(False)
 
     # Set the axis labels.

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -1781,8 +1781,7 @@ class Gromacs(_process.Process):
         length : :class:`Length <BioSimSpace.Types.Length>`
             The constrained RMSD.
         """
-        # TODO: the constrained RMSD is a relative quantity and is unitless.
-        return self.getRecord("CONSTRRMSD", time_series, _Units.Length.nanometer, block)
+        return self.getRecord("CONSTRRMSD", time_series, None, block)
 
     def getCurrentConstraintRMSD(self, time_series=False):
         """
@@ -2245,7 +2244,7 @@ class Gromacs(_process.Process):
                 elif unit == "kg/m^3":
                     units.append(_Types._GeneralUnit("kg/m3"))
                 else:
-                    units.append(_Types.GeneralUnit("m/m"))
+                    units.append(1.0)
                     _warnings.warn(
                         f"Unit {unit} cannot be parsed, recording the unit as unitless."
                     )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2130,7 +2130,9 @@ class Gromacs(_process.Process):
         self._energy_keys = keys
         self._energy_dict["TIME"] = []
         for key in keys:
-            self._energy_dict[self._sanitise_energy_term(key)] = []
+            # Skip surface tension records, since there is no appropriate general unit.
+            if key != "#Surf*SurfTen":
+                self._energy_dict[self._sanitise_energy_term(key)] = []
 
     @staticmethod
     def _parse_energy_terms(text):
@@ -2222,7 +2224,7 @@ class Gromacs(_process.Process):
         ]
         for line in lines:
             terms = line.split()
-            if len(terms) > 1:
+            if len(terms) > 1 and terms[0] != "#Surf*SurfTen":
                 unit = terms[-1][1:-1]
                 if unit == "K":
                     units.append(_Units.Temperature.kelvin)
@@ -2240,12 +2242,12 @@ class Gromacs(_process.Process):
                     units.append(_Units.Pressure.bar * _Units.Length.nanometer)
                 elif unit == "nm/ps":
                     units.append(_Units.Length.nanometer / _Units.Time.picosecond)
+                elif unit == "kg/m^3":
+                    units.append(_Types._GeneralUnit("kg/m3"))
                 else:
-                    # TODO: set this to a unitless unit probabily from BSS.Types._GeneralUnit
-                    units.append(_Units.Length.nanometer)
-                    # kg/m^3 cannot be parsed as there is no mass unit.
+                    units.append(_Types.GeneralUnit("m/m"))
                     _warnings.warn(
-                        f"Unit {unit} cannot be parsed, record the unit as unitless."
+                        f"Unit {unit} cannot be parsed, recording the unit as unitless."
                     )
         return units
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -42,8 +42,8 @@ class GeneralUnit(_Type):
         "M",  # Mass
         "Q",  # Quantity
         "t",  # Temperature
-        "T",
-    ]  # Time
+        "T",  # Tme
+    ]
 
     def __new__(cls, *args):
         """
@@ -242,10 +242,7 @@ class GeneralUnit(_Type):
 
     def __str__(self):
         """Return a human readable string representation of the object."""
-        if abs(self._value) > 1e4 or abs(self._value) < 1e-4:
-            return "%.4e %s" % (self._value, self._unit)
-        else:
-            return "%5.4f %s" % (self._value, self._unit)
+        return str(self._sire_unit)
 
     def __repr__(self):
         """Return a human readable string representation of the object."""
@@ -744,53 +741,61 @@ class GeneralUnit(_Type):
         string_copy = string
 
         if isinstance(string, str):
-            # Convert to lower case and strip whitespace.
-            string = string.lower().replace(" ", "")
-
-            # Convert powers to common format.
-            string = string.replace("squared", "2")
-            string = string.replace("**2", "2")
-            string = string.replace("^2", "2")
-            string = string.replace("cubed", "3")
-            string = string.replace("**3", "3")
-            string = string.replace("^3", "3")
-            string = string.replace("**-1", "-1")
-            string = string.replace("^-1", "-1")
-            string = string.replace("**-2", "-2")
-            string = string.replace("^-2", "-2")
-            string = string.replace("**-3", "-3")
-            string = string.replace("^-3", "-3")
-
-            for unit in _base_units:
-                string = unit._to_sire_format(string)
-
+            # Try to parse as a GeneralUnit using Sire's inbuilt unit grammar.
             try:
-                # Compile the eval expression to bytecode.
-                code = compile(string, "<string>", "eval")
+                from sire import u as _unit
 
-                # The bytecode must contain names.
-                if not code.co_names:
-                    raise ValueError(
-                        f"Could not infer GeneralUnit from string '{string}'"
-                    ) from None
+                return GeneralUnit(_unit(string))
 
-                # Make sure the co_names only contains names within the allowed
-                # sire_units_local dictionary.
-                for name in code.co_names:
-                    if name not in _sire_units_locals:
+            # Try manually parsing the string.
+            except:
+                # Convert to lower case and strip whitespace.
+                string = string.lower().replace(" ", "")
+
+                # Convert powers to common format.
+                string = string.replace("squared", "2")
+                string = string.replace("**2", "2")
+                string = string.replace("^2", "2")
+                string = string.replace("cubed", "3")
+                string = string.replace("**3", "3")
+                string = string.replace("^3", "3")
+                string = string.replace("**-1", "-1")
+                string = string.replace("^-1", "-1")
+                string = string.replace("**-2", "-2")
+                string = string.replace("^-2", "-2")
+                string = string.replace("**-3", "-3")
+                string = string.replace("^-3", "-3")
+
+                for unit in _base_units:
+                    string = unit._to_sire_format(string)
+
+                try:
+                    # Compile the eval expression to bytecode.
+                    code = compile(string, "<string>", "eval")
+
+                    # The bytecode must contain names.
+                    if not code.co_names:
                         raise ValueError(
                             f"Could not infer GeneralUnit from string '{string}'"
                         ) from None
 
-                general_unit = eval(string, {}, _sire_units_locals)
+                    # Make sure the co_names only contains names within the allowed
+                    # sire_units_local dictionary.
+                    for name in code.co_names:
+                        if name not in _sire_units_locals:
+                            raise ValueError(
+                                f"Could not infer GeneralUnit from string '{string}'"
+                            ) from None
 
-                # Create and return a new object.
-                return GeneralUnit(general_unit)
+                    general_unit = eval(string, {}, _sire_units_locals)
 
-            except Exception as e:
-                raise ValueError(
-                    f"Could not infer GeneralUnit from string '{string}'"
-                ) from None
+                    # Create and return a new object.
+                    return GeneralUnit(general_unit)
+
+                except Exception as e:
+                    raise ValueError(
+                        f"Could not infer GeneralUnit from string '{string}'"
+                    ) from None
 
         else:
             raise TypeError("'string' must be of type 'str'")

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
@@ -30,6 +30,8 @@ import re as _re
 
 from sire.legacy import Units as _SireUnits
 
+from .._Exceptions import IncompatibleError as _IncompatibleError
+
 
 class Type:
     """A base class for custom types."""
@@ -462,6 +464,33 @@ class Type:
             The unit of the type.
         """
         return self._unit
+
+    def to(self, unit):
+        """
+        Return the value of this general unit in the specified unit.
+
+        Parameters
+        ----------
+
+        unit : str
+            The unit to convert to.
+
+        Returns
+        -------
+
+        value : float
+            The value in the specified unit.
+        """
+
+        if not isinstance(unit, str):
+            raise TypeError("'unit' must be of type 'str'.")
+
+        try:
+            return self._value * self._supported_units[self._unit].to(unit)
+        except Exception as e:
+            raise _IncompatibleError(
+                str(e).split("incompatible_error:")[1].split("(call")[0].strip()
+            )
 
     @classmethod
     def dimensions(cls):

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -42,8 +42,8 @@ class GeneralUnit(_Type):
         "M",  # Mass
         "Q",  # Quantity
         "t",  # Temperature
-        "T",
-    ]  # Time
+        "T",  # Tme
+    ]
 
     def __new__(cls, *args):
         """
@@ -242,10 +242,7 @@ class GeneralUnit(_Type):
 
     def __str__(self):
         """Return a human readable string representation of the object."""
-        if abs(self._value) > 1e4 or abs(self._value) < 1e-4:
-            return "%.4e %s" % (self._value, self._unit)
-        else:
-            return "%5.4f %s" % (self._value, self._unit)
+        return str(self._sire_unit)
 
     def __repr__(self):
         """Return a human readable string representation of the object."""
@@ -744,53 +741,61 @@ class GeneralUnit(_Type):
         string_copy = string
 
         if isinstance(string, str):
-            # Convert to lower case and strip whitespace.
-            string = string.lower().replace(" ", "")
-
-            # Convert powers to common format.
-            string = string.replace("squared", "2")
-            string = string.replace("**2", "2")
-            string = string.replace("^2", "2")
-            string = string.replace("cubed", "3")
-            string = string.replace("**3", "3")
-            string = string.replace("^3", "3")
-            string = string.replace("**-1", "-1")
-            string = string.replace("^-1", "-1")
-            string = string.replace("**-2", "-2")
-            string = string.replace("^-2", "-2")
-            string = string.replace("**-3", "-3")
-            string = string.replace("^-3", "-3")
-
-            for unit in _base_units:
-                string = unit._to_sire_format(string)
-
+            # Try to parse as a GeneralUnit using Sire's inbuilt unit grammar.
             try:
-                # Compile the eval expression to bytecode.
-                code = compile(string, "<string>", "eval")
+                from sire import u as _unit
 
-                # The bytecode must contain names.
-                if not code.co_names:
-                    raise ValueError(
-                        f"Could not infer GeneralUnit from string '{string}'"
-                    ) from None
+                return GeneralUnit(_unit(string))
 
-                # Make sure the co_names only contains names within the allowed
-                # sire_units_local dictionary.
-                for name in code.co_names:
-                    if name not in _sire_units_locals:
+            # Try manually parsing the string.
+            except:
+                # Convert to lower case and strip whitespace.
+                string = string.lower().replace(" ", "")
+
+                # Convert powers to common format.
+                string = string.replace("squared", "2")
+                string = string.replace("**2", "2")
+                string = string.replace("^2", "2")
+                string = string.replace("cubed", "3")
+                string = string.replace("**3", "3")
+                string = string.replace("^3", "3")
+                string = string.replace("**-1", "-1")
+                string = string.replace("^-1", "-1")
+                string = string.replace("**-2", "-2")
+                string = string.replace("^-2", "-2")
+                string = string.replace("**-3", "-3")
+                string = string.replace("^-3", "-3")
+
+                for unit in _base_units:
+                    string = unit._to_sire_format(string)
+
+                try:
+                    # Compile the eval expression to bytecode.
+                    code = compile(string, "<string>", "eval")
+
+                    # The bytecode must contain names.
+                    if not code.co_names:
                         raise ValueError(
                             f"Could not infer GeneralUnit from string '{string}'"
                         ) from None
 
-                general_unit = eval(string, {}, _sire_units_locals)
+                    # Make sure the co_names only contains names within the allowed
+                    # sire_units_local dictionary.
+                    for name in code.co_names:
+                        if name not in _sire_units_locals:
+                            raise ValueError(
+                                f"Could not infer GeneralUnit from string '{string}'"
+                            ) from None
 
-                # Create and return a new object.
-                return GeneralUnit(general_unit)
+                    general_unit = eval(string, {}, _sire_units_locals)
 
-            except Exception as e:
-                raise ValueError(
-                    f"Could not infer GeneralUnit from string '{string}'"
-                ) from None
+                    # Create and return a new object.
+                    return GeneralUnit(general_unit)
+
+                except Exception as e:
+                    raise ValueError(
+                        f"Could not infer GeneralUnit from string '{string}'"
+                    ) from None
 
         else:
             raise TypeError("'string' must be of type 'str'")

--- a/python/BioSimSpace/Types/_type.py
+++ b/python/BioSimSpace/Types/_type.py
@@ -30,12 +30,15 @@ import re as _re
 
 from sire.legacy import Units as _SireUnits
 
+from .._Exceptions import IncompatibleError as _IncompatibleError
+
 
 class Type:
     """A base class for custom types."""
 
     def __init__(self, *args):
-        """Constructor.
+        """
+        Constructor.
 
         ``*args`` can be a value and unit, or a string representation
         of the type.
@@ -461,6 +464,33 @@ class Type:
             The unit of the type.
         """
         return self._unit
+
+    def to(self, unit):
+        """
+        Return the value of this general unit in the specified unit.
+
+        Parameters
+        ----------
+
+        unit : str
+            The unit to convert to.
+
+        Returns
+        -------
+
+        value : float
+            The value in the specified unit.
+        """
+
+        if not isinstance(unit, str):
+            raise TypeError("'unit' must be of type 'str'.")
+
+        try:
+            return self._value * self._supported_units[self._unit].to(unit)
+        except Exception as e:
+            raise _IncompatibleError(
+                str(e).split("incompatible_error:")[1].split("(call")[0].strip()
+            )
 
     @classmethod
     def dimensions(cls):

--- a/tests/Sandpit/Exscientia/Types/test_general_unit.py
+++ b/tests/Sandpit/Exscientia/Types/test_general_unit.py
@@ -32,7 +32,7 @@ def test_supported_units(string, dimensions):
         ("radian * degree**2 / radian^2", Types.Angle),
         ("angstrom**3 / nanometer", Types.Area),
         ("coulombs * angstrom**-2 * nanometer**2", Types.Charge),
-        ("kcal_per_mol / angstrom**2 * nanometer**2", Types.Energy),
+        ("(kcal_per_mol / angstrom**2) * nanometer**2", Types.Energy),
         ("angstrom**3 * nanometer^-1 / picometer", Types.Length),
         ("bar * kJ_per_mol**2 / (kcal_per_mol * kJ_per_mol)", Types.Pressure),
         ("coulomb * kelvin^-3 * celsius**2 * kelvin^2 / e_charge", Types.Temperature),

--- a/tests/Types/test_general_unit.py
+++ b/tests/Types/test_general_unit.py
@@ -32,7 +32,7 @@ def test_supported_units(string, dimensions):
         ("radian * degree**2 / radian^2", Types.Angle),
         ("angstrom**3 / nanometer", Types.Area),
         ("coulombs * angstrom**-2 * nanometer**2", Types.Charge),
-        ("kcal_per_mol / angstrom**2 * nanometer**2", Types.Energy),
+        ("(kcal_per_mol / angstrom**2) * nanometer**2", Types.Energy),
         ("angstrom**3 * nanometer^-1 / picometer", Types.Length),
         ("bar * kJ_per_mol**2 / (kcal_per_mol * kJ_per_mol)", Types.Pressure),
         ("coulomb * kelvin^-3 * celsius**2 * kelvin^2 / e_charge", Types.Temperature),


### PR DESCRIPTION
This PR improves the unit parsing within BioSimSpace by wrapping the new Sire units grammar within `BioSImSpace.Types._GeneralUnit`. When a string is passed to the constructor we first try to use the new grammar, falling back on the existing approach when this fails. I've also exposed the `.to()` method on all unit based types. This currently doesn't work correctly for temperatures, as described [here](https://github.com/OpenBioSim/sire/issues/73).

I've also fixed a few bugs that were exposed by the updates. One was an incorrect expression in a test, where parentheses were needed to ensure the order of operation was correct. The other was a parsing error in the Exs GROMACS energy record parser for surface tension records, which have different formatting to everything else. These can't be handled in the same way, so I've skipped them for now.

(Apologies for the diff in the plotting code. This is just the result of `black`. The previous code was blackened, but using the same version as the rest of the repo, i.e. `pytest-black` passed, but `black` still reformats.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods