### PR TITLE
Fix issue #114

### DIFF
--- a/python/BioSimSpace/Protocol/_steering.py
+++ b/python/BioSimSpace/Protocol/_steering.py
@@ -52,6 +52,7 @@ class Steering(_Protocol):
         runtime=_Types.Time(1, "nanosecond"),
         temperature=_Types.Temperature(300, "kelvin"),
         pressure=_Types.Pressure(1, "atmosphere"),
+        thermostat_time_constant=_Types.Time(1, "picosecond"),
         report_interval=1000,
         restart_interval=1000,
         colvar_file=None,
@@ -90,6 +91,9 @@ class Steering(_Protocol):
 
         pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure. Pass pressure=None to use the NVT ensemble.
+
+        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+            Time constant for thermostat coupling.
 
         restart_interval : int
             The frequency at which restart configurations and trajectory
@@ -139,6 +143,9 @@ class Steering(_Protocol):
             self.setPressure(pressure)
         else:
             self._pressure = None
+
+        # Set the thermostat time constant.
+        self.setThermostatTimeConstant(thermostat_time_constant)
 
         if colvar_file is not None:
             self.setColvarFile(colvar_file)
@@ -544,6 +551,35 @@ class Steering(_Protocol):
             self._pressure = pressure
         else:
             raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+
+    def getThermostatTimeConstant(self):
+        """
+        Return the time constant for the thermostat.
+
+        Returns
+        -------
+
+        runtime : :class:`Time <BioSimSpace.Types.Time>`
+            The time constant for the thermostat.
+        """
+        return self._thermostat_time_constant
+
+    def setThermostatTimeConstant(self, thermostat_time_constant):
+        """
+        Set the time constant for the thermostat.
+
+        Parameters
+        ----------
+
+        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+            The time constant for the thermostat.
+        """
+        if isinstance(thermostat_time_constant, _Types.Time):
+            self._thermostat_time_constant = thermostat_time_constant
+        else:
+            raise TypeError(
+                "'thermostat_time_constant' must be of type 'BioSimSpace.Types.Time'"
+            )
 
     def getReportInterval(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
@@ -48,6 +48,7 @@ class Metadynamics(_Protocol):
         runtime=_Types.Time(1, "nanosecond"),
         temperature=_Types.Temperature(300, "kelvin"),
         pressure=_Types.Pressure(1, "atmosphere"),
+        thermostat_time_constant=_Types.Time(1, "picosecond"),
         hill_height=_Types.Energy(1, "kj per mol"),
         hill_frequency=1000,
         report_interval=1000,
@@ -75,6 +76,9 @@ class Metadynamics(_Protocol):
 
         pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure. Pass pressure=None to use the NVT ensemble.
+
+        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+            Time constant for thermostat coupling.
 
         hill_height : :class:`Energy <BioSimSpace.Types.Energy>`
             The height of the Gaussian hills.
@@ -122,6 +126,9 @@ class Metadynamics(_Protocol):
             self.setPressure(pressure)
         else:
             self._pressure = None
+
+        # Set the thermostat time constant.
+        self.setThermostatTimeConstant(thermostat_time_constant)
 
         # Set the hill parameters: height, frequency.
         self.setHillHeight(hill_height)
@@ -335,6 +342,35 @@ class Metadynamics(_Protocol):
             self._pressure = pressure
         else:
             raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+
+    def getThermostatTimeConstant(self):
+        """
+        Return the time constant for the thermostat.
+
+        Returns
+        -------
+
+        runtime : :class:`Time <BioSimSpace.Types.Time>`
+            The time constant for the thermostat.
+        """
+        return self._thermostat_time_constant
+
+    def setThermostatTimeConstant(self, thermostat_time_constant):
+        """
+        Set the time constant for the thermostat.
+
+        Parameters
+        ----------
+
+        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+            The time constant for the thermostat.
+        """
+        if isinstance(thermostat_time_constant, _Types.Time):
+            self._thermostat_time_constant = thermostat_time_constant
+        else:
+            raise TypeError(
+                "'thermostat_time_constant' must be of type 'BioSimSpace.Types.Time'"
+            )
 
     def getHillHeight(self):
         """

--- a/python/BioSimSpace/_Config/_gromacs.py
+++ b/python/BioSimSpace/_Config/_gromacs.py
@@ -206,10 +206,7 @@ class Gromacs(_Config):
                     )
 
         # Temperature control.
-        if not isinstance(
-            self._protocol,
-            (_Protocol.Metadynamics, _Protocol.Steering, _Protocol.Minimisation),
-        ):
+        if not isinstance(self._protocol, _Protocol.Minimisation):
             # Leap-frog molecular dynamics.
             protocol_dict["integrator"] = "md"
             # Temperature coupling using velocity rescaling with a stochastic term.


### PR DESCRIPTION
This PR closes #114 by reinstating temperature control for steering and metadynamics protocols for GROMACS, which was somehow omitted when porting the configuration generator code from the Exscientia sandpit. This fix is tested by the notebooks in BioSimSpaceTutorials.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods