### PR TITLE
Add support for Sire as a trajectory backend

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -24,7 +24,7 @@
 __author__ = "Lester Hedges"
 __email__ = "lester.hedges@gmail.com"
 
-__all__ = ["getFrame", "Trajectory"]
+__all__ = ["getFrame", "Trajectory", "backends"]
 
 from .._Utils import _try_import, _have_imported
 
@@ -37,9 +37,11 @@ import shutil as _shutil
 import uuid as _uuid
 import warnings as _warnings
 
+from sire.legacy import Base as _SireBase
 from sire.legacy import IO as _SireIO
 from sire.legacy import Mol as _SireMol
 
+from sire import load as _sire_load
 from sire._load import _resolve_path
 
 from .. import _isVerbose
@@ -51,6 +53,19 @@ from ..Types import Time as _Time
 from .. import IO as _IO
 from .. import Units as _Units
 from .. import _Utils
+
+
+def backends():
+    """
+    Return the list of supported trajectory parsing backends.
+
+    Returns
+
+    backends : [str]
+        The list of supported trajectory parsing backends.
+    """
+
+    return ["SIRE", "MDANALYSIS", "MDTRAJ"]
 
 
 def getFrame(trajectory, topology, index, system=None, property_map={}):
@@ -108,9 +123,9 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
     # Download files if they are URLs.
     if trajectory.startswith(("http", "www")):
         try:
-            trajectory = _resolve_path(trajectory.lower(), str(work_dir), silent=True)[
-                0
-            ]
+            trajectory = _resolve_path(
+                trajectory.lower(), str(work_dir), show_warnings=False, silent=True
+            )[0]
         except:
             raise ValueError(f"Unable to download trajectory file: {trajectory}")
     if topology.startswith(("http", "www")):
@@ -136,91 +151,134 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
         # Update the water topology to match topology/trajectory.
         system = _update_water_topology(system, topology, trajectory)
 
-    # Try to load the frame with MDTraj.
+    # Try to load the frame with Sire.
     errors = []
+    is_sire = False
     is_mdanalysis = False
     pdb_file = work_dir + f"/{str(_uuid.uuid4())}.pdb"
     try:
-        frame_file = work_dir + f"/{str(_uuid.uuid4())}.rst7"
-        frame = _mdtraj.load_frame(trajectory, index, top=topology)
-        frame.save(frame_file, force_overwrite=True)
-        frame.save(pdb_file, force_overwrite=True)
+        frame = _sire_load(
+            [trajectory, topology],
+            map=property_map,
+            ignore_topology_frame=True,
+            silent=True,
+        ).trajectory()[index]
+        is_sire = True
     except Exception as e:
-        is_mdanalysis = True
-        errors.append(f"MDTraj: {str(e)}")
-        # Try to load the frame with MDAnalysis.
+        errors.append(f"Sire: {str(e)}")
         try:
-            frame_file = work_dir + f"/{str(_uuid.uuid4())}.gro"
-            universe = _mdanalysis.Universe(topology, trajectory)
-            universe.trajectory.trajectory[index]
-            with _warnings.catch_warnings():
-                _warnings.simplefilter("ignore")
-                universe.select_atoms("all").write(frame_file)
-                universe.select_atoms("all").write(pdb_file)
+            frame_file = work_dir + f"/{str(_uuid.uuid4())}.rst7"
+            frame = _mdtraj.load_frame(trajectory, index, top=topology)
+            frame.save(frame_file, force_overwrite=True)
+            frame.save(pdb_file, force_overwrite=True)
         except Exception as e:
-            errors.append(f"MDAnalysis: {str(e)}")
-            msg = "MDTraj/MDAnalysis failed to read frame %d from: traj=%s, top=%s" % (
-                index,
-                trajectory,
-                topology,
-            )
-            if _isVerbose():
-                raise IOError(msg + "\n" + "\n".join(errors))
-            else:
-                raise IOError(msg) from None
+            is_mdanalysis = True
+            errors.append(f"MDTraj: {str(e)}")
+            # Try to load the frame with MDAnalysis.
+            try:
+                frame_file = work_dir + f"/{str(_uuid.uuid4())}.gro"
+                universe = _mdanalysis.Universe(topology, trajectory)
+                universe.trajectory.trajectory[index]
+                with _warnings.catch_warnings():
+                    _warnings.simplefilter("ignore")
+                    universe.select_atoms("all").write(frame_file)
+                    universe.select_atoms("all").write(pdb_file)
+            except Exception as e:
+                errors.append(f"MDAnalysis: {str(e)}")
+                msg = (
+                    "MDTraj/MDAnalysis failed to read frame %d from: traj=%s, top=%s"
+                    % (
+                        index,
+                        trajectory,
+                        topology,
+                    )
+                )
+                if _isVerbose():
+                    raise IOError(msg + "\n" + "\n".join(errors))
+                else:
+                    raise IOError(msg) from None
 
     # Try to update the coordinates/velocities in the reference system.
     if system is not None:
-        # Parse the coordinates/velocites frame.
-        try:
-            if is_mdanalysis:
-                frame = _SireIO.Gro87(frame_file)
-            else:
-                frame = _SireIO.AmberRst7(frame_file)
-        except Exception as e:
-            msg = "Failed to read trajectory frame: '%s'" % frame_file
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+        if is_sire and frame.current().num_molecules() > 1:
+            try:
+                sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                    system._sire_object,
+                    frame.current()._system,
+                    mapping,
+                    False,
+                    property_map,
+                    {},
+                )
 
-        # Parse the PDB frame.
-        try:
-            pdb = _SireIO.PDB2(pdb_file)
-        except Exception as e:
-            msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+                new_system = _System(sire_system)
 
-        # The new_system object will contain a single molecule with the
-        # coordinates of all of the atoms in the reference. As such, we
-        # will need to split the system into molecules.
-        new_system = _split_molecules(frame, pdb, system, str(work_dir), property_map)
-        return _System(new_system)
-        try:
-            sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
-                system._sire_object, new_system, mapping, False, property_map, {}
-            )
-
-            new_system = _System(sire_system)
-        except Exception as e:
-            msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+            except Exception as e:
+                msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
 
         else:
-            raise IOError(
-                "The trajectory frame is incompatible with the passed system!"
+            # Parse the coordinates/velocites frame.
+            try:
+                if is_sire:
+                    frame = frame.current()._system
+                    pdb = _SireIO.PDB2(frame)
+                    pdb.writeToFile(pdb_file)
+                    frame = _SireIO.AmberRst7(frame)
+                elif is_mdanalysis:
+                    frame = _SireIO.Gro87(frame_file)
+                else:
+                    frame = _SireIO.AmberRst7(frame_file)
+            except Exception as e:
+                msg = "Failed to read trajectory frame: '%s'" % frame_file
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+            # Parse the PDB frame.
+            try:
+                pdb = _SireIO.PDB2(pdb_file)
+            except Exception as e:
+                msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+            # The new_system object will contain a single molecule with the
+            # coordinates of all of the atoms in the reference. As such, we
+            # will need to split the system into molecules.
+            new_system = _split_molecules(
+                frame, pdb, system, str(work_dir), property_map
             )
+            try:
+                sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                    system._sire_object, new_system, mapping, False, property_map, {}
+                )
+
+                new_system = _System(sire_system)
+            except Exception as e:
+                msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+            else:
+                raise IOError(
+                    "The trajectory frame is incompatible with the passed system!"
+                )
 
     # Load the frame directly to create a new System object.
     else:
         try:
-            if is_mdanalysis:
+            if is_sire:
+                new_system = _System(frame.current()._system)
+            elif is_mdanalysis:
                 new_system = _System(_SireIO.MoleculeParser.read(frame_file))
             else:
                 new_system = _System(
@@ -241,7 +299,13 @@ class Trajectory:
     """A class for reading a manipulating biomolecular trajectories."""
 
     def __init__(
-        self, process=None, trajectory=None, topology=None, system=None, property_map={}
+        self,
+        process=None,
+        trajectory=None,
+        topology=None,
+        system=None,
+        backend="AUTO",
+        property_map={},
     ):
         """
         Constructor.
@@ -264,6 +328,12 @@ class Trajectory:
             useful if you wish to preserve all molecular properties, which might
             be lost during reading of the topology format required by the
             trajectory backend.
+
+        backend : str
+            The backend used to parse the trajectory file. Options are 'Sire',
+            'MDTraj', or 'MDAnalysis'. Use "auto" if you are happy with any
+            backend, i.e. it will try each in sequence and use the first that
+            worked.
 
         property_map : dict
            A dictionary that maps system "properties" to their user defined
@@ -376,12 +446,21 @@ class Trajectory:
                     self._system, self._top_file, self._traj_file
                 )
 
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        # Strip whitespace and convert to upper case.
+        backend = backend.replace(" ", "").upper()
+
+        if backend not in ["AUTO"] + backends():
+            _warnings.warn("Invalid trajectory format. Using default (Sire).")
+            backend = "SIRE"
+
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'")
-        self._property_map = property_map
 
         # Get the current trajectory.
-        self._trajectory = self.getTrajectory(format="AUTO")
+        self._trajectory = self.getTrajectory(format=backend)
 
     def __str__(self):
         """Return a human readable string representation of the object."""
@@ -405,10 +484,10 @@ class Trajectory:
         ----------
 
         format : str
-            Whether to return an 'MDTraj' or 'MDAnalysis' object.
-            Use "auto" if you are happy with either format, i.e. it
-            will try each backend in sequence and return an object
-            from the first one that works.
+            Whether to return a 'Sire', 'MDTraj', or 'MDAnalysis' object.
+            Use "auto" if you are happy with any format, i.e. it will try
+            each backend in sequence and return an object from the first one
+            that works.
 
         Returns
         -------
@@ -417,12 +496,15 @@ class Trajectory:
             The trajectory in MDTraj or MDAnalysis format.
         """
 
+        if not isinstance(format, str):
+            raise TypeError("'format' must be of type 'str'")
+
         # Strip whitespace and convert to upper case.
         format = format.replace(" ", "").upper()
 
-        if format.replace(" ", "").upper() not in ["MDTRAJ", "MDANALYSIS", "AUTO"]:
-            _warnings.warn("Invalid trajectory format. Using default (mdtraj).")
-            format = "MDTRAJ"
+        if format not in ["AUTO"] + backends():
+            _warnings.warn("Invalid trajectory format. Using default (Sire).")
+            format = "SIRE"
 
         # If this object isn't bound to a Process and the format matches the
         # existing backend, then return the trajectory directly.
@@ -431,6 +513,8 @@ class Trajectory:
                 return _copy.deepcopy(self._trajectory)
             elif format in ["MDANALYSIS", "AUTO"] and self._backend == "MDANALYSIS":
                 return self._trajectory.copy()
+            elif format in ["SIRE", "AUTO"] and self._backend == "SIRE":
+                return self._trajectory
 
         if format == "MDTRAJ" and self._backend == "MDANALYSIS":
             raise _IncompatibleError(
@@ -458,6 +542,30 @@ class Trajectory:
 
         if not _os.path.isfile(self._top_file):
             raise IOError("Topology file doesn't exist: '%s'" % self._top_file)
+
+        # Return a Sire trajectory object.
+        if format in ["SIRE", "AUTO"]:
+            try:
+                # Load the molecules.
+                mols = _sire_load(
+                    [self._traj_file, self._top_file],
+                    map=self._property_map,
+                    ignore_topology_frame=True,
+                    silent=True,
+                )
+
+                if self._backend is None:
+                    self._backend = "SIRE"
+
+                # Return the trajectory for the molecules.
+                return mols.trajectory()
+            except:
+                if format == "SIRE":
+                    _warnings.warn(
+                        "Sire failed to read: traj=%s, top=%s"
+                        % (self._traj_file, self._top_file)
+                    )
+                    return None
 
         # Return an MDTraj object.
         if format in ["MDTRAJ", "AUTO"]:
@@ -503,7 +611,7 @@ class Trajectory:
                     )
                 else:
                     _warnings.warn(
-                        "MDTraj and MDAnalysis failed to read: traj=%s, top=%s"
+                        "Sire, MDTraj, and MDAnalysis failed to read: traj=%s, top=%s"
                         % (self._traj_file, self._top_file)
                     )
                 universe = None
@@ -550,7 +658,14 @@ class Trajectory:
                 )
                 time_interval = time_interval.nanoseconds().value()
             else:
-                if self._backend == "MDTRAJ":
+                if self._backend == "SIRE":
+                    if len(self._trajectory) > 1:
+                        time_interval = (
+                            self._trajectory.times()[1] - self._trajectory.times()[0]
+                        ).to("nanoseconds")
+                    else:
+                        time_interval = self._trajectory.times()[0]
+                elif self._backend == "MDTRAJ":
                     time_interval = self._trajectory.timestep / 1000
                 elif self._backend == "MDANALYSIS":
                     time_interval = self._trajectory.trajectory.totaltime / 1000
@@ -623,7 +738,9 @@ class Trajectory:
 
             pdb_file = self._work_dir + f"/{str(_uuid.uuid4())}.pdb"
 
-            if self._backend == "MDTRAJ":
+            if self._backend == "SIRE":
+                frame = self._trajectory[x]
+            elif self._backend == "MDTRAJ":
                 frame_file = self._work_dir + f"/{str(_uuid.uuid4())}.rst7"
                 self._trajectory[x].save(frame_file, force_overwrite=True)
                 self._trajectory[x].save(pdb_file, force_overwrite=True)
@@ -637,57 +754,89 @@ class Trajectory:
 
             # Try to update the coordinates/velocities in the reference system.
             if self._system is not None:
-                # Parse the coordinates/velocites frame.
-                try:
-                    if self._backend == "MDANALYSIS":
-                        frame = _SireIO.Gro87(frame_file)
-                    else:
-                        frame = _SireIO.AmberRst7(frame_file)
-                except Exception as e:
-                    msg = "Failed to read trajectory frame: '%s'" % frame_file
-                    if _isVerbose():
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
+                if self._backend == "SIRE" and frame.current().num_molecules() > 1:
+                    try:
+                        sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                            self._system._sire_object,
+                            frame.current()._system,
+                            self._mapping,
+                            False,
+                            self._property_map,
+                            {},
+                        )
 
-                # Parse the PDB file.
-                try:
-                    pdb = _SireIO.PDB2(pdb_file)
-                except Exception as e:
-                    msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
-                    if _isVerbose():
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
+                        new_system = _System(sire_system)
+                    except Exception as e:
+                        msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
 
-                # The new_system object will contain a single molecule with the
-                # coordinates of all of the atoms in the reference. As such, we
-                # will need to split the system into molecules.
-                new_system = _split_molecules(
-                    frame, pdb, self._system, str(self._work_dir), self._property_map
-                )
-                try:
-                    sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
-                        self._system._sire_object,
-                        new_system,
-                        self._mapping,
-                        False,
+                else:
+                    # Parse the coordinates/velocites frame.
+                    try:
+                        if self._backend == "SIRE":
+                            frame = frame.current()._system
+                            pdb = _SireIO.PDB2(frame)
+                            pdb.writeToFile(pdb_file)
+                            frame = _SireIO.AmberRst7(frame)
+                        elif self._backend == "MDANALYSIS":
+                            frame = _SireIO.Gro87(frame_file)
+                        else:
+                            frame = _SireIO.AmberRst7(frame_file)
+                    except Exception as e:
+                        msg = "Failed to read trajectory frame: '%s'" % frame_file
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
+
+                    # Parse the PDB file.
+                    try:
+                        pdb = _SireIO.PDB2(pdb_file)
+                    except Exception as e:
+                        msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
+
+                    # The new_system object will contain a single molecule with the
+                    # coordinates of all of the atoms in the reference. As such, we
+                    # will need to split the system into molecules.
+                    new_system = _split_molecules(
+                        frame,
+                        pdb,
+                        self._system,
+                        str(self._work_dir),
                         self._property_map,
-                        {},
                     )
+                    try:
+                        sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                            self._system._sire_object,
+                            new_system,
+                            self._mapping,
+                            False,
+                            self._property_map,
+                            {},
+                        )
 
-                    new_system = _System(sire_system)
-                except Exception as e:
-                    msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
-                    if _isVerbose():
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
+                        new_system = _System(sire_system)
+                    except Exception as e:
+                        msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
 
             # Load the frame directly to create a new System object.
             else:
                 try:
-                    if self._backend == "MDANALYSIS":
+                    if self._backend == "SIRE":
+                        new_system = _System(frame.current()._system)
+
+                    elif self._backend == "MDANALYSIS":
                         new_system = _System(
                             _SireIO.MoleculeParser.read(
                                 [frame_file], self._property_map
@@ -700,6 +849,7 @@ class Trajectory:
                             )
                         )
                 except Exception as e:
+                    raise
                     msg = "Failed to read trajectory frame: '%s'" % frame_file
                     if _isVerbose():
                         raise IOError(msg) from e
@@ -735,7 +885,9 @@ class Trajectory:
         if self._trajectory is None:
             return 0
         else:
-            if self._backend == "MDTRAJ":
+            if self._backend == "SIRE":
+                return len(self._trajectory)
+            elif self._backend == "MDTRAJ":
                 return self._trajectory.n_frames
             elif self._backend == "MDANALYSIS":
                 return self._trajectory.trajectory.n_frames
@@ -786,9 +938,19 @@ class Trajectory:
             if not all(type(x) is int for x in atoms):
                 raise TypeError("'atom' indices must be of type 'int'")
 
-        if self._backend == "MDTRAJ":
+        if self._backend == "SIRE":
+            raise _IncompatibleError(
+                "RMSD currently isn't supported using the Sire backend."
+            )
+
+        elif self._backend == "MDTRAJ":
             try:
-                rmsd = _mdtraj.rmsd(self._trajectory, self._trajectory, frame, atoms)
+                rmsd = _mdtraj.rmsd(
+                    self._trajectory,
+                    self._trajectory,
+                    frame=frame,
+                    atom_indices=atoms,
+                )
             except Exception as e:
                 msg = "Atom indices not found in the system."
                 if _isVerbose():

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -24,7 +24,7 @@
 __author__ = "Lester Hedges"
 __email__ = "lester.hedges@gmail.com"
 
-__all__ = ["getFrame", "Trajectory"]
+__all__ = ["getFrame", "Trajectory", "backends"]
 
 from .._Utils import _try_import, _have_imported
 
@@ -37,9 +37,11 @@ import shutil as _shutil
 import uuid as _uuid
 import warnings as _warnings
 
+from sire.legacy import Base as _SireBase
 from sire.legacy import IO as _SireIO
 from sire.legacy import Mol as _SireMol
 
+from sire import load as _sire_load
 from sire._load import _resolve_path
 
 from .. import _isVerbose
@@ -51,6 +53,19 @@ from ..Types import Time as _Time
 from .. import IO as _IO
 from .. import Units as _Units
 from .. import _Utils
+
+
+def backends():
+    """
+    Return the list of supported trajectory parsing backends.
+
+    Returns
+
+    backends : [str]
+        The list of supported trajectory parsing backends.
+    """
+
+    return ["SIRE", "MDANALYSIS", "MDTRAJ"]
 
 
 def getFrame(trajectory, topology, index, system=None, property_map={}):
@@ -108,9 +123,9 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
     # Download files if they are URLs.
     if trajectory.startswith(("http", "www")):
         try:
-            trajectory = _resolve_path(trajectory.lower(), str(work_dir), silent=True)[
-                0
-            ]
+            trajectory = _resolve_path(
+                trajectory.lower(), str(work_dir), show_warnings=False, silent=True
+            )[0]
         except:
             raise ValueError(f"Unable to download trajectory file: {trajectory}")
     if topology.startswith(("http", "www")):
@@ -136,91 +151,134 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
         # Update the water topology to match topology/trajectory.
         system = _update_water_topology(system, topology, trajectory)
 
-    # Try to load the frame with MDTraj.
+    # Try to load the frame with Sire.
     errors = []
+    is_sire = False
     is_mdanalysis = False
     pdb_file = work_dir + f"/{str(_uuid.uuid4())}.pdb"
     try:
-        frame_file = work_dir + f"/{str(_uuid.uuid4())}.rst7"
-        frame = _mdtraj.load_frame(trajectory, index, top=topology)
-        frame.save(frame_file, force_overwrite=True)
-        frame.save(pdb_file, force_overwrite=True)
+        frame = _sire_load(
+            [trajectory, topology],
+            map=property_map,
+            ignore_topology_frame=True,
+            silent=True,
+        ).trajectory()[index]
+        is_sire = True
     except Exception as e:
-        is_mdanalysis = True
-        errors.append(f"MDTraj: {str(e)}")
-        # Try to load the frame with MDAnalysis.
+        errors.append(f"Sire: {str(e)}")
         try:
-            frame_file = work_dir + f"/{str(_uuid.uuid4())}.gro"
-            universe = _mdanalysis.Universe(topology, trajectory)
-            universe.trajectory.trajectory[index]
-            with _warnings.catch_warnings():
-                _warnings.simplefilter("ignore")
-                universe.select_atoms("all").write(frame_file)
-                universe.select_atoms("all").write(pdb_file)
+            frame_file = work_dir + f"/{str(_uuid.uuid4())}.rst7"
+            frame = _mdtraj.load_frame(trajectory, index, top=topology)
+            frame.save(frame_file, force_overwrite=True)
+            frame.save(pdb_file, force_overwrite=True)
         except Exception as e:
-            errors.append(f"MDAnalysis: {str(e)}")
-            msg = "MDTraj/MDAnalysis failed to read frame %d from: traj=%s, top=%s" % (
-                index,
-                trajectory,
-                topology,
-            )
-            if _isVerbose():
-                raise IOError(msg + "\n" + "\n".join(errors))
-            else:
-                raise IOError(msg) from None
+            is_mdanalysis = True
+            errors.append(f"MDTraj: {str(e)}")
+            # Try to load the frame with MDAnalysis.
+            try:
+                frame_file = work_dir + f"/{str(_uuid.uuid4())}.gro"
+                universe = _mdanalysis.Universe(topology, trajectory)
+                universe.trajectory.trajectory[index]
+                with _warnings.catch_warnings():
+                    _warnings.simplefilter("ignore")
+                    universe.select_atoms("all").write(frame_file)
+                    universe.select_atoms("all").write(pdb_file)
+            except Exception as e:
+                errors.append(f"MDAnalysis: {str(e)}")
+                msg = (
+                    "MDTraj/MDAnalysis failed to read frame %d from: traj=%s, top=%s"
+                    % (
+                        index,
+                        trajectory,
+                        topology,
+                    )
+                )
+                if _isVerbose():
+                    raise IOError(msg + "\n" + "\n".join(errors))
+                else:
+                    raise IOError(msg) from None
 
     # Try to update the coordinates/velocities in the reference system.
     if system is not None:
-        # Parse the coordinates/velocites frame.
-        try:
-            if is_mdanalysis:
-                frame = _SireIO.Gro87(frame_file)
-            else:
-                frame = _SireIO.AmberRst7(frame_file)
-        except Exception as e:
-            msg = "Failed to read trajectory frame: '%s'" % frame_file
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+        if is_sire and frame.current().num_molecules() > 1:
+            try:
+                sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                    system._sire_object,
+                    frame.current()._system,
+                    mapping,
+                    False,
+                    property_map,
+                    {},
+                )
 
-        # Parse the PDB frame.
-        try:
-            pdb = _SireIO.PDB2(pdb_file)
-        except Exception as e:
-            msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+                new_system = _System(sire_system)
 
-        # The new_system object will contain a single molecule with the
-        # coordinates of all of the atoms in the reference. As such, we
-        # will need to split the system into molecules.
-        new_system = _split_molecules(frame, pdb, system, str(work_dir), property_map)
-        return _System(new_system)
-        try:
-            sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
-                system._sire_object, new_system, mapping, False, property_map, {}
-            )
-
-            new_system = _System(sire_system)
-        except Exception as e:
-            msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+            except Exception as e:
+                msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
 
         else:
-            raise IOError(
-                "The trajectory frame is incompatible with the passed system!"
+            # Parse the coordinates/velocites frame.
+            try:
+                if is_sire:
+                    frame = frame.current()._system
+                    pdb = _SireIO.PDB2(frame)
+                    pdb.writeToFile(pdb_file)
+                    frame = _SireIO.AmberRst7(frame)
+                elif is_mdanalysis:
+                    frame = _SireIO.Gro87(frame_file)
+                else:
+                    frame = _SireIO.AmberRst7(frame_file)
+            except Exception as e:
+                msg = "Failed to read trajectory frame: '%s'" % frame_file
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+            # Parse the PDB frame.
+            try:
+                pdb = _SireIO.PDB2(pdb_file)
+            except Exception as e:
+                msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+            # The new_system object will contain a single molecule with the
+            # coordinates of all of the atoms in the reference. As such, we
+            # will need to split the system into molecules.
+            new_system = _split_molecules(
+                frame, pdb, system, str(work_dir), property_map
             )
+            try:
+                sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                    system._sire_object, new_system, mapping, False, property_map, {}
+                )
+
+                new_system = _System(sire_system)
+            except Exception as e:
+                msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+            else:
+                raise IOError(
+                    "The trajectory frame is incompatible with the passed system!"
+                )
 
     # Load the frame directly to create a new System object.
     else:
         try:
-            if is_mdanalysis:
+            if is_sire:
+                new_system = _System(frame.current()._system)
+            elif is_mdanalysis:
                 new_system = _System(_SireIO.MoleculeParser.read(frame_file))
             else:
                 new_system = _System(
@@ -241,7 +299,13 @@ class Trajectory:
     """A class for reading a manipulating biomolecular trajectories."""
 
     def __init__(
-        self, process=None, trajectory=None, topology=None, system=None, property_map={}
+        self,
+        process=None,
+        trajectory=None,
+        topology=None,
+        system=None,
+        backend="AUTO",
+        property_map={},
     ):
         """
         Constructor.
@@ -264,6 +328,12 @@ class Trajectory:
             useful if you wish to preserve all molecular properties, which might
             be lost during reading of the topology format required by the
             trajectory backend.
+
+        backend : str
+            The backend used to parse the trajectory file. Options are 'Sire',
+            'MDTraj', or 'MDAnalysis'. Use "auto" if you are happy with any
+            backend, i.e. it will try each in sequence and use the first that
+            worked.
 
         property_map : dict
            A dictionary that maps system "properties" to their user defined
@@ -376,12 +446,21 @@ class Trajectory:
                     self._system, self._top_file, self._traj_file
                 )
 
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        # Strip whitespace and convert to upper case.
+        backend = backend.replace(" ", "").upper()
+
+        if backend not in ["AUTO"] + backends():
+            _warnings.warn("Invalid trajectory format. Using default (Sire).")
+            backend = "SIRE"
+
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'")
-        self._property_map = property_map
 
         # Get the current trajectory.
-        self._trajectory = self.getTrajectory(format="AUTO")
+        self._trajectory = self.getTrajectory(format=backend)
 
     def __str__(self):
         """Return a human readable string representation of the object."""
@@ -405,10 +484,10 @@ class Trajectory:
         ----------
 
         format : str
-            Whether to return an 'MDTraj' or 'MDAnalysis' object.
-            Use "auto" if you are happy with either format, i.e. it
-            will try each backend in sequence and return an object
-            from the first one that works.
+            Whether to return a 'Sire', 'MDTraj', or 'MDAnalysis' object.
+            Use "auto" if you are happy with any format, i.e. it will try
+            each backend in sequence and return an object from the first one
+            that works.
 
         Returns
         -------
@@ -417,12 +496,15 @@ class Trajectory:
             The trajectory in MDTraj or MDAnalysis format.
         """
 
+        if not isinstance(format, str):
+            raise TypeError("'format' must be of type 'str'")
+
         # Strip whitespace and convert to upper case.
         format = format.replace(" ", "").upper()
 
-        if format.replace(" ", "").upper() not in ["MDTRAJ", "MDANALYSIS", "AUTO"]:
-            _warnings.warn("Invalid trajectory format. Using default (mdtraj).")
-            format = "MDTRAJ"
+        if format not in ["AUTO"] + backends():
+            _warnings.warn("Invalid trajectory format. Using default (Sire).")
+            format = "SIRE"
 
         # If this object isn't bound to a Process and the format matches the
         # existing backend, then return the trajectory directly.
@@ -431,6 +513,8 @@ class Trajectory:
                 return _copy.deepcopy(self._trajectory)
             elif format in ["MDANALYSIS", "AUTO"] and self._backend == "MDANALYSIS":
                 return self._trajectory.copy()
+            elif format in ["SIRE", "AUTO"] and self._backend == "SIRE":
+                return self._trajectory
 
         if format == "MDTRAJ" and self._backend == "MDANALYSIS":
             raise _IncompatibleError(
@@ -458,6 +542,30 @@ class Trajectory:
 
         if not _os.path.isfile(self._top_file):
             raise IOError("Topology file doesn't exist: '%s'" % self._top_file)
+
+        # Return a Sire trajectory object.
+        if format in ["SIRE", "AUTO"]:
+            try:
+                # Load the molecules.
+                mols = _sire_load(
+                    [self._traj_file, self._top_file],
+                    map=self._property_map,
+                    ignore_topology_frame=True,
+                    silent=True,
+                )
+
+                if self._backend is None:
+                    self._backend = "SIRE"
+
+                # Return the trajectory for the molecules.
+                return mols.trajectory()
+            except:
+                if format == "SIRE":
+                    _warnings.warn(
+                        "Sire failed to read: traj=%s, top=%s"
+                        % (self._traj_file, self._top_file)
+                    )
+                    return None
 
         # Return an MDTraj object.
         if format in ["MDTRAJ", "AUTO"]:
@@ -503,7 +611,7 @@ class Trajectory:
                     )
                 else:
                     _warnings.warn(
-                        "MDTraj and MDAnalysis failed to read: traj=%s, top=%s"
+                        "Sire, MDTraj, and MDAnalysis failed to read: traj=%s, top=%s"
                         % (self._traj_file, self._top_file)
                     )
                 universe = None
@@ -550,7 +658,14 @@ class Trajectory:
                 )
                 time_interval = time_interval.nanoseconds().value()
             else:
