### PR TITLE
Fix issue #124

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -22,14 +22,14 @@ jobs:
           # Exclude all but the latest Python from all but Linux
           - platform:
               { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-            python-version: "3.8"
+            python-version: "3.9"
           - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
-            python-version: "3.8"
+            python-version: "3.9"
           - platform:
               { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-            python-version: "3.9"
+            python-version: "3.10"
           - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
-            python-version: "3.9"
+            python-version: "3.10"
     environment:
       name: biosimspace-build
     defaults:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,14 +22,14 @@ jobs:
           # but Linux
           - platform:
               { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-            python-version: "3.8"
+            python-version: "3.9"
           - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
-            python-version: "3.8"
+            python-version: "3.9"
           - platform:
               { name: "macos", os: "macos-latest", shell: "bash -l {0}" }
-            python-version: "3.9"
+            python-version: "3.10"
           - platform: { name: "windows", os: "windows-latest", shell: "pwsh" }
-            python-version: "3.9"
+            python-version: "3.10"
     environment:
       name: biosimspace-build
     defaults:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -286,10 +286,15 @@ class Gromacs(_process.Process):
         """Generate GROMACS configuration file strings."""
 
         # Check whether the system contains periodic box information.
-        # For now, well not attempt to generate a box if the system property
-        # is missing. If no box is present, we'll assume a non-periodic simulation.
-        if "space" in self._system._sire_object.propertyKeys():
-            has_box = True
+        space_prop = self._property_map.get("space", "space")
+        if space_prop in self._system._sire_object.propertyKeys():
+            try:
+                # Make sure that we have a periodic box. The system will now have
+                # a default cartesian space.
+                box = self._system._sire_object.property(space_prop)
+                has_box = box.isPeriodic()
+            except:
+                has_box = False
         else:
             _warnings.warn("No simulation box found. Assuming gas phase simulation.")
             has_box = False

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -283,10 +283,14 @@ class OpenMM(_process.Process):
         prop = self._property_map.get("space", "space")
 
         # Check whether the system contains periodic box information.
-        # For now, we'll not attempt to generate a box if the system property
-        # is missing. If no box is present, we'll assume a non-periodic simulation.
         if prop in self._system._sire_object.propertyKeys():
-            has_box = True
+            try:
+                # Make sure that we have a periodic box. The system will now have
+                # a default cartesian space.
+                box = self._system._sire_object.property(prop)
+                has_box = box.isPeriodic()
+            except:
+                has_box = False
         else:
             _warnings.warn("No simulation box found. Assuming gas phase simulation.")
             has_box = False

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -285,7 +285,13 @@ class OpenMM(_process.Process):
         # For now, we'll not attempt to generate a box if the system property
         # is missing. If no box is present, we'll assume a non-periodic simulation.
         if prop in self._system._sire_object.propertyKeys():
-            has_box = True
+            try:
+                # Make sure that we have a periodic box. The system will now have
+                # a default cartesian space.
+                box = self._system._sire_object.property(prop)
+                has_box = box.isPeriodic()
+            except:
+                has_box = False
         else:
             _warnings.warn("No simulation box found. Assuming gas phase simulation.")
             has_box = False

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -39,7 +39,13 @@ class ConfigFactory:
     def _has_box(self):
         """Return whether the current system has a box."""
         if "space" in self.system._sire_object.propertyKeys():
-            has_box = True
+            try:
+                # Make sure that we have a periodic box. The system will now have
+                # a default cartesian space.
+                box = self.system._sire_object.property("space")
+                has_box = box.isPeriodic()
+            except:
+                has_box = False
         else:
             _warnings.warn("No simulation box found. Assuming gas phase simulation.")
             has_box = False

--- a/python/BioSimSpace/_Config/_config.py
+++ b/python/BioSimSpace/_Config/_config.py
@@ -91,10 +91,18 @@ class Config:
         """
         space_prop = self._property_map.get("space", "space")
         if space_prop in self._system._sire_object.propertyKeys():
-            return True
+            try:
+                # Make sure that we have a periodic box. The system will now have
+                # a default cartesian space.
+                box = self._system._sire_object.property(space_prop)
+                has_box = box.isPeriodic()
+            except:
+                has_box = False
         else:
+            has_box = False
             _warnings.warn("No simulation box found. Assuming gas phase simulation.")
-            return False
+
+        return has_box
 
     def hasWater(self):
         """


### PR DESCRIPTION
This PR closes #124. We now check that the space property of the system is periodic for _all_ supported engines, to ensure that vacuum simulations are run correctly. Note that there is some code duplication here since not all process classes have been ported to the new configuration generator code. The GROMAC code is duplicated since we need to write a modified GRO file for vacuum simulations, which is done in the process setup, not the configuration generator.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods