### PR TITLE
Expose Sire "make whole" functionality

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -341,7 +341,9 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
     )
 
 
-def readMolecules(files, show_warnings=False, download_dir=None, property_map={}):
+def readMolecules(
+    files, make_whole=False, show_warnings=False, download_dir=None, property_map={}
+):
     """
     Read a molecular system from file.
 
@@ -352,6 +354,10 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
         A file name, or a list of file names. Note that the file names can
         be URLs, in which case the files will be downloaded and (if necessary)
         extracted before reading.
+
+    make_whole : bool
+        Whether to make molecules whole, i.e. unwrap those that are split across
+        the periodic boundary.
 
     show_warnings : bool
         Whether to show any warnings raised during parsing of the input files.
@@ -425,6 +431,13 @@ def readMolecules(files, show_warnings=False, download_dir=None, property_map={}
             files = list(files)
     else:
         raise TypeError("'files' must be of type 'str', or a list of 'str' types.")
+
+    # Validate the molecule unwrapping flag.
+    if not isinstance(make_whole, bool):
+        raise TypeError("'make_whole' must be of type 'bool'.")
+    # Flag that we want' to unwrap molecules.
+    if make_whole:
+        property_map["make_whole"] = _SireBase.wrap(make_whole)
 
     # Validate the warning message flag.
     if not isinstance(show_warnings, bool):
@@ -1038,6 +1051,11 @@ def _patch_sire_load(path, *args, show_warnings=True, property_map={}, **kwargs)
         Whether or not to print out any warnings that are encountered
         when loading your file(s). This is default True, and may lead
         to noisy output. Set `show_warnings=False` to silence this output.
+
+    property_map : dict
+        A dictionary that maps system "properties" to their user defined
+        values. This allows the user to refer to properties with their
+        own naming scheme, e.g. { "charge" : "my-charge" }
 
     directory : str
         Optional directory which will be used when creating any

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
@@ -1056,6 +1056,7 @@ def viewFunnel(system, collective_variable, property_map={}):
         except:
             raise ValueError(f"Could not obtain coordinates for atom index '{atom}'!")
     com0 /= len(atoms0)
+    com0 = [x.value() for x in com0]
 
     for atom in atoms1:
         try:
@@ -1063,6 +1064,7 @@ def viewFunnel(system, collective_variable, property_map={}):
         except:
             raise ValueError(f"Could not obtain coordinates for atom index '{atom}'!")
     com1 /= len(atoms1)
+    com1 = [x.value() for x in com1]
 
     # Create a new molecule to hold the funnel.
     funnel_mol = _SireMol.Molecule("Funnel")

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -328,7 +328,7 @@ class Plumed:
                             # Check the upper bound is greater than dim/2 for
                             # each dimension.
                             for dim in dimensions:
-                                if value >= 0.5 * dim:
+                                if value >= 0.5 * dim.value():
                                     message = (
                                         "The simulation box is too small for the funnel. "
                                         "Try reducing the upper bound of the collective "

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
@@ -1056,6 +1056,7 @@ def viewFunnel(system, collective_variable, property_map={}):
         except:
             raise ValueError(f"Could not obtain coordinates for atom index '{atom}'!")
     com0 /= len(atoms0)
+    com0 = [x.value() for x in com0]
 
     for atom in atoms1:
         try:
@@ -1063,6 +1064,7 @@ def viewFunnel(system, collective_variable, property_map={}):
         except:
             raise ValueError(f"Could not obtain coordinates for atom index '{atom}'!")
     com1 /= len(atoms1)
+    com1 = [x.value() for x in com1]
 
     # Create a new molecule to hold the funnel.
     funnel_mol = _SireMol.Molecule("Funnel")

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -328,7 +328,7 @@ class Plumed:
                             # Check the upper bound is greater than dim/2 for
                             # each dimension.
                             for dim in dimensions:
-                                if value >= 0.5 * dim:
+                                if value >= 0.5 * dim.value():
                                     message = (
                                         "The simulation box is too small for the funnel. "
                                         "Try reducing the upper bound of the collective "

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1478,6 +1478,25 @@ class System(_SireWrapper):
 
         return box, angles
 
+    def makeWhole(self, property_map={}):
+        """
+        Make all molecules in the system "whole", i.e. unwrap any molecules that have
+        been split across the periodic boundary.
+
+        Parameters
+        ----------
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+        """
+
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+
+        self._sire_object.makeWhole()
+
     def translate(self, vector, property_map={}):
         """
         Translate the system.

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1452,6 +1452,25 @@ class System(_SireWrapper):
 
         return box, angles
 
+    def makeWhole(self, property_map={}):
+        """
+        Make all molecules in the system "whole", i.e. unwrap any molecules that have
+        been split across the periodic boundary.
+
+        Parameters
+        ----------
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+        """
+
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+
+        self._sire_object.makeWhole()
+
     def translate(self, vector, property_map={}):
         """
         Translate the system.


### PR DESCRIPTION
This PR exposes the new `make whole` functionality in Sire. Users can now specify whether to unwrap molecules on read using the `make_whole` keyword argument. I've also exposed the `system.make_whole()` method, which calls the underlying Sire function to unwrap all of the molecules in the system.

I've also taken the opportunity to fix a few issues related to the [BioSimSpaceTutorials](https://github.com/OpenBioSim/BioSimSpaceTutorials/issues/6) repository. These involve minor updates to call `.value()` on objects that now have length units.

Closes OpenBioSim/BioSimSpaceTutorials#4
Closes OpenBioSim/BioSimSpaceTutorials#6

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [n] (Tested via Sire)
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y] (API docs)
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
 @chryswoods