### PR TITLE
Fix issue #132

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -57,7 +57,7 @@ from .._Utils import _assert_imported, _have_imported, _try_import
 _alchemlyb = _try_import("alchemlyb")
 
 if _have_imported(_alchemlyb):
-    from alchemlyb.parsing.amber import extract as _extract
+    from alchemlyb.parsing.gmx import extract as _extract
 
 from .. import _gmx_exe
 from .. import _isVerbose

--- a/tests/Sandpit/Exscientia/Process/test_openmm.py
+++ b/tests/Sandpit/Exscientia/Process/test_openmm.py
@@ -125,7 +125,7 @@ def test_production(system, restraint):
     )
 
     # Run the process, check that it finished without error, and returns a system.
-    run_process(system, protocol, restraint=restraint, tolerance=1)
+    run_process(system, protocol, restraint=restraint, tolerance=1.1)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR closes #132. When adding guards to protect against `alchemlyb` being missing on various platforms, I had accidentally duplicated the logic from `Process.Amber` into `Process.Gromacs`, meaning that the _wrong_ extract function was imported.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods