### PR TITLE
Fix issue #150

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -30,11 +30,9 @@ __email__ = "finlay.clark@ed.ac.uk"
 __all__ = ["RestraintSearch"]
 
 import matplotlib.pyplot as _plt
-import MDAnalysis as _mda
 import numpy as _np
 import os as _os
 from scipy.stats import circmean as _circmean
-import sys as _sys
 import warnings as _warnings
 
 from sire.legacy.Base import getBinDir as _getBinDir
@@ -99,24 +97,6 @@ if _have_imported(_MDRestraintsGenerator):
     )
 
 is_MDRestraintsGenerator = _have_imported(_MDRestraintsGenerator)
-
-# Check that the analyse_freenrg script exists.
-if _sys.platform != "win32":
-    _analyse_freenrg = _os.path.join(_getBinDir(), "analyse_freenrg")
-else:
-    _analyse_freenrg = _os.path.join(
-        _os.path.normpath(_getShareDir()), "scripts", "analyse_freenrg.py"
-    )
-if not _os.path.isfile(_analyse_freenrg):
-    raise _MissingSoftwareError(
-        "Cannot find free energy analysis script in expected location: '%s'"
-        % _analyse_freenrg
-    )
-if _sys.platform == "win32":
-    _analyse_freenrg = "%s %s" % (
-        _os.path.join(_os.path.normpath(_getBinDir()), "sire_python.exe"),
-        _analyse_freenrg,
-    )
 
 
 class RestraintSearch:


### PR DESCRIPTION
This PR closes #150. It removes a few redundant imports and attributes from the `BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py` module. Importantly, it removes a _direct_ import of `MDAnalysis`, which won't work on certain platforms where the package is unavailable.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@fjclark 