### PR TITLE
Fix issues caught by BioSimSpaceTutorials

### DIFF
--- a/demo/interactive_md.ipynb
+++ b/demo/interactive_md.ipynb
@@ -336,10 +336,10 @@
    "outputs": [],
    "source": [
     "# Search the system for a residue named ALA. Since there is a single match, we take the first result.\n",
-    "residue = system.search(\"resname ALA\")[0]\n",
+    "atoms = system.search(\"resname ALA\")\n",
     "\n",
     "# Get the indices of the atoms in the molecule, relative to the original system.\n",
-    "indices = [system.getIndex(x) for x in residue.getAtoms()]\n",
+    "indices = [system.getIndex(atom) for atom in atoms]\n",
     "\n",
     "# Compute the RMSD for each frame and plot the result.\n",
     "BSS.Notebook.plot(\n",

--- a/demo/interactive_md.ipynb
+++ b/demo/interactive_md.ipynb
@@ -343,7 +343,7 @@
     "\n",
     "# Compute the RMSD for each frame and plot the result.\n",
     "BSS.Notebook.plot(\n",
-    "    y=process.getTrajectory().rmsd(frame=0, atoms=indices),\n",
+    "    y=process.getTrajectory(backend=\"mdtraj\").rmsd(frame=0, atoms=indices),\n",
     "    xlabel=\"Frame\",\n",
     "    ylabel=\"RMSD\",\n",
     ")"
@@ -352,7 +352,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -366,7 +366,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -461,12 +461,17 @@ class Amber(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -477,6 +482,12 @@ class Amber(_process.Process):
         trajectory : :class:`Trajectory <BioSimSpace.Trajectory.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -489,7 +500,7 @@ class Amber(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         try:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -659,12 +659,17 @@ class Gromacs(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -675,6 +680,12 @@ class Gromacs(_process.Process):
         trajectory : :class:`System <BioSimSpace.Trajectory.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -695,7 +706,7 @@ class Gromacs(_process.Process):
             else:
                 self._traj_file = traj_file
 
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -813,12 +813,17 @@ class Namd(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -829,6 +834,13 @@ class Namd(_process.Process):
         trajectory : :class:`Trajectory <BioSimSpace.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
+
         # Wait for the process to finish.
         if block is True:
             self.wait()
@@ -840,7 +852,7 @@ class Namd(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         try:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1109,7 +1109,7 @@ class OpenMM(_process.Process):
 
             # Create a dummy PLUMED input file so that we can bind PLUMED
             # analysis functions to this process.
-            self._plumed = _Plumed(self._work_dir)
+            self._plumed = _Plumed(str(self._work_dir))
             plumed_config, auxillary_files = self._plumed.createConfig(
                 self._system, self._protocol, self._property_map
             )

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1350,12 +1350,17 @@ class OpenMM(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -1366,6 +1371,13 @@ class OpenMM(_process.Process):
         trajectory : :class:`System <BioSimSpace.Trajectory.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
+
 
         # Wait for the process to finish.
         if block is True:
@@ -1380,7 +1392,7 @@ class OpenMM(_process.Process):
         if not _os.path.isfile(self._traj_file):
             return None
         else:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
     def getFrame(self, index):
         """

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1378,7 +1378,6 @@ class OpenMM(_process.Process):
         if not isinstance(block, (bool, str)):
             raise TypeError("'block' must be of type 'bool' or 'str'")
 
-
         # Wait for the process to finish.
         if block is True:
             self.wait()

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -106,6 +106,10 @@ class Plumed:
                     "PLUMED version >= 2.5 is required."
                 )
 
+            # Store the major and minor versions.
+            self._plumed_major = major
+            self._plumed_minor = minor
+
         else:
             raise _Exceptions.IncompatibleError("Could not determine PLUMED version!")
 
@@ -377,7 +381,9 @@ class Plumed:
 
                 # The funnel collective variable requires an auxiliary file for
                 # PLUMED versions < 2.7.
-                if self._plumed_version < 2.7:
+                if self._plumed_major < 2 or (
+                    self._plumed_major < 3 and self._plumed_minor < 7
+                ):
                     aux_file = "ProjectionOnAxis.cpp"
                     self._config.append(f"LOAD FILE={aux_file}")
                     aux_file = (

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -585,12 +585,17 @@ class Somd(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -601,6 +606,12 @@ class Somd(_process.Process):
         trajectory : :class:`Trajectory <BioSimSpace.Trajectory.trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -613,7 +624,7 @@ class Somd(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         try:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -708,12 +708,17 @@ class Amber(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -724,6 +729,12 @@ class Amber(_process.Process):
         trajectory : :class:`Trajectory <BioSimSpace.Trajectory.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -736,7 +747,7 @@ class Amber(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         try:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -704,12 +704,17 @@ class Gromacs(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -720,6 +725,12 @@ class Gromacs(_process.Process):
         trajectory : :class:`System <BioSimSpace.Trajectory.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -740,7 +751,7 @@ class Gromacs(_process.Process):
             else:
                 self._traj_file = traj_file
 
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
@@ -811,12 +811,17 @@ class Namd(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -827,6 +832,13 @@ class Namd(_process.Process):
         trajectory : :class:`Trajectory <BioSimSpace.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
+
         # Wait for the process to finish.
         if block is True:
             self.wait()
@@ -838,7 +850,7 @@ class Namd(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         try:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -1350,12 +1350,17 @@ class OpenMM(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -1366,6 +1371,12 @@ class OpenMM(_process.Process):
         trajectory : :class:`System <BioSimSpace.Trajectory.Trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -1380,7 +1391,7 @@ class OpenMM(_process.Process):
         if not _os.path.isfile(self._traj_file):
             return None
         else:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
     def getFrame(self, index):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -1109,7 +1109,7 @@ class OpenMM(_process.Process):
 
             # Create a dummy PLUMED input file so that we can bind PLUMED
             # analysis functions to this process.
-            self._plumed = _Plumed(self._work_dir)
+            self._plumed = _Plumed(str(self._work_dir))
             plumed_config, auxillary_files = self._plumed.createConfig(
                 self._system, self._protocol, self._property_map
             )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -106,6 +106,10 @@ class Plumed:
                     "PLUMED version >= 2.5 is required."
                 )
 
+            # Store the major and minor versions.
+            self._plumed_major = major
+            self._plumed_minor = minor
+
         else:
             raise _Exceptions.IncompatibleError("Could not determine PLUMED version!")
 
@@ -377,7 +381,9 @@ class Plumed:
 
                 # The funnel collective variable requires an auxiliary file for
                 # PLUMED versions < 2.7.
-                if self._plumed_version < 2.7:
+                if self._plumed_major < 2 or (
+                    self._plumed_major < 3 and self._plumed_minor < 7
+                ):
                     aux_file = "ProjectionOnAxis.cpp"
                     self._config.append(f"LOAD FILE={aux_file}")
                     aux_file = (

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -600,12 +600,17 @@ class Somd(_process.Process):
         """
         return self.getSystem(block=False)
 
-    def getTrajectory(self, block="AUTO"):
+    def getTrajectory(self, backend="AUTO", block="AUTO"):
         """
         Return a trajectory object.
 
         Parameters
         ----------
+
+        backend : str
+            The backend to use for trajectory parsing. To see supported backends,
+            run BioSimSpace.Trajectory.backends(). Using "AUTO" will try each in
+            sequence.
 
         block : bool
             Whether to block until the process has finished running.
@@ -616,6 +621,12 @@ class Somd(_process.Process):
         trajectory : :class:`Trajectory <BioSimSpace.Trajectory.trajectory>`
             The latest trajectory object.
         """
+
+        if not isinstance(backend, str):
+            raise TypeError("'backend' must be of type 'str'")
+
+        if not isinstance(block, (bool, str)):
+            raise TypeError("'block' must be of type 'bool' or 'str'")
 
         # Wait for the process to finish.
         if block is True:
@@ -628,7 +639,7 @@ class Somd(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         try:
-            return _Trajectory.Trajectory(process=self)
+            return _Trajectory.Trajectory(process=self, backend=backend)
 
         except:
             return None


### PR DESCRIPTION
This PR fixes some issues that were caught by the [BioSimSpaceTutorials](https://github.com/OpenBioSim/BioSimSpaceTutorials) suite. (Why some of these weren't caught by the previous run through, I don't know.)

Changes are:

* Allow the user to specify a trajectory backend when calling `process.getTrajectory`. This is required since the default Sire backend can't (yet) compute the RMSD correctly. I've also updated the example notebook in `demos` to specify a backend.
* Fix the PLUMED version check required for determining whether and auxiliary file is needed to enable funnel metadynamics simulations.
* Pass the `process._work_dir` attribute to the `Process.Plumed` constructor as a string within `Process.OpenMM`. Previously, the `_Utils.WorkDir` object was being passed, so a type check was failing.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods