### PR TITLE
Fix issue #134

### DIFF
--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -345,7 +345,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
             self.addToConfig(
                 f"simulation.minimizeEnergy(maxIterations={self._protocol.getSteps()})"
@@ -452,7 +455,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
 
             # Set initial velocities from temperature distribution.
@@ -633,7 +639,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
 
             # Set initial velocities from temperature distribution.
@@ -1006,7 +1015,10 @@ class OpenMM(_process.Process):
             self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
 
             # Set initial velocities from temperature distribution.
@@ -1922,6 +1934,9 @@ class OpenMM(_process.Process):
         self.addToConfig("from openmm import *")
         self.addToConfig("from openmm.app import *")
         self.addToConfig("from openmm.unit import *")
+        self.addToConfig(
+            "from openmm.app.internal.unitcell import reducePeriodicBoxVectors"
+        )
         self.addToConfig("import parmed")
 
     def _add_config_platform(self):

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -346,7 +346,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
             self.addToConfig(
                 f"simulation.minimizeEnergy(maxIterations={self._protocol.getSteps()})"
@@ -448,7 +451,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
 
             # Set initial velocities from temperature distribution.
@@ -624,7 +630,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
 
             # Set initial velocities from temperature distribution.
@@ -1006,7 +1015,10 @@ class OpenMM(_process.Process):
                 self.addToConfig("simulation.context.setPositions(prm.positions)")
             self.addToConfig("if prm.box_vectors is not None:")
             self.addToConfig(
-                "    simulation.context.setPeriodicBoxVectors(*prm.box_vectors)"
+                "    box_vectors = reducePeriodicBoxVectors(prm.box_vectors)"
+            )
+            self.addToConfig(
+                "    simulation.context.setPeriodicBoxVectors(*box_vectors)"
             )
 
             # Set initial velocities from temperature distribution.
@@ -1922,6 +1934,9 @@ class OpenMM(_process.Process):
         self.addToConfig("from openmm import *")
         self.addToConfig("from openmm.app import *")
         self.addToConfig("from openmm.unit import *")
+        self.addToConfig(
+            "from openmm.app.internal.unitcell import reducePeriodicBoxVectors"
+        )
         self.addToConfig("import parmed")
 
     def _add_config_platform(self):

--- a/tests/Process/test_openmm.py
+++ b/tests/Process/test_openmm.py
@@ -102,6 +102,21 @@ def test_rhombic_dodecahedron():
     run_process(solvated, protocol)
 
 
+def test_parmed_triclinic():
+    """Test the workaround for fixing ParmEd triclinic lattice reduction."""
+
+    # Load the test system.
+    system = BSS.IO.readMolecules(
+        BSS.IO.expand(url, ["parmed_issue.rst7", "parmed_issue.prm7"])
+    )
+
+    # Create a short minimisation protocol.
+    protocol = BSS.Protocol.Minimisation(steps=100)
+
+    # Run the process, check that it finished without error, and returns a system.
+    run_process(system, protocol)
+
+
 def run_process(system, protocol):
     """Helper function to run various simulation protocols."""
 

--- a/tests/Sandpit/Exscientia/Process/test_openmm.py
+++ b/tests/Sandpit/Exscientia/Process/test_openmm.py
@@ -151,6 +151,21 @@ def test_rhombic_dodecahedron():
     run_process(solvated, protocol)
 
 
+def test_parmed_triclinic():
+    """Test the workaround for fixing ParmEd triclinic lattice reduction."""
+
+    # Load the test system.
+    system = BSS.IO.readMolecules(
+        BSS.IO.expand(url, ["parmed_issue.rst7", "parmed_issue.prm7"])
+    )
+
+    # Create a short minimisation protocol.
+    protocol = BSS.Protocol.Minimisation(steps=100)
+
+    # Run the process, check that it finished without error, and returns a system.
+    run_process(system, protocol)
+
+
 def run_process(system, protocol, restraint="none", tolerance=0.05):
     """Helper function to run various simulation protocols.
 


### PR DESCRIPTION
This PR closes #134. To work around rounding issues with triclinic box vectors following conversion from dimensions and angles we now perform a pre lattice reduction using the internal OpenMM functionality. This isn't needed when using the native OpenMM AMBER format parsers, so can be removed once the fix related to [this](https://github.com/OpenBioSim/biosimspace/issues/76) previous issue has made its way into a conda-forge release of OpenMM.

Note that a single test may fail for macOS py311. This is due to a precision issue, which has been adjusted in #132.

As before, the code duplication here is because the OpenMM protocols are currently (mostly) independent as we work out the best options for each. This will be refactored once we port to `BioSimSpace._Config`. (We might just use the native Sire conversion, so do away with this entirely.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods