### PR TITLE
Fix issue #145

### DIFF
--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -2083,6 +2083,11 @@ class OpenMM(_process.Process):
             is_time = True
             is_temperature = True
 
+        # Work out the total number of steps.
+        total_steps = _math.ceil(
+            self._protocol.getRunTime() / self._protocol.getTimeStep()
+        )
+
         # Write state information to file every 100 steps.
         self.addToConfig(f"log_file = open('{self._name}.log', 'a')")
         self.addToConfig(f"simulation.reporters.append(StateDataReporter(log_file,")
@@ -2109,7 +2114,7 @@ class OpenMM(_process.Process):
         )
         self.addToConfig("                                              volume=True,")
         self.addToConfig(
-            "                                              totalSteps=True,"
+            f"                                              totalSteps={total_steps},"
         )
         self.addToConfig("                                              speed=True,")
         self.addToConfig(

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -2084,9 +2084,12 @@ class OpenMM(_process.Process):
             is_temperature = True
 
         # Work out the total number of steps.
-        total_steps = _math.ceil(
-            self._protocol.getRunTime() / self._protocol.getTimeStep()
-        )
+        if isinstance(self._protocol, _Protocol.Minimisation):
+            total_steps = None
+        else:
+            total_steps = _math.ceil(
+                self._protocol.getRunTime() / self._protocol.getTimeStep()
+            )
 
         # Write state information to file every 100 steps.
         self.addToConfig(f"log_file = open('{self._name}.log', 'a')")

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -2085,7 +2085,7 @@ class OpenMM(_process.Process):
 
         # Work out the total number of steps.
         if isinstance(self._protocol, _Protocol.Minimisation):
-            total_steps = None
+            total_steps = 1
         else:
             total_steps = _math.ceil(
                 self._protocol.getRunTime() / self._protocol.getTimeStep()

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -2123,6 +2123,11 @@ class OpenMM(_process.Process):
             is_time = True
             is_temperature = True
 
+        # Work out the total number of steps.
+        total_steps = _math.ceil(
+            self._protocol.getRunTime() / self._protocol.getTimeStep()
+        )
+
         # Write state information to file every 100 steps.
         self.addToConfig(f"log_file = open('{self._name}.log', 'a')")
         self.addToConfig(f"simulation.reporters.append(StateDataReporter(log_file,")
@@ -2149,7 +2154,7 @@ class OpenMM(_process.Process):
         )
         self.addToConfig("                                              volume=True,")
         self.addToConfig(
-            "                                              totalSteps=True,"
+            f"                                              totalSteps={total_steps},"
         )
         self.addToConfig("                                              speed=True,")
         self.addToConfig(

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -2125,7 +2125,7 @@ class OpenMM(_process.Process):
 
         # Work out the total number of steps.
         if isinstance(self._protocol, _Protocol.Minimisation):
-            total_steps = None
+            total_steps = 1
         else:
             total_steps = _math.ceil(
                 self._protocol.getRunTime() / self._protocol.getTimeStep()

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -2124,9 +2124,12 @@ class OpenMM(_process.Process):
             is_temperature = True
 
         # Work out the total number of steps.
-        total_steps = _math.ceil(
-            self._protocol.getRunTime() / self._protocol.getTimeStep()
-        )
+        if isinstance(self._protocol, _Protocol.Minimisation):
+            total_steps = None
+        else:
+            total_steps = _math.ceil(
+                self._protocol.getRunTime() / self._protocol.getTimeStep()
+            )
 
         # Write state information to file every 100 steps.
         self.addToConfig(f"log_file = open('{self._name}.log', 'a')")


### PR DESCRIPTION
This PR closes #145 and closes #145. It fixes the use of the `totalSteps` parameter within the OpenMM `StateDataReporter`. Previously a boolean was passed (which was silently ignored). We actually need to pass an integer that specifies the total number of simulation steps. This allows the reporter to correctly report things like the remaining simulation time, or the progress percentage.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods