### PR TITLE
Fixed an exception raised if a system has a cartesian space.

### DIFF
--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -288,11 +288,17 @@ class Namd(_process.Process):
 
         prop = self._property_map.get("space", "space")
 
-        # Check whether the system contains periodic box information.
         if prop in self._system._sire_object.propertyKeys():
-            # Flag that we have found a box.
-            has_box = True
+            try:
+                box = self._system._sire_object.property(prop)
 
+                # Flag that we have found a periodic box.
+                has_box = box.isPeriodic()
+            except Exception:
+                box = None
+
+        # Check whether the system contains periodic box information.
+        if has_box:
             # Periodic box.
             try:
                 box_size = self._system._sire_object.property(prop).dimensions()

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
@@ -284,9 +284,16 @@ class Namd(_process.Process):
 
         # Check whether the system contains periodic box information.
         if prop in self._system._sire_object.propertyKeys():
-            # Flag that we have found a box.
-            has_box = True
+            try:
+                box = self._system._sire_object.property(prop)
 
+                # Flag that we have found a periodic box.
+                has_box = box.isPeriodic()
+            except Exception:
+                box = None
+
+        # Check whether the system contains periodic box information.
+        if has_box:
             # Periodic box.
             try:
                 box_size = self._system._sire_object.property(prop).dimensions()


### PR DESCRIPTION
This adds a catch for a system having a non-periodic (`Cartesian`) space for namd.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@lohedges

## Any additional context of information?

I came across this as I now make sure that `sire.system.System` objects contain both a "space" and "time" property (defaults to `Cartesian` and `GeneralUnit(0)`.