-                if self._backend == "MDTRAJ":
+                if self._backend == "SIRE":
+                    if len(self._trajectory) > 1:
+                        time_interval = (
+                            self._trajectory.times()[1] - self._trajectory.times()[0]
+                        ).to("nanoseconds")
+                    else:
+                        time_interval = self._trajectory.times()[0]
+                elif self._backend == "MDTRAJ":
                     time_interval = self._trajectory.timestep / 1000
                 elif self._backend == "MDANALYSIS":
                     time_interval = self._trajectory.trajectory.totaltime / 1000
@@ -623,7 +738,9 @@ class Trajectory:
 
             pdb_file = self._work_dir + f"/{str(_uuid.uuid4())}.pdb"
 
-            if self._backend == "MDTRAJ":
+            if self._backend == "SIRE":
+                frame = self._trajectory[x]
+            elif self._backend == "MDTRAJ":
                 frame_file = self._work_dir + f"/{str(_uuid.uuid4())}.rst7"
                 self._trajectory[x].save(frame_file, force_overwrite=True)
                 self._trajectory[x].save(pdb_file, force_overwrite=True)
@@ -637,57 +754,89 @@ class Trajectory:
 
             # Try to update the coordinates/velocities in the reference system.
             if self._system is not None:
-                # Parse the coordinates/velocites frame.
-                try:
-                    if self._backend == "MDANALYSIS":
-                        frame = _SireIO.Gro87(frame_file)
-                    else:
-                        frame = _SireIO.AmberRst7(frame_file)
-                except Exception as e:
-                    msg = "Failed to read trajectory frame: '%s'" % frame_file
-                    if _isVerbose():
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
+                if self._backend == "SIRE" and frame.current().num_molecules() > 1:
+                    try:
+                        sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                            self._system._sire_object,
+                            frame.current()._system,
+                            self._mapping,
+                            False,
+                            self._property_map,
+                            {},
+                        )
 
-                # Parse the PDB file.
-                try:
-                    pdb = _SireIO.PDB2(pdb_file)
-                except Exception as e:
-                    msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
-                    if _isVerbose():
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
+                        new_system = _System(sire_system)
+                    except Exception as e:
+                        msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
 
-                # The new_system object will contain a single molecule with the
-                # coordinates of all of the atoms in the reference. As such, we
-                # will need to split the system into molecules.
-                new_system = _split_molecules(
-                    frame, pdb, self._system, str(self._work_dir), self._property_map
-                )
-                try:
-                    sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
-                        self._system._sire_object,
-                        new_system,
-                        self._mapping,
-                        False,
+                else:
+                    # Parse the coordinates/velocites frame.
+                    try:
+                        if self._backend == "SIRE":
+                            frame = frame.current()._system
+                            pdb = _SireIO.PDB2(frame)
+                            pdb.writeToFile(pdb_file)
+                            frame = _SireIO.AmberRst7(frame)
+                        elif self._backend == "MDANALYSIS":
+                            frame = _SireIO.Gro87(frame_file)
+                        else:
+                            frame = _SireIO.AmberRst7(frame_file)
+                    except Exception as e:
+                        msg = "Failed to read trajectory frame: '%s'" % frame_file
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
+
+                    # Parse the PDB file.
+                    try:
+                        pdb = _SireIO.PDB2(pdb_file)
+                    except Exception as e:
+                        msg = "Failed to read PDB trajectory frame: '%s'" % pdb_file
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
+
+                    # The new_system object will contain a single molecule with the
+                    # coordinates of all of the atoms in the reference. As such, we
+                    # will need to split the system into molecules.
+                    new_system = _split_molecules(
+                        frame,
+                        pdb,
+                        self._system,
+                        str(self._work_dir),
                         self._property_map,
-                        {},
                     )
+                    try:
+                        sire_system, _ = _SireIO.updateCoordinatesAndVelocities(
+                            self._system._sire_object,
+                            new_system,
+                            self._mapping,
+                            False,
+                            self._property_map,
+                            {},
+                        )
 
-                    new_system = _System(sire_system)
-                except Exception as e:
-                    msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
-                    if _isVerbose():
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
+                        new_system = _System(sire_system)
+                    except Exception as e:
+                        msg = "Failed to copy trajectory coordinates/velocities into BioSimSpace system!"
+                        if _isVerbose():
+                            raise IOError(msg) from e
+                        else:
+                            raise IOError(msg) from None
 
             # Load the frame directly to create a new System object.
             else:
                 try:
-                    if self._backend == "MDANALYSIS":
+                    if self._backend == "SIRE":
+                        new_system = _System(frame.current()._system)
+
+                    elif self._backend == "MDANALYSIS":
                         new_system = _System(
                             _SireIO.MoleculeParser.read(
                                 [frame_file], self._property_map
@@ -700,6 +849,7 @@ class Trajectory:
                             )
                         )
                 except Exception as e:
+                    raise
                     msg = "Failed to read trajectory frame: '%s'" % frame_file
                     if _isVerbose():
                         raise IOError(msg) from e
@@ -735,7 +885,9 @@ class Trajectory:
         if self._trajectory is None:
             return 0
         else:
-            if self._backend == "MDTRAJ":
+            if self._backend == "SIRE":
+                return len(self._trajectory)
+            elif self._backend == "MDTRAJ":
                 return self._trajectory.n_frames
             elif self._backend == "MDANALYSIS":
                 return self._trajectory.trajectory.n_frames
@@ -786,9 +938,19 @@ class Trajectory:
             if not all(type(x) is int for x in atoms):
                 raise TypeError("'atom' indices must be of type 'int'")
 
-        if self._backend == "MDTRAJ":
+        if self._backend == "SIRE":
+            raise _IncompatibleError(
+                "RMSD currently isn't supported using the Sire backend."
+            )
+
+        elif self._backend == "MDTRAJ":
             try:
-                rmsd = _mdtraj.rmsd(self._trajectory, self._trajectory, frame, atoms)
+                rmsd = _mdtraj.rmsd(
+                    self._trajectory,
+                    self._trajectory,
+                    frame=frame,
+                    atom_indices=atoms,
+                )
             except Exception as e:
                 msg = "Atom indices not found in the system."
                 if _isVerbose():

--- a/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
+++ b/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
@@ -1,4 +1,4 @@
-import BioSimSpace as BSS
+import BioSimSpace.Sandpit.Exscientia as BSS
 
 try:
     from Sire.Base import wrap
@@ -30,12 +30,24 @@ def system():
 
 
 @pytest.fixture(scope="session")
+def traj_sire(system):
+    """A trajectory object using the Sire backend."""
+    return BSS.Trajectory.Trajectory(
+        trajectory="tests/input/ala.trr",
+        topology="tests/input/ala.gro",
+        system=system,
+        backend="SIRE",
+    )
+
+
+@pytest.fixture(scope="session")
 def traj_mdtraj(system):
     """A trajectory object using the MDTraj backend."""
     return BSS.Trajectory.Trajectory(
         trajectory="tests/input/ala.trr",
         topology="tests/input/ala.gro",
         system=system,
+        backend="MDTRAJ",
     )
 
 
@@ -46,6 +58,7 @@ def traj_mdanalysis(system):
         trajectory="tests/input/ala.trr",
         topology="tests/input/ala.tpr",
         system=system,
+        backend="MDANALYSIS",
     )
 
 
@@ -58,6 +71,7 @@ def traj_mdanalysis_pdb(system):
         trajectory="tests/input/ala.trr",
         topology="tests/input/ala.tpr",
         system=new_system,
+        backend="MDANALYSIS",
     )
 
 
@@ -65,29 +79,44 @@ def traj_mdanalysis_pdb(system):
     have_mdanalysis is False or have_mdtraj is False,
     reason="Requires MDAnalysis and mdtraj to be installed.",
 )
-def test_frames(traj_mdtraj, traj_mdanalysis):
+def test_frames(traj_sire, traj_mdtraj, traj_mdanalysis):
     """Make sure that the number of frames loaded by each backend agree."""
-    assert traj_mdtraj.nFrames() == traj_mdanalysis.nFrames()
+    assert traj_sire.nFrames() == traj_mdtraj.nFrames() == traj_mdanalysis.nFrames()
 
 
 @pytest.mark.skipif(
     have_mdanalysis is False or have_mdtraj is False,
     reason="Requires MDAnalysis and mdtraj to be installed.",
 )
-def test_coords(traj_mdtraj, traj_mdanalysis):
+def test_coords(traj_sire, traj_mdtraj, traj_mdanalysis):
     """Make sure that frames from both backends have comparable coordinates."""
 
     # Extract the first and last frame from each trajectory.
-    frames0 = traj_mdtraj.getFrames([0, -1])
-    frames1 = traj_mdanalysis.getFrames([0, -1])
+    frames0 = traj_sire.getFrames([0, -1])
+    frames1 = traj_mdtraj.getFrames([0, -1])
+    frames2 = traj_mdanalysis.getFrames([0, -1])
 
     # Make sure that all coordinates are approximately the same.
-    for system0, system1 in zip(frames0, frames1):
-        for mol0, mol1 in zip(system0, system1):
-            for c0, c1 in zip(mol0.coordinates(), mol1.coordinates()):
-                assert c0.x().value() == pytest.approx(c1.x().value(), abs=1e-2)
-                assert c0.y().value() == pytest.approx(c1.y().value(), abs=1e-2)
-                assert c0.z().value() == pytest.approx(c1.z().value(), abs=1e-2)
+    for system0, system1, system2 in zip(frames0, frames1, frames2):
+        for mol0, mol1, mol2 in zip(system0, system1, system2):
+            for c0, c1, c2 in zip(
+                mol0.coordinates(), mol1.coordinates(), mol2.coordinates()
+            ):
+                assert (
+                    c0.x().value()
+                    == pytest.approx(c1.x().value(), abs=1e-2)
+                    == pytest.approx(c2.x().value(), abs=1e-2)
+                )
+                assert (
+                    c0.y().value()
+                    == pytest.approx(c1.y().value(), abs=1e-2)
+                    == pytest.approx(c2.y().value(), abs=1e-2)
+                )
+                assert (
+                    c0.z().value()
+                    == pytest.approx(c1.z().value(), abs=1e-2)
+                    == pytest.approx(c2.z().value(), abs=1e-2)
+                )
 
 
 @pytest.mark.skipif(
@@ -96,7 +125,8 @@ def test_coords(traj_mdtraj, traj_mdanalysis):
 )
 def test_coords_pdb(traj_mdtraj, traj_mdanalysis_pdb):
     """Make sure that frames from both backends have comparable coordinates
-    when a PDB intermediate topology is used for reconstruction.
+    when a PDB intermediate topology is used for reconstruction. This isn't
+    needed for Sire.
     """
 
     # Extract the first and last frame from each trajectory.

--- a/tests/Trajectory/test_trajectory.py
+++ b/tests/Trajectory/test_trajectory.py
@@ -30,12 +30,24 @@ def system():
 
 
 @pytest.fixture(scope="session")
+def traj_sire(system):
+    """A trajectory object using the Sire backend."""
+    return BSS.Trajectory.Trajectory(
+        trajectory="tests/input/ala.trr",
+        topology="tests/input/ala.gro",
+        system=system,
+        backend="SIRE",
+    )
+
+
+@pytest.fixture(scope="session")
 def traj_mdtraj(system):
     """A trajectory object using the MDTraj backend."""
     return BSS.Trajectory.Trajectory(
         trajectory="tests/input/ala.trr",
         topology="tests/input/ala.gro",
         system=system,
+        backend="MDTRAJ",
     )
 
 
@@ -46,6 +58,7 @@ def traj_mdanalysis(system):
         trajectory="tests/input/ala.trr",
         topology="tests/input/ala.tpr",
         system=system,
+        backend="MDANALYSIS",
     )
 
 
@@ -58,6 +71,7 @@ def traj_mdanalysis_pdb(system):
         trajectory="tests/input/ala.trr",
         topology="tests/input/ala.tpr",
         system=new_system,
+        backend="MDANALYSIS",
     )
 
 
@@ -65,29 +79,44 @@ def traj_mdanalysis_pdb(system):
     have_mdanalysis is False or have_mdtraj is False,
     reason="Requires MDAnalysis and mdtraj to be installed.",
 )
-def test_frames(traj_mdtraj, traj_mdanalysis):
+def test_frames(traj_sire, traj_mdtraj, traj_mdanalysis):
     """Make sure that the number of frames loaded by each backend agree."""
-    assert traj_mdtraj.nFrames() == traj_mdanalysis.nFrames()
+    assert traj_sire.nFrames() == traj_mdtraj.nFrames() == traj_mdanalysis.nFrames()
 
 
 @pytest.mark.skipif(
     have_mdanalysis is False or have_mdtraj is False,
     reason="Requires MDAnalysis and mdtraj to be installed.",
 )
-def test_coords(traj_mdtraj, traj_mdanalysis):
+def test_coords(traj_sire, traj_mdtraj, traj_mdanalysis):
     """Make sure that frames from both backends have comparable coordinates."""
 
     # Extract the first and last frame from each trajectory.
-    frames0 = traj_mdtraj.getFrames([0, -1])
-    frames1 = traj_mdanalysis.getFrames([0, -1])
+    frames0 = traj_sire.getFrames([0, -1])
+    frames1 = traj_mdtraj.getFrames([0, -1])
+    frames2 = traj_mdanalysis.getFrames([0, -1])
 
     # Make sure that all coordinates are approximately the same.
-    for system0, system1 in zip(frames0, frames1):
-        for mol0, mol1 in zip(system0, system1):
-            for c0, c1 in zip(mol0.coordinates(), mol1.coordinates()):
-                assert c0.x().value() == pytest.approx(c1.x().value(), abs=1e-2)
-                assert c0.y().value() == pytest.approx(c1.y().value(), abs=1e-2)
-                assert c0.z().value() == pytest.approx(c1.z().value(), abs=1e-2)
+    for system0, system1, system2 in zip(frames0, frames1, frames2):
+        for mol0, mol1, mol2 in zip(system0, system1, system2):
+            for c0, c1, c2 in zip(
+                mol0.coordinates(), mol1.coordinates(), mol2.coordinates()
+            ):
+                assert (
+                    c0.x().value()
+                    == pytest.approx(c1.x().value(), abs=1e-2)
+                    == pytest.approx(c2.x().value(), abs=1e-2)
+                )
+                assert (
+                    c0.y().value()
+                    == pytest.approx(c1.y().value(), abs=1e-2)
+                    == pytest.approx(c2.y().value(), abs=1e-2)
+                )
+                assert (
+                    c0.z().value()
+                    == pytest.approx(c1.z().value(), abs=1e-2)
+                    == pytest.approx(c2.z().value(), abs=1e-2)
+                )
 
 
 @pytest.mark.skipif(
@@ -96,7 +125,8 @@ def test_coords(traj_mdtraj, traj_mdanalysis):
 )
 def test_coords_pdb(traj_mdtraj, traj_mdanalysis_pdb):
     """Make sure that frames from both backends have comparable coordinates
-    when a PDB intermediate topology is used for reconstruction.
+    when a PDB intermediate topology is used for reconstruction. This isn't
+    needed for Sire.
     """
 
     # Extract the first and last frame from each trajectory.


### PR DESCRIPTION
This PR adds support for Sire as a trajectory parsing backend within the `BioSimSpace.Trajectory` sub-package. This means that Sire can be used as a native trajectory backend for all engines that we currently support. At present, GROMACS is still parsed with MDAnalysis, since users have requested the use of the `tpr` format to preserve information that would otherwise be lost with, say gro, e.g. `bonds`, etc. This can obviously be achieved with Sire too, since it can parse any compatible format along with the trajectory, e.g. a top file. I'll port this over at a later date once I've given users some examples for how this works. (I don't want to break any external workflows that rely on this.)

The PR also closes #118.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods