### PR TITLE
Correctly handle PLUMED version number

### DIFF
--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -94,9 +94,14 @@ class Plumed:
         )
 
         if process.returncode == 0:
-            self._plumed_version = float(process.stdout.decode("ascii").strip())
+            self._plumed_version = process.stdout.decode("ascii").strip()
 
-            if self._plumed_version < 2.5:
+            # Get the major minor version.
+            major, minor = self._plumed_version.split(".")
+            major = int(major)
+            minor = int(minor)
+
+            if major < 2 or (major < 3 and minor < 5):
                 raise _Exceptions.IncompatibleError(
                     "PLUMED version >= 2.5 is required."
                 )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -94,9 +94,14 @@ class Plumed:
         )
 
         if process.returncode == 0:
-            self._plumed_version = float(process.stdout.decode("ascii").strip())
+            self._plumed_version = process.stdout.decode("ascii").strip()
 
-            if self._plumed_version < 2.5:
+            # Get the major minor version.
+            major, minor = self._plumed_version.split(".")
+            major = int(major)
+            minor = int(minor)
+
+            if major < 2 or (major < 3 and minor < 5):
                 raise _Exceptions.IncompatibleError(
                     "PLUMED version >= 2.5 is required."
                 )


### PR DESCRIPTION
This PR fixes an issue in the PLUMED version number check. PLUMED just uses `major.minor`, so the check for versions `>2.5` were failing once we got to version `2.10`. (I've checked the `conda-forge` package and version `2.8.2` reports `2.8` from the command-line.) This has been tested via notebooks that require PLUMED functionality. (I guess I could also just multiply things by 10.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods