### PR TITLE
Fix issue #84

### DIFF
--- a/python/BioSimSpace/Notebook/_plot.py
+++ b/python/BioSimSpace/Notebook/_plot.py
@@ -164,9 +164,13 @@ def plot(
         raise TypeError("'x' must be of type 'list'")
 
     else:
-        # Make sure all records are of the same type.
-        _type = type(x[0])
-        if not all(isinstance(xx, _type) for xx in x):
+        # Make sure all records are of the same type. Missing data will be
+        # None, so find the first unit type.
+        for idx, xx in enumerate(x):
+            if xx is not None:
+                _type = type(xx)
+                break
+        if not all(isinstance(xx, (_type, type(None))) for xx in x):
             raise TypeError("All 'x' data values must be of same type")
 
         # Convert int to float.
@@ -181,11 +185,11 @@ def plot(
 
         # Make sure any associated error has the same unit.
         if xerr is not None:
-            if not all(isinstance(xx, _type) for xx in xerr):
+            if not all(isinstance(xx, (_type, type(None))) for xx in xerr):
                 raise TypeError("All 'xerr' values must be of same type as x data")
 
         # Does this type have units?
-        if isinstance(x[0], _Type):
+        if isinstance(x[idx], _Type):
             is_unit_x = True
 
     # The y argument must be a list or tuple of data records.
@@ -193,9 +197,13 @@ def plot(
         raise TypeError("'y' must be of type 'list'")
 
     else:
-        # Make sure all records are of the same type.
-        _type = type(y[0])
-        if not all(isinstance(yy, _type) for yy in y):
+        # Make sure all records are of the same type. Missing data will be
+        # None, so find the first unit type.
+        for idx, yy in enumerate(y):
+            if yy is not None:
+                _type = type(yy)
+                break
+        if not all(isinstance(yy, (_type, type(None))) for yy in y):
             raise TypeError("All 'y' data values must be of same type")
 
         # Convert int to float.
@@ -210,12 +218,32 @@ def plot(
 
         # Make sure any associated error has the same unit.
         if yerr is not None:
-            if not all(isinstance(yy, _type) for yy in yerr):
+            if not all(isinstance(yy, (_type, type(None))) for yy in yerr):
                 raise TypeError("All 'yerr' values must be of same type as y data")
 
         # Does this type have units?
-        if isinstance(y[0], _Type):
+        if isinstance(y[idx], _Type):
             is_unit_y = True
+
+    # Strip any missing values.
+
+    # x-dimension
+    idx = [i for i, v in enumerate(x) if v is not None]
+    x = list(filter(lambda v: v is not None, x))
+    y = [y[i] for i in idx]
+    if xerr is not None:
+        xerr = [xerr[i] for i in idx]
+    if yerr is not None:
+        yerr = [xerr[i] for i in idx]
+
+    # y-dimension
+    idx = [i for i, v in enumerate(y) if v is not None]
+    y = list(filter(lambda v: v is not None, y))
+    x = [x[i] for i in idx]
+    if xerr is not None:
+        xerr = [xerr[i] for i in idx]
+    if yerr is not None:
+        yerr = [yerr[i] for i in idx]
 
     # Lists must contain the same number of records.
     # Truncate the longer list to the length of the shortest.
@@ -510,8 +538,8 @@ def plotContour(x, y, z, xlabel=None, ylabel=None, zlabel=None):
     return _plt.show()
 
 
-def plotOverlapMatrix(overlap, 
-                      continuous_cbar=False, 
+def plotOverlapMatrix(overlap,
+                      continuous_cbar=False,
                       color_bar_cutoffs=[0.03, 0.1, 0.3]):
     """
     Plot the overlap matrix from a free-energy perturbation analysis.
@@ -523,7 +551,7 @@ def plotOverlapMatrix(overlap,
         The overlap matrix.
     continuous_cbar : bool, optional, default=False
         If True, use a continuous colour bar. Otherwise, use a discrete
-        set of values defined by the 'color_bar_cutoffs' argument to 
+        set of values defined by the 'color_bar_cutoffs' argument to
         assign a colour to each element in the matrix.
     color_bar_cutoffs : List of float, optional, default=[0.03, 0.1, 0.3]
         The cutoffs to use when assigning a colour to each element in the
@@ -543,7 +571,7 @@ def plotOverlapMatrix(overlap,
             "to load. Please check your matplotlib installation."
         )
         return None
-    
+
     # Validate the input
     if not isinstance(overlap, (list, tuple, _np.ndarray)):
         raise TypeError("The 'overlap' matrix must be a list of list types, or a numpy array!")
@@ -588,7 +616,7 @@ def plotOverlapMatrix(overlap,
                   ("#117733", "white"),
                   ("#004D00", "white")) # Darker green
 
-    # Set the colour map. 
+    # Set the colour map.
     if continuous_cbar:
         # Create a color map using the extended palette and positions
         box_colors = [all_colors[i][0] for i in range(len(color_bounds)+1)]
@@ -638,7 +666,7 @@ def plotOverlapMatrix(overlap,
                                 norm=norm,
                                 shrink=0.7)
     else:
-        cbar = ax.figure.colorbar(im, 
+        cbar = ax.figure.colorbar(im,
                                 ax=ax,
                                 cmap=cmap,
                                 norm=norm,

--- a/tests/Sandpit/Exscientia/output/amber_fep.out
+++ b/tests/Sandpit/Exscientia/output/amber_fep.out
@@ -414,7 +414,7 @@ Energy at 1.0000 =    -20527.018427
 | TI region  1
 
 
- NSTEP =      200   TIME(PS) =       0.400  TEMP(K) =   299.11  PRESS =     0.0
+ NSTEP =      200   TIME(PS) =       0.400  TEMP(K) =   299.11  PRESS =********
  Etot   =    -17729.5249  EKtot   =      3848.1375  EPtot      =    -21577.6625
  BOND   =         8.1288  ANGLE   =       104.5238  DIHED      =         4.3669
  1-4 NB =         4.9543  1-4 EEL =       -33.5151  VDWAALS    =      3094.9338


### PR DESCRIPTION
This PR closes #84. We now handle missing values in AMBER output files by extending the regex to parse records such as `PRESS =********`. In all cases, any missing values are interpreted as `None`. I've modified one of the files used in the AMBER parsing tests to contain a missing value in order to confirm that things work as expected. Currently this code is only applied to the Exscientia Sandpit, where the records are being used. (They are saved to disk after a run.) I'll move this into the core code when I port over the AMBER FEP code.

I've also updated the plotting code to handle `None` values in time-series data with units. When `None` is present we filter the both the x and y data (and any associated errors) to remove data corresponding to the `None` indices in _both_ sets, i.e. if `None` is present in x, then we remove this value from x and the same index from y. I've not updated the logic for raw `float` values since this isn't used internally by BioSimSpace, nor the code for plotting contours for 3D data.

I've also removed some trailing whitespace that was introduced in PR #107.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods