### PR TITLE
Add support for computing trajectory RMSDs using Sire

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -937,11 +937,26 @@ class Trajectory:
             # Check that all of the atom indices are integers.
             if not all(type(x) is int for x in atoms):
                 raise TypeError("'atom' indices must be of type 'int'")
+            # Make sure the atom index is within range.
+            num_atoms = self.getFrames()[0].nAtoms()
+            for atom in atoms:
+                if atom < 0 or atom >= num_atoms:
+                    raise ValueError(
+                        f"Atom index {atom} out of range [0, {num_atoms})."
+                    )
 
         if self._backend == "SIRE":
-            raise _IncompatibleError(
-                "RMSD currently isn't supported using the Sire backend."
-            )
+            # Get the reference.
+            if atoms is not None:
+                reference = self._trajectory.current().atoms()[atoms]
+            else:
+                reference = None
+
+            # Compute the RMSD.
+            rmsd = self._trajectory.rmsd(reference=reference, frame=frame)
+
+            # Convert to BioSimSpace units.
+            rmsd = [(_Units.Length.angstrom * x.value()).nanometers() for x in rmsd]
 
         elif self._backend == "MDTRAJ":
             try:

--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -54,6 +54,9 @@ from .. import IO as _IO
 from .. import Units as _Units
 from .. import _Utils
 
+if _have_imported(_mdanalysis):
+    _mdanalysis.stop_logging()
+
 
 def backends():
     """

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -30,6 +30,7 @@ from .._Utils import _try_import, _have_imported
 
 _mdanalysis = _try_import("MDAnalysis")
 _mdtraj = _try_import("mdtraj")
+
 import copy as _copy
 import logging as _logging
 import os as _os
@@ -53,6 +54,9 @@ from ..Types import Time as _Time
 from .. import IO as _IO
 from .. import Units as _Units
 from .. import _Utils
+
+if _have_imported(_mdanalysis):
+    _mdanalysis.stop_logging()
 
 
 def backends():

--- a/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
+++ b/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
@@ -165,6 +165,5 @@ def test_rmsd(traj_sire, traj_mdtraj, traj_mdanalysis):
 
     # Make sure the values are approximately the same.
     for v0, v1, v2 in zip(rmsd0, rmsd1, rmsd2):
-        print(v0, v1, v2)
         assert v0.value() == pytest.approx(v1.value(), abs=1e-2)
         assert v0.value() == pytest.approx(v2.value(), abs=1e-2)

--- a/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
+++ b/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
@@ -151,14 +151,20 @@ def test_velocities(traj_mdanalysis):
     has_mdanalysis is False or has_mdtraj is False,
     reason="Requires MDAnalysis and mdtraj to be installed.",
 )
-def test_rmsd(traj_mdtraj, traj_mdanalysis):
-    """Make sure that the RMSD computed by both backends is comparable."""
+def test_rmsd(traj_sire, traj_mdtraj, traj_mdanalysis):
+    """Make sure that the RMSD computed by all backends are comparable."""
+
+    # List of reference atoms spanning multiple molecules.
+    atoms = [0, 10, 20, 30, 40]
 
     # Compute the RMSD for a subset of atoms using the third frame
     # as a reference.
-    rmsd0 = traj_mdtraj.rmsd(frame=3, atoms=[0, 10, 20, 30, 40])
-    rmsd1 = traj_mdanalysis.rmsd(frame=3, atoms=[0, 10, 20, 30, 40])
+    rmsd0 = traj_sire.rmsd(frame=0, atoms=atoms)
+    rmsd1 = traj_mdtraj.rmsd(frame=0, atoms=atoms)
+    rmsd2 = traj_mdanalysis.rmsd(frame=0, atoms=atoms)
 
     # Make sure the values are approximately the same.
-    for v0, v1 in zip(rmsd0, rmsd1):
+    for v0, v1, v2 in zip(rmsd0, rmsd1, rmsd2):
+        print(v0, v1, v2)
         assert v0.value() == pytest.approx(v1.value(), abs=1e-2)
+        assert v0.value() == pytest.approx(v2.value(), abs=1e-2)

--- a/tests/Trajectory/test_trajectory.py
+++ b/tests/Trajectory/test_trajectory.py
@@ -24,7 +24,7 @@ def traj_sire(system):
     """A trajectory object using the Sire backend."""
     return BSS.Trajectory.Trajectory(
         trajectory="tests/input/ala.trr",
-        topology="tests/input/ala.top",
+        topology="tests/input/ala.gro",
         system=system,
         backend="SIRE",
     )
@@ -154,8 +154,8 @@ def test_velocities(traj_mdanalysis):
 def test_rmsd(traj_sire, traj_mdtraj, traj_mdanalysis):
     """Make sure that the RMSD computed by all backends are comparable."""
 
-    # List of reference atoms.
-    atoms = list(range(22))
+    # List of reference atoms spanning multiple molecules.
+    atoms = [0, 10, 20, 30, 40]
 
     # Compute the RMSD for a subset of atoms using the third frame
     # as a reference.

--- a/tests/Trajectory/test_trajectory.py
+++ b/tests/Trajectory/test_trajectory.py
@@ -24,7 +24,7 @@ def traj_sire(system):
     """A trajectory object using the Sire backend."""
     return BSS.Trajectory.Trajectory(
         trajectory="tests/input/ala.trr",
-        topology="tests/input/ala.gro",
+        topology="tests/input/ala.top",
         system=system,
         backend="SIRE",
     )
@@ -151,14 +151,20 @@ def test_velocities(traj_mdanalysis):
     has_mdanalysis is False or has_mdtraj is False,
     reason="Requires MDAnalysis and mdtraj to be installed.",
 )
-def test_rmsd(traj_mdtraj, traj_mdanalysis):
-    """Make sure that the RMSD computed by both backends is comparable."""
+def test_rmsd(traj_sire, traj_mdtraj, traj_mdanalysis):
+    """Make sure that the RMSD computed by all backends are comparable."""
+
+    # List of reference atoms.
+    atoms = list(range(22))
 
     # Compute the RMSD for a subset of atoms using the third frame
     # as a reference.
-    rmsd0 = traj_mdtraj.rmsd(frame=3, atoms=[0, 10, 20, 30, 40])
-    rmsd1 = traj_mdanalysis.rmsd(frame=3, atoms=[0, 10, 20, 30, 40])
+    rmsd0 = traj_sire.rmsd(frame=0, atoms=atoms)
+    rmsd1 = traj_mdtraj.rmsd(frame=0, atoms=atoms)
+    rmsd2 = traj_mdanalysis.rmsd(frame=0, atoms=atoms)
 
     # Make sure the values are approximately the same.
-    for v0, v1 in zip(rmsd0, rmsd1):
+    for v0, v1, v2 in zip(rmsd0, rmsd1, rmsd2):
+        print(v0, v1, v2)
         assert v0.value() == pytest.approx(v1.value(), abs=1e-2)
+        assert v0.value() == pytest.approx(v2.value(), abs=1e-2)

--- a/tests/Trajectory/test_trajectory.py
+++ b/tests/Trajectory/test_trajectory.py
@@ -165,6 +165,5 @@ def test_rmsd(traj_sire, traj_mdtraj, traj_mdanalysis):
 
     # Make sure the values are approximately the same.
     for v0, v1, v2 in zip(rmsd0, rmsd1, rmsd2):
-        print(v0, v1, v2)
         assert v0.value() == pytest.approx(v1.value(), abs=1e-2)
         assert v0.value() == pytest.approx(v2.value(), abs=1e-2)


### PR DESCRIPTION
This PR exposes the new Sire trajectory alignment and RMSD functionality, making the Sire trajectory backend _fully_ compatible with the existing MDAnalysis and MDTraj interfaces.

This PR requires OpenBioSIm/Sire#97. I'll cancel the CI and re-trigger once that PR has been merged.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y] (Already documented via existing API and website docs.)
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods