### PR TITLE
Add support for crystal waters

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,9 @@ Steps to reproduce the behavior:
 2. Run the code '...'
 3. This is the exception that was raised / this is what went wrong.
 
+(If possible, please quote code snippets using the markdown formatting
+described [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code). This makes it easy to copy and paste the example, avoiding any translation errors.)
+
 **Expected behavior**
 A clear and concise description of what you expected to happen
 (or, it should not raise an exception if an exception was raised)

--- a/doc/source/tutorials/crystal_water.rst
+++ b/doc/source/tutorials/crystal_water.rst
@@ -1,0 +1,135 @@
+.. _ref_crystal_water:
+=============
+Crystal water
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+Water molecules are important for the structure, function, and dynamics of
+proteins. When setting up a simulation it may be important to preserve
+specific water molecules, often referred to as *crystal waters*. For example,
+many structures from the `Protein Data Bank <https://www.rcsb.org/>`__
+contain the coordinates of water molecules that are resolvable via X-ray
+crystallography. In this example, we will use BioSimSpace to parameterise
+and solvate a `tyrosine kinase 2 <https://en.wikipedia.org/wiki/Tyrosine_kinase_2>`__
+protein structure containing two crystal waters within its binding site.
+
+Firstly, let's load the PDB structure:
+
+>>> import BioSimSpace as BSS
+>>> tyk2_xtal = BSS.IO.readMolecules(
+...    BSS.IO.expand(
+...        BSS.IO.tutorialUrl(), "tyk2_xtal.pdb"
+...    )
+...)[0]
+
+This is a single molecule that contains the oxgyen atoms of two crystal waters
+at the end of the structure:
+
+>>> for residue in tyk2_xtal.getResidues()[-2:]:
+...     for atom in residue:
+...         print(atom, atom.coordinates())
+...
+<BioSimSpace.Atom: name='O', molecule=2, index=4652> (-4.5180 A, -0.0520 A, -15.6070 A)
+<BioSimSpace.Atom: name='O', molecule=2, index=4653> (-7.2040 A, -8.5540 A, -20.7520 A)
+
+We can use BioSimSpace to search for and extract the protein and water
+components of the system. In this case, the waters are part of a residue
+named ``WAT``, so we can use this as our search term:
+
+>>> tyk2 = tyk2_xtal.extract(
+...    [atom.index() for atom in tyk2_xtal.search("not resname WAT").atoms()]
+... )
+>>> xtal_water = tyk2_xtal.extract(
+...    [atom.index() for atom in tyk2_xtal.search("resname WAT").atoms()]
+... )
+
+Now we have the components, we can parameterise them individually. First the
+protein:
+
+>>> tyk2 = BSS.Parameters.ff14SB(tyk2).getMolecule()
+
+And then the water:
+
+>>> xtal_water = BSS.Parameters.tip3p(
+...     xtal_water,
+...     water_model="tip3p",
+...     ensure_compatible=False
+... ).getMolecule()
+
+In this case we need to specify the desired water model, and also that we don't
+want to ensure that the parameterised molecule is compatible with the topology
+of the molecule that we passed in. This is because we are only passing in
+oxygen atoms, so ``tLEaP`` will add the missing hydrogens.
+
+.. note ::
+
+   By default, BioSimSpace ensures that the topology of the parameterised molecule(s)
+   matches that of the input molecule and will raise an exception if this is not
+   the case. This is because the input system is often required as a reference by
+   the user, e.g. they might want to preserve a specific naming convention, chain
+   identifiers, etc.
+
+Let's check one of the parameterised crystal waters:
+
+>>> for atom in xtal_water[0].getAtoms():
+...     print(atom, atom.coordinates())
+...
+<BioSimSpace.Atom: name='O', molecule=9, index=0> (-4.5180 A, -0.0520 A, -15.6070 A)
+<BioSimSpace.Atom: name='H1', molecule=9, index=1> (-3.5608 A, -0.0520 A, -15.6070 A)
+<BioSimSpace.Atom: name='H2', molecule=9, index=2> (-4.7580 A, 0.8746 A, -15.6070 A)
+
+Note that the coordinates of the oxygen atom are preserved.
+
+Once both components are parameterised, we can combine them together to create
+a new system:
+
+>>> system = tyk2.toSystem() + xtal_water
+
+The next step in our setup procedure is to solvate the system in a water box.
+Here we will use a truncated octahedral box with a base length of 7 nanometers:
+
+>>> box, angles = BSS.Box.truncatedOctahedron(7 * BSS.Units.Length.nanometer)
+>>> solvated = BSS.Solvent.tip3p(system, box=box, angles=angles)
+
+Since the protein is charged, during the solvation process ``gmx genion`` will
+have been used to neutralise the solvated system by adding counter ions. We can
+check this as follows:
+
+>>> print(system.charge(), solvated.charge())
+... -2.0000 |e| -1.5091e-07 |e|
+>>> print(len(solvated.search("element Na")))
+... 2
+
+In this case, two sodium ions have been added to neutralise the system. In
+doing so, ``gmx genion`` will have removed two *random* water molecules. In
+order to ensure that crystal waters are not removed, we temporarily tag them
+with a unique residue and molecule name during solvation.
+
+To check that they are preserved we can re-solvate the system, asking to
+preserve the water naming for the existing waters in the system. (By default,
+they will be updated to the default ``GROMACS`` naming convention.)
+
+>>> solvated_no_match = BSS.Solvent.tip3p(
+...     system,
+...     box=box,
+...     angles=angles,
+...     match_water=False
+... )
+
+We can check that the crystal waters are still present as follows:
+
+>>> for residue in solvated_no_match.getWaterMolecules().toSystem().search("resname WAT").residues():
+...     print(residue)
+<BioSimSpace.Residue: name='WAT', molecule=8, index=0, nAtoms=3>
+<BioSimSpace.Residue: name='WAT', molecule=9, index=0, nAtoms=3>
+
+.. note ::
+
+   When solvating, molecules in the original system will be centered within the
+   solvation box, hence the coordinates of the crystal waters after solvation
+   won't necessarily match those from before. By setting ``match_water=False``,
+   it is possible to preserve the naming convention used for any existing
+   waters in the system. However, note that some simulation engines rely on a
+   specific naming convention for water molecules and a single solvent group.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -20,5 +20,6 @@ please :doc:`ask for support. <../support>`
 .. toctree::
    :maxdepth: 1
 
+   crystal_water
    hydration_freenrg
    metadynamics

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -85,6 +85,7 @@ def check_cache(
     system,
     format,
     filebase,
+    match_water=True,
     property_map={},
     excluded_properties=[],
     skip_water=True,
@@ -104,6 +105,12 @@ def check_cache(
 
     filebase : str
         The file base to copy the file to.
+
+    match_water : bool
+        Whether to update the naming of water molecules to match the expected
+        convention for the chosen file format. This is useful when a system
+        is being saved to a different file format to that from which it was
+        loaded.
 
     property_map : dict
         A dictionary that maps system "properties" to their user
@@ -135,6 +142,9 @@ def check_cache(
     if not isinstance(filebase, str):
         raise TypeError("'filebase' must be of type 'str'")
 
+    if not isinstance(match_water, bool):
+        raise TypeError("'match_water' must be of type 'bool'")
+
     if not isinstance(excluded_properties, (list, tuple)):
         raise TypeError("'excluded_properties' must be a list of 'str' types.")
 
@@ -153,6 +163,7 @@ def check_cache(
         format,
         _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
+        str(match_water),
         str(skip_water),
     )
 
@@ -211,7 +222,13 @@ def check_cache(
 
 
 def update_cache(
-    system, format, path, excluded_properties=[], skip_water=True, **kwargs
+    system,
+    format,
+    path,
+    excluded_properties=[],
+    match_water=True,
+    skip_water=True,
+    **kwargs,
 ):
     """
     Update the file cache when a new system is written to a specified format.
@@ -230,6 +247,12 @@ def update_cache(
 
     excluded_properties : [str]
         A list of properties to exclude when comparing systems when checking
+
+    match_water : bool
+        Whether to update the naming of water molecules to match the expected
+        convention for the chosen file format. This is useful when a system
+        is being saved to a different file format to that from which it was
+        loaded.
 
     skip_water : bool
         Whether to skip water molecules when comparing systems.
@@ -255,6 +278,9 @@ def update_cache(
     if not all(isinstance(x, str) for x in excluded_properties):
         raise TypeError("'excluded_properties' must be a list of 'str' types.")
 
+    if not isinstance(match_water, bool):
+        raise TypeError("'match_water' must be of type 'bool'")
+
     if not isinstance(skip_water, bool):
         raise TypeError("'skip_water' must be of type 'bool'.")
 
@@ -270,6 +296,7 @@ def update_cache(
         format,
         _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
+        str(match_water),
         str(skip_water),
     )
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -742,10 +742,8 @@ def saveMolecules(
                         "GROMACS", property_map=_property_map
                     )
                 else:
-                    system_copy = system.copy()
-                    system_copy._sire_object.setProperty(
-                        "skip_water", _SireBase.wrap(True)
-                    )
+                    system_copy = system
+                    _property_map["skip_water"] = _SireBase.wrap(True)
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )[0]
@@ -760,6 +758,7 @@ def saveMolecules(
                     )
                 else:
                     system_copy = system
+                    _property_map["skip_water"] = _SireBase.wrap(True)
                 # Write to 3dp by default, unless greater precision is
                 # requested by the user.
                 if "precision" not in _property_map:

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -687,6 +687,7 @@ def saveMolecules(
             system,
             format,
             filebase,
+            match_water=match_water,
             property_map=property_map,
             **kwargs,
         )
@@ -728,7 +729,7 @@ def saveMolecules(
             if format.upper() == "PRM7":
                 if match_water:
                     system_copy = system.copy()
-                    system_copy._set_water_topology("AMBER", _property_map)
+                    system_copy._set_water_topology("AMBER", property_map=_property_map)
                 else:
                     system_copy = system
                 file = _SireIO.MoleculeParser.save(
@@ -737,9 +738,14 @@ def saveMolecules(
             elif format.upper() == "GROTOP":
                 if match_water:
                     system_copy = system.copy()
-                    system_copy._set_water_topology("GROMACS", _property_map)
+                    system_copy._set_water_topology(
+                        "GROMACS", property_map=_property_map
+                    )
                 else:
-                    system_copy = system
+                    system_copy = system.copy()
+                    system_copy._sire_object.setProperty(
+                        "skip_water", _SireBase.wrap(True)
+                    )
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )[0]
@@ -749,7 +755,9 @@ def saveMolecules(
             elif format.upper() == "GRO87":
                 if match_water:
                     system_copy = system.copy()
-                    system_copy._set_water_topology("GROMACS", _property_map)
+                    system_copy._set_water_topology(
+                        "GROMACS", property_map=_property_map
+                    )
                 else:
                     system_copy = system
                 # Write to 3dp by default, unless greater precision is
@@ -770,7 +778,7 @@ def saveMolecules(
             files += file
 
             # If this is a new file, then add it to the cache.
-            _update_cache(system, format, file[0], **kwargs)
+            _update_cache(system, format, file[0], match_water=match_water, **kwargs)
 
         except Exception as e:
             msg = "Failed to save system to format: '%s'" % format

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -378,7 +378,15 @@ class AmberProtein(_protocol.Protocol):
                     verbose=False,
                 )
             else:
-                new_mol = par_mol
+                try:
+                    new_mol.makeCompatibleWith(
+                        par_mol,
+                        property_map=self._property_map,
+                        overwrite=True,
+                        verbose=False,
+                    )
+                except:
+                    new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield
@@ -1232,7 +1240,15 @@ class GAFF(_protocol.Protocol):
                                 verbose=False,
                             )
                         else:
-                            new_mol = par_mol
+                            try:
+                                new_mol.makeCompatibleWith(
+                                    par_mol,
+                                    property_map=self._property_map,
+                                    overwrite=True,
+                                    verbose=False,
+                                )
+                            except:
+                                new_mol = par_mol
 
                     # Record the forcefield used to parameterise the molecule.
                     new_mol._forcefield = ff

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -124,6 +124,7 @@ class AmberProtein(_protocol.Protocol):
         water_model=None,
         leap_commands=None,
         bonds=None,
+        ensure_compatible=True,
         property_map={},
     ):
         """
@@ -164,6 +165,15 @@ class AmberProtein(_protocol.Protocol):
             should be bonded. This is useful when the PDB CONECT record is
             incomplete.
 
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules. When True, the parameterised
+            molecule will preserve the topology of the original molecule, e.g.
+            the original atom and residue names will be kept.
+
         property_map : dict
             A dictionary that maps system "properties" to their user defined
             values. This allows the user to refer to properties with their
@@ -171,7 +181,11 @@ class AmberProtein(_protocol.Protocol):
         """
 
         # Call the base class constructor.
-        super().__init__(forcefield=forcefield, property_map=property_map)
+        super().__init__(
+            forcefield=forcefield,
+            ensure_compatible=ensure_compatible,
+            property_map=property_map,
+        )
 
         # Validate the pdb2gmx compatibility flag.
         if not isinstance(pdb2gmx, bool):
@@ -356,9 +370,15 @@ class AmberProtein(_protocol.Protocol):
             new_mol._sire_object = edit_mol.commit()
 
         else:
-            new_mol.makeCompatibleWith(
-                par_mol, property_map=self._property_map, overwrite=True, verbose=False
-            )
+            if self._ensure_compatible:
+                new_mol.makeCompatibleWith(
+                    par_mol,
+                    property_map=self._property_map,
+                    overwrite=True,
+                    verbose=False,
+                )
+            else:
+                new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield
@@ -503,13 +523,14 @@ class AmberProtein(_protocol.Protocol):
             prefix + "leap.crd"
         ):
             # Check the output of tLEaP for missing atoms.
-            if _has_missing_atoms(prefix + "leap.out"):
-                raise _ParameterisationError(
-                    "tLEaP added missing atoms. The topology is now "
-                    "inconsistent with the original molecule. Please "
-                    "make sure that your initial molecule has a "
-                    "complete topology."
-                )
+            if self._ensure_compatible:
+                if _has_missing_atoms(prefix + "leap.out"):
+                    raise _ParameterisationError(
+                        "tLEaP added missing atoms. The topology is now "
+                        "inconsistent with the original molecule. Please "
+                        "make sure that your initial molecule has a "
+                        "complete topology."
+                    )
             return ["leap.top", "leap.crd"]
         else:
             raise _ParameterisationError("tLEaP failed!")
@@ -825,7 +846,14 @@ class GAFF(_protocol.Protocol):
     # A list of supported charge methods.
     _charge_methods = ["RESP", "CM2", "MUL", "BCC", "ESP", "GAS"]
 
-    def __init__(self, version, charge_method="BCC", net_charge=None, property_map={}):
+    def __init__(
+        self,
+        version,
+        charge_method="BCC",
+        net_charge=None,
+        ensure_compatible=True,
+        property_map={},
+    ):
         """
         Constructor.
 
@@ -841,6 +869,17 @@ class GAFF(_protocol.Protocol):
 
         net_charge : int
             The net charge on the molecule.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. When
+            True, the parameterised molecule will preserve the topology of the
+            original molecule, e.g. the original atom and residue names will be
+            kept.
+
+            property_map : dict
+            A dictionary that maps system "properties" to their user defined
 
         property_map : dict
             A dictionary that maps system "properties" to their user defined
@@ -895,7 +934,11 @@ class GAFF(_protocol.Protocol):
         self._charge_method = charge_method
 
         # Call the base class constructor.
-        super().__init__(forcefield="gaff", property_map=property_map)
+        super().__init__(
+            forcefield="gaff",
+            ensure_compatible=ensure_compatible,
+            property_map=property_map,
+        )
 
     def run(self, molecule, work_dir=None, queue=None):
         """
@@ -1131,13 +1174,14 @@ class GAFF(_protocol.Protocol):
                     prefix + "leap.crd"
                 ):
                     # Check the output of tLEaP for missing atoms.
-                    if _has_missing_atoms(prefix + "leap.out"):
-                        raise _ParameterisationError(
-                            "tLEaP added missing atoms. The topology is now "
-                            "inconsistent with the original molecule. Please "
-                            "make sure that your initial molecule has a "
-                            "complete topology."
-                        )
+                    if self._ensure_compatible:
+                        if _has_missing_atoms(prefix + "leap.out"):
+                            raise _ParameterisationError(
+                                "tLEaP added missing atoms. The topology is now "
+                                "inconsistent with the original molecule. Please "
+                                "make sure that your initial molecule has a "
+                                "complete topology."
+                            )
 
                     # Load the parameterised molecule. (This could be a system of molecules.)
                     try:
@@ -1180,12 +1224,15 @@ class GAFF(_protocol.Protocol):
                         new_mol._sire_object = edit_mol.commit()
 
                     else:
-                        new_mol.makeCompatibleWith(
-                            par_mol,
-                            property_map=self._property_map,
-                            overwrite=True,
-                            verbose=False,
-                        )
+                        if self._ensure_compatible:
+                            new_mol.makeCompatibleWith(
+                                par_mol,
+                                property_map=self._property_map,
+                                overwrite=True,
+                                verbose=False,
+                            )
+                        else:
+                            new_mol = par_mol
 
                     # Record the forcefield used to parameterise the molecule.
                     new_mol._forcefield = ff

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -105,7 +105,7 @@ from . import _protocol
 class OpenForceField(_protocol.Protocol):
     """A class for handling protocols for Open Force Field models."""
 
-    def __init__(self, forcefield, property_map={}):
+    def __init__(self, forcefield, ensure_compatible=True, property_map={}):
         """
         Constructor.
 
@@ -115,6 +115,14 @@ class OpenForceField(_protocol.Protocol):
         forcefield : str
             The name of the force field.
 
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. When
+            True, the parameterised molecule will preserve the topology of the
+            original molecule, e.g. the original atom and residue names will be
+            kept.
+
         property_map : dict
             A dictionary that maps system "properties" to their user defined
             values. This allows the user to refer to properties with their
@@ -122,7 +130,11 @@ class OpenForceField(_protocol.Protocol):
         """
 
         # Call the base class constructor.
-        super().__init__(forcefield=forcefield, property_map=property_map)
+        super().__init__(
+            forcefield=forcefield,
+            ensure_compatible=ensure_compatible,
+            property_map=property_map,
+        )
 
         # Set the compatibility flags.
         self._tleap = False
@@ -373,10 +385,16 @@ class OpenForceField(_protocol.Protocol):
             new_mol._sire_object = edit_mol.commit()
 
         else:
-            new_mol = molecule.copy()
-            new_mol.makeCompatibleWith(
-                par_mol, property_map=self._property_map, overwrite=True, verbose=False
-            )
+            if self._ensure_compatible:
+                new_mol = molecule.copy()
+                new_mol.makeCompatibleWith(
+                    par_mol,
+                    property_map=self._property_map,
+                    overwrite=True,
+                    verbose=False,
+                )
+            else:
+                new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -394,7 +394,15 @@ class OpenForceField(_protocol.Protocol):
                     verbose=False,
                 )
             else:
-                new_mol = par_mol
+                try:
+                    new_mol.makeCompatibleWith(
+                        par_mol,
+                        property_map=self._property_map,
+                        overwrite=True,
+                        verbose=False,
+                    )
+                except:
+                    new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield

--- a/python/BioSimSpace/Parameters/_Protocol/_protocol.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_protocol.py
@@ -33,7 +33,7 @@ __all__ = ["Protocol"]
 class Protocol:
     """A base class for parameterisation protocols."""
 
-    def __init__(self, forcefield, property_map={}):
+    def __init__(self, forcefield, ensure_compatible=True, property_map={}):
         """
         Constructor.
 
@@ -42,6 +42,13 @@ class Protocol:
 
         forcefield : str
             The name of the force field.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules.
 
         property_map : dict
             A dictionary that maps system "properties" to their user defined
@@ -58,6 +65,12 @@ class Protocol:
             raise TypeError("'forcefield' must be of type 'str'")
         else:
             self._forcefield = forcefield
+
+        # Validate and set the topology compatibilty flag.
+        if not isinstance(ensure_compatible, bool):
+            raise TypeError("'ensure_compatible' must be of type 'bool'")
+        else:
+            self._ensure_compatible = ensure_compatible
 
         # Validate and set the property map.
         if not isinstance(property_map, dict):

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -65,7 +65,14 @@ from ._process import Process as _Process
 from . import _Protocol
 
 
-def parameterise(molecule, forcefield, work_dir=None, property_map={}, **kwargs):
+def parameterise(
+    molecule,
+    forcefield,
+    ensure_compatible=True,
+    work_dir=None,
+    property_map={},
+    **kwargs,
+):
     """
     Parameterise a molecule using a specified force field.
 
@@ -79,6 +86,15 @@ def parameterise(molecule, forcefield, work_dir=None, property_map={}, **kwargs)
     forcefield : str
         The force field. Run BioSimSpace.Parameters.forceFields() to get a
         list of the supported force fields.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. Set
+        this to False is parameterising lone oxygen atoms corresponding to
+        structural (crystal) water molecules. When True, the parameterised
+        molecule will preserve the topology of the original molecule, e.g.
+        the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -121,6 +137,7 @@ def _parameterise_amber_protein(
     water_model=None,
     leap_commands=None,
     bonds=None,
+    ensure_compatible=True,
     work_dir=None,
     property_map={},
     **kwargs,
@@ -150,7 +167,9 @@ def _parameterise_amber_protein(
     water_model : str
         The water model used to parameterise any structural ions.
         Run 'BioSimSpace.Solvent.waterModels()' to see the supported
-        water models. This is ignored if ions are not present.
+        water models. This can also be used to parameterise water molecules,
+        or lone oxygen atoms corresponding to structural (crystal) water
+        molecules.
 
     leap_commands : [str]
         An optional list of extra commands for the LEaP program. These
@@ -161,6 +180,15 @@ def _parameterise_amber_protein(
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
         should be bonded.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. Set
+        this to False is parameterising lone oxygen atoms corresponding to
+        structural (crystal) water molecules. When True, the parameterised
+        molecule will preserve the topology of the original molecule, e.g.
+        the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -211,6 +239,7 @@ def _parameterise_amber_protein(
         check_ions=True,
         leap_commands=leap_commands,
         bonds=bonds,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -223,6 +252,7 @@ def _parameterise_amber_protein(
         max_distance=max_distance,
         leap_commands=leap_commands,
         bonds=bonds,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -236,6 +266,7 @@ def gaff(
     work_dir=None,
     net_charge=None,
     charge_method="BCC",
+    ensure_compatible=True,
     property_map={},
     **kwargs,
 ):
@@ -255,6 +286,13 @@ def gaff(
     charge_method : str
             The method to use when calculating atomic charges:
             "RESP", "CM2", "MUL", "BCC", "ESP", "GAS"
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. When True,
+        the parameterised molecule will preserve the topology of the original
+        molecule, e.g. the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -278,7 +316,12 @@ def gaff(
         )
 
     # Validate arguments.
-    _validate(molecule=molecule, check_ions=False, property_map=property_map)
+    _validate(
+        molecule=molecule,
+        check_ions=False,
+        ensure_compatible=ensure_compatible,
+        property_map=property_map,
+    )
 
     if net_charge is not None:
         # Get the value of the charge.
@@ -302,6 +345,7 @@ def gaff(
         version=1,
         net_charge=net_charge,
         charge_method=charge_method,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -315,6 +359,7 @@ def gaff2(
     work_dir=None,
     net_charge=None,
     charge_method="BCC",
+    ensure_compatible=True,
     property_map={},
     **kwargs,
 ):
@@ -334,6 +379,13 @@ def gaff2(
     charge_method : str
             The method to use when calculating atomic charges:
             "RESP", "CM2", "MUL", "BCC", "ESP", "GAS"
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. When True,
+        the parameterised molecule will preserve the topology of the original
+        molecule, e.g. the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -357,7 +409,12 @@ def gaff2(
         )
 
     # Validate arguments.
-    _validate(molecule=molecule, check_ions=False, property_map=property_map)
+    _validate(
+        molecule=molecule,
+        check_ions=False,
+        ensure_compatible=ensure_compatible,
+        property_map=property_map,
+    )
 
     if net_charge is not None:
         # Get the value of the charge.
@@ -384,6 +441,7 @@ def gaff2(
         version=2,
         net_charge=net_charge,
         charge_method=charge_method,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -393,7 +451,12 @@ def gaff2(
 
 
 def _parameterise_openff(
-    forcefield, molecule, work_dir=None, property_map={}, **kwargs
+    forcefield,
+    molecule,
+    ensure_compatible=True,
+    work_dir=None,
+    property_map={},
+    **kwargs,
 ):
     """
     Parameterise a molecule using a force field from the Open Force Field
@@ -409,6 +472,13 @@ def _parameterise_openff(
     molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, str
         The molecule to parameterise, either as a Molecule object or SMILES
         string.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. When True,
+        the parameterised molecule will preserve the topology of the original
+        molecule, e.g. the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -508,7 +578,9 @@ def _parameterise_openff(
         raise TypeError("'property_map' must be of type 'dict'")
 
     # Create a default protocol.
-    protocol = _Protocol.OpenForceField(forcefield, property_map=property_map)
+    protocol = _Protocol.OpenForceField(
+        forcefield, ensure_compatible=ensure_compatible, property_map=property_map
+    )
 
     # Run the parameterisation protocol in the background and return
     # a handle to the thread.
@@ -726,6 +798,7 @@ def _validate(
     check_ions=False,
     leap_commands=None,
     bonds=None,
+    ensure_compatible=True,
     work_dir=None,
     property_map=None,
 ):
@@ -751,7 +824,9 @@ def _validate(
     water_model : str
         The water model used to parameterise any structural ions.
         Run 'BioSimSpace.Solvent.waterModels()' to see the supported
-        water models. This is ignored if ions are not present.
+        water models. This can also be used to parameterise water molecules,
+        or lone oxygen atoms corresponding to structural (crystal) water
+        molecules.
 
     check_ions : bool
         Whether to check for the presence of structural ions. This is only
@@ -766,6 +841,15 @@ def _validate(
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
         should be bonded.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. Set this
+        to False is parameterising lone oxygen atoms corresponding to
+        structural (crystal) water molecules. When True, the parameterised
+        molecule will preserve the topology of the original molecule, e.g.
+        the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -853,6 +937,9 @@ def _validate(
                                 "Atoms in 'bonds' don't belong to the 'molecule'."
                             )
 
+    if not isinstance(ensure_compatible, bool):
+        raise TypeError("'ensure_compatible' must be of type 'bool'.")
+
     if property_map is not None:
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'")
@@ -876,6 +963,7 @@ def _make_amber_protein_function(name):
         water_model=None,
         leap_commands=None,
         bonds=None,
+        ensure_compatible=True,
         work_dir=None,
         property_map={},
     ):
@@ -901,7 +989,9 @@ def _make_amber_protein_function(name):
         water_model : str
             The water model used to parameterise any structural ions.
             Run 'BioSimSpace.Solvent.waterModels()' to see the supported
-            water models. This is ignored if ions are not present.
+            water models. This can also be used to parameterise water molecules,
+            or lone oxygen atoms corresponding to structural (crystal) water
+            molecules.
 
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These
@@ -912,6 +1002,15 @@ def _make_amber_protein_function(name):
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
             should be bonded.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules. When True, the parameterised
+            molecule will preserve the topology of the original molecule, e.g.
+            the original atom and residue names will be kept.
 
         work_dir : str
              The working directory for the process.
@@ -935,6 +1034,7 @@ def _make_amber_protein_function(name):
             water_model=water_model,
             leap_commands=leap_commands,
             bonds=bonds,
+            ensure_compatible=ensure_compatible,
             work_dir=work_dir,
             property_map=property_map,
         )
@@ -948,7 +1048,7 @@ def _make_amber_protein_function(name):
 # it conforms to sensible function naming standards, i.e. "-" and "."
 # characters replaced by underscores.
 def _make_openff_function(name):
-    def _function(molecule, work_dir=None, property_map={}):
+    def _function(molecule, ensure_compatible=True, work_dir=None, property_map={}):
         """
         Parameterise a molecule using the named force field from the
         Open Force Field initiative.
@@ -959,6 +1059,15 @@ def _make_openff_function(name):
         molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, str
             The molecule to parameterise, either as a Molecule object or SMILES
             string.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules. When True, the parameterised
+            molecule will preserve the topology of the original molecule, e.g.
+            the original atom and residue names will be kept.
 
         work_dir : str
             The working directory for the process.
@@ -974,7 +1083,13 @@ def _make_openff_function(name):
         molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
             The parameterised molecule.
         """
-        return _parameterise_openff(name, molecule, work_dir, property_map)
+        return _parameterise_openff(
+            name,
+            molecule,
+            ensure_compatible=ensure_compatible,
+            work_dir=work_dir,
+            property_map=property_map,
+        )
 
     return _function
 

--- a/python/BioSimSpace/Parameters/_process.py
+++ b/python/BioSimSpace/Parameters/_process.py
@@ -223,7 +223,16 @@ class Process:
 
             # Fix the charges so that the total is integer valued.
             if self._new_molecule is not None:
-                self._new_molecule._fixCharge(property_map=self._protocol._property_map)
+                # This is a single molecule.
+                try:
+                    self._new_molecule._fixCharge(
+                        property_map=self._protocol._property_map
+                    )
+                # This is a system object.
+                except:
+                    for mol in self._new_molecule:
+                        mol._fixCharge(property_map=self._protocol._property_map)
+                        self._new_molecule.updateMolecules(mol)
 
         # If there was an problem, return the last error.
         if self._is_error:

--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -193,7 +193,7 @@ class Amber(_process.Process):
         system = self._system.copy()
 
         # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
+        system._set_water_topology("AMBER", property_map=self._property_map)
 
         # Check for perturbable molecules and convert to the chosen end state.
         system = self._checkPerturbable(system)

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -254,7 +254,7 @@ class Gromacs(_process.Process):
             system = self._checkPerturbable(system)
 
         # Convert the water model topology so that it matches the GROMACS naming convention.
-        system._set_water_topology("GROMACS")
+        system._set_water_topology("GROMACS", property_map=self._property_map)
 
         # GRO87 file.
         file = _os.path.splitext(self._gro_file)[0]

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -231,7 +231,7 @@ class OpenMM(_process.Process):
         system = self._system.copy()
 
         # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
+        system._set_water_topology("AMBER", property_map=self._property_map)
 
         # Check for perturbable molecules and convert to the chosen end state.
         system = self._checkPerturbable(system)

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -342,7 +342,7 @@ class Somd(_process.Process):
             system = self._checkPerturbable(system)
 
         # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
+        system._set_water_topology("AMBER", property_map=self._property_map)
 
         # RST file (coordinates).
         try:

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -85,6 +85,7 @@ def check_cache(
     system,
     format,
     filebase,
+    match_water=True,
     property_map={},
     excluded_properties=[],
     skip_water=True,
@@ -104,6 +105,12 @@ def check_cache(
 
     filebase : str
         The file base to copy the file to.
+
+    match_water : bool
+        Whether to update the naming of water molecules to match the expected
+        convention for the chosen file format. This is useful when a system
+        is being saved to a different file format to that from which it was
+        loaded.
 
     property_map : dict
         A dictionary that maps system "properties" to their user
@@ -135,6 +142,9 @@ def check_cache(
     if not isinstance(filebase, str):
         raise TypeError("'filebase' must be of type 'str'")
 
+    if not isinstance(match_water, bool):
+        raise TypeError("'match_water' must be of type 'bool'")
+
     if not isinstance(excluded_properties, (list, tuple)):
         raise TypeError("'excluded_properties' must be a list of 'str' types.")
 
@@ -153,6 +163,7 @@ def check_cache(
         format,
         _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
+        str(match_water),
         str(skip_water),
     )
 
@@ -211,7 +222,13 @@ def check_cache(
 
 
 def update_cache(
-    system, format, path, excluded_properties=[], skip_water=True, **kwargs
+    system,
+    format,
+    path,
+    excluded_properties=[],
+    match_water=True,
+    skip_water=True,
+    **kwargs,
 ):
     """
     Update the file cache when a new system is written to a specified format.
@@ -230,6 +247,12 @@ def update_cache(
 
     excluded_properties : [str]
         A list of properties to exclude when comparing systems when checking
+
+    match_water : bool
+        Whether to update the naming of water molecules to match the expected
+        convention for the chosen file format. This is useful when a system
+        is being saved to a different file format to that from which it was
+        loaded.
 
     skip_water : bool
         Whether to skip water molecules when comparing systems.
@@ -255,6 +278,9 @@ def update_cache(
     if not all(isinstance(x, str) for x in excluded_properties):
         raise TypeError("'excluded_properties' must be a list of 'str' types.")
 
+    if not isinstance(match_water, bool):
+        raise TypeError("'match_water' must be of type 'bool'")
+
     if not isinstance(skip_water, bool):
         raise TypeError("'skip_water' must be of type 'bool'.")
 
@@ -270,6 +296,7 @@ def update_cache(
         format,
         _compress_molnum_key(str(system._mol_nums)),
         str(set(excluded_properties)),
+        str(match_water),
         str(skip_water),
     )
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -742,10 +742,8 @@ def saveMolecules(
                         "GROMACS", property_map=_property_map
                     )
                 else:
-                    system_copy = system.copy()
-                    system_copy._sire_object.setProperty(
-                        "skip_water", _SireBase.wrap(True)
-                    )
+                    system_copy = system
+                    _property_map["skip_water"] = _SireBase.wrap(True)
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )[0]
@@ -760,6 +758,7 @@ def saveMolecules(
                     )
                 else:
                     system_copy = system
+                    _property_map["skip_water"] = _SireBase.wrap(True)
                 # Write to 3dp by default, unless greater precision is
                 # requested by the user.
                 if "precision" not in _property_map:

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -687,6 +687,7 @@ def saveMolecules(
             system,
             format,
             filebase,
+            match_water=match_water,
             property_map=property_map,
             **kwargs,
         )
@@ -728,7 +729,7 @@ def saveMolecules(
             if format.upper() == "PRM7":
                 if match_water:
                     system_copy = system.copy()
-                    system_copy._set_water_topology("AMBER", _property_map)
+                    system_copy._set_water_topology("AMBER", property_map=_property_map)
                 else:
                     system_copy = system
                 file = _SireIO.MoleculeParser.save(
@@ -737,9 +738,14 @@ def saveMolecules(
             elif format.upper() == "GROTOP":
                 if match_water:
                     system_copy = system.copy()
-                    system_copy._set_water_topology("GROMACS", _property_map)
+                    system_copy._set_water_topology(
+                        "GROMACS", property_map=_property_map
+                    )
                 else:
-                    system_copy = system
+                    system_copy = system.copy()
+                    system_copy._sire_object.setProperty(
+                        "skip_water", _SireBase.wrap(True)
+                    )
                 file = _SireIO.MoleculeParser.save(
                     system_copy._sire_object, filebase, _property_map
                 )[0]
@@ -749,7 +755,9 @@ def saveMolecules(
             elif format.upper() == "GRO87":
                 if match_water:
                     system_copy = system.copy()
-                    system_copy._set_water_topology("GROMACS", _property_map)
+                    system_copy._set_water_topology(
+                        "GROMACS", property_map=_property_map
+                    )
                 else:
                     system_copy = system
                 # Write to 3dp by default, unless greater precision is
@@ -770,7 +778,7 @@ def saveMolecules(
             files += file
 
             # If this is a new file, then add it to the cache.
-            _update_cache(system, format, file[0], **kwargs)
+            _update_cache(system, format, file[0], match_water=match_water, **kwargs)
 
         except Exception as e:
             msg = "Failed to save system to format: '%s'" % format

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -378,7 +378,15 @@ class AmberProtein(_protocol.Protocol):
                     verbose=False,
                 )
             else:
-                new_mol = par_mol
+                try:
+                    new_mol.makeCompatibleWith(
+                        par_mol,
+                        property_map=self._property_map,
+                        overwrite=True,
+                        verbose=False,
+                    )
+                except:
+                    new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield
@@ -1232,7 +1240,15 @@ class GAFF(_protocol.Protocol):
                                 verbose=False,
                             )
                         else:
-                            new_mol = par_mol
+                            try:
+                                new_mol.makeCompatibleWith(
+                                    par_mol,
+                                    property_map=self._property_map,
+                                    overwrite=True,
+                                    verbose=False,
+                                )
+                            except:
+                                new_mol = par_mol
 
                     # Record the forcefield used to parameterise the molecule.
                     new_mol._forcefield = ff

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -124,6 +124,7 @@ class AmberProtein(_protocol.Protocol):
         water_model=None,
         leap_commands=None,
         bonds=None,
+        ensure_compatible=True,
         property_map={},
     ):
         """
@@ -164,6 +165,15 @@ class AmberProtein(_protocol.Protocol):
             should be bonded. This is useful when the PDB CONECT record is
             incomplete.
 
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules. When True, the parameterised
+            molecule will preserve the topology of the original molecule, e.g.
+            the original atom and residue names will be kept.
+
         property_map : dict
             A dictionary that maps system "properties" to their user defined
             values. This allows the user to refer to properties with their
@@ -171,7 +181,11 @@ class AmberProtein(_protocol.Protocol):
         """
 
         # Call the base class constructor.
-        super().__init__(forcefield=forcefield, property_map=property_map)
+        super().__init__(
+            forcefield=forcefield,
+            ensure_compatible=ensure_compatible,
+            property_map=property_map,
+        )
 
         # Validate the pdb2gmx compatibility flag.
         if not isinstance(pdb2gmx, bool):
@@ -356,9 +370,15 @@ class AmberProtein(_protocol.Protocol):
             new_mol._sire_object = edit_mol.commit()
 
         else:
-            new_mol.makeCompatibleWith(
-                par_mol, property_map=self._property_map, overwrite=True, verbose=False
-            )
+            if self._ensure_compatible:
+                new_mol.makeCompatibleWith(
+                    par_mol,
+                    property_map=self._property_map,
+                    overwrite=True,
+                    verbose=False,
+                )
+            else:
+                new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield
@@ -503,13 +523,14 @@ class AmberProtein(_protocol.Protocol):
             prefix + "leap.crd"
         ):
             # Check the output of tLEaP for missing atoms.
-            if _has_missing_atoms(prefix + "leap.out"):
-                raise _ParameterisationError(
-                    "tLEaP added missing atoms. The topology is now "
-                    "inconsistent with the original molecule. Please "
-                    "make sure that your initial molecule has a "
-                    "complete topology."
-                )
+            if self._ensure_compatible:
+                if _has_missing_atoms(prefix + "leap.out"):
+                    raise _ParameterisationError(
+                        "tLEaP added missing atoms. The topology is now "
+                        "inconsistent with the original molecule. Please "
+                        "make sure that your initial molecule has a "
+                        "complete topology."
+                    )
             return ["leap.top", "leap.crd"]
         else:
             raise _ParameterisationError("tLEaP failed!")
@@ -825,7 +846,14 @@ class GAFF(_protocol.Protocol):
     # A list of supported charge methods.
     _charge_methods = ["RESP", "CM2", "MUL", "BCC", "ESP", "GAS"]
 
-    def __init__(self, version, charge_method="BCC", net_charge=None, property_map={}):
+    def __init__(
+        self,
+        version,
+        charge_method="BCC",
+        net_charge=None,
+        ensure_compatible=True,
+        property_map={},
+    ):
         """
         Constructor.
 
@@ -841,6 +869,17 @@ class GAFF(_protocol.Protocol):
 
         net_charge : int
             The net charge on the molecule.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. When
+            True, the parameterised molecule will preserve the topology of the
+            original molecule, e.g. the original atom and residue names will be
+            kept.
+
+            property_map : dict
+            A dictionary that maps system "properties" to their user defined
 
         property_map : dict
             A dictionary that maps system "properties" to their user defined
@@ -895,7 +934,11 @@ class GAFF(_protocol.Protocol):
         self._charge_method = charge_method
 
         # Call the base class constructor.
-        super().__init__(forcefield="gaff", property_map=property_map)
+        super().__init__(
+            forcefield="gaff",
+            ensure_compatible=ensure_compatible,
+            property_map=property_map,
+        )
 
     def run(self, molecule, work_dir=None, queue=None):
         """
@@ -1131,13 +1174,14 @@ class GAFF(_protocol.Protocol):
                     prefix + "leap.crd"
                 ):
                     # Check the output of tLEaP for missing atoms.
-                    if _has_missing_atoms(prefix + "leap.out"):
-                        raise _ParameterisationError(
-                            "tLEaP added missing atoms. The topology is now "
-                            "inconsistent with the original molecule. Please "
-                            "make sure that your initial molecule has a "
-                            "complete topology."
-                        )
+                    if self._ensure_compatible:
+                        if _has_missing_atoms(prefix + "leap.out"):
+                            raise _ParameterisationError(
+                                "tLEaP added missing atoms. The topology is now "
+                                "inconsistent with the original molecule. Please "
+                                "make sure that your initial molecule has a "
+                                "complete topology."
+                            )
 
                     # Load the parameterised molecule. (This could be a system of molecules.)
                     try:
@@ -1180,12 +1224,15 @@ class GAFF(_protocol.Protocol):
                         new_mol._sire_object = edit_mol.commit()
 
                     else:
-                        new_mol.makeCompatibleWith(
-                            par_mol,
-                            property_map=self._property_map,
-                            overwrite=True,
-                            verbose=False,
-                        )
+                        if self._ensure_compatible:
+                            new_mol.makeCompatibleWith(
+                                par_mol,
+                                property_map=self._property_map,
+                                overwrite=True,
+                                verbose=False,
+                            )
+                        else:
+                            new_mol = par_mol
 
                     # Record the forcefield used to parameterise the molecule.
                     new_mol._forcefield = ff

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -105,7 +105,7 @@ from . import _protocol
 class OpenForceField(_protocol.Protocol):
     """A class for handling protocols for Open Force Field models."""
 
-    def __init__(self, forcefield, property_map={}):
+    def __init__(self, forcefield, ensure_compatible=True, property_map={}):
         """
         Constructor.
 
@@ -115,6 +115,14 @@ class OpenForceField(_protocol.Protocol):
         forcefield : str
             The name of the force field.
 
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. When
+            True, the parameterised molecule will preserve the topology of the
+            original molecule, e.g. the original atom and residue names will be
+            kept.
+
         property_map : dict
             A dictionary that maps system "properties" to their user defined
             values. This allows the user to refer to properties with their
@@ -122,7 +130,11 @@ class OpenForceField(_protocol.Protocol):
         """
 
         # Call the base class constructor.
-        super().__init__(forcefield=forcefield, property_map=property_map)
+        super().__init__(
+            forcefield=forcefield,
+            ensure_compatible=ensure_compatible,
+            property_map=property_map,
+        )
 
         # Set the compatibility flags.
         self._tleap = False
@@ -373,10 +385,16 @@ class OpenForceField(_protocol.Protocol):
             new_mol._sire_object = edit_mol.commit()
 
         else:
-            new_mol = molecule.copy()
-            new_mol.makeCompatibleWith(
-                par_mol, property_map=self._property_map, overwrite=True, verbose=False
-            )
+            if self._ensure_compatible:
+                new_mol = molecule.copy()
+                new_mol.makeCompatibleWith(
+                    par_mol,
+                    property_map=self._property_map,
+                    overwrite=True,
+                    verbose=False,
+                )
+            else:
+                new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -394,7 +394,15 @@ class OpenForceField(_protocol.Protocol):
                     verbose=False,
                 )
             else:
-                new_mol = par_mol
+                try:
+                    new_mol.makeCompatibleWith(
+                        par_mol,
+                        property_map=self._property_map,
+                        overwrite=True,
+                        verbose=False,
+                    )
+                except:
+                    new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_protocol.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_protocol.py
@@ -33,7 +33,7 @@ __all__ = ["Protocol"]
 class Protocol:
     """A base class for parameterisation protocols."""
 
-    def __init__(self, forcefield, property_map={}):
+    def __init__(self, forcefield, ensure_compatible=True, property_map={}):
         """
         Constructor.
 
@@ -42,6 +42,13 @@ class Protocol:
 
         forcefield : str
             The name of the force field.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules.
 
         property_map : dict
             A dictionary that maps system "properties" to their user defined
@@ -58,6 +65,12 @@ class Protocol:
             raise TypeError("'forcefield' must be of type 'str'")
         else:
             self._forcefield = forcefield
+
+        # Validate and set the topology compatibilty flag.
+        if not isinstance(ensure_compatible, bool):
+            raise TypeError("'ensure_compatible' must be of type 'bool'")
+        else:
+            self._ensure_compatible = ensure_compatible
 
         # Validate and set the property map.
         if not isinstance(property_map, dict):

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -65,7 +65,14 @@ from ._process import Process as _Process
 from . import _Protocol
 
 
-def parameterise(molecule, forcefield, work_dir=None, property_map={}, **kwargs):
+def parameterise(
+    molecule,
+    forcefield,
+    ensure_compatible=True,
+    work_dir=None,
+    property_map={},
+    **kwargs,
+):
     """
     Parameterise a molecule using a specified force field.
 
@@ -79,6 +86,15 @@ def parameterise(molecule, forcefield, work_dir=None, property_map={}, **kwargs)
     forcefield : str
         The force field. Run BioSimSpace.Parameters.forceFields() to get a
         list of the supported force fields.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. Set
+        this to False is parameterising lone oxygen atoms corresponding to
+        structural (crystal) water molecules. When True, the parameterised
+        molecule will preserve the topology of the original molecule, e.g.
+        the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -121,6 +137,7 @@ def _parameterise_amber_protein(
     water_model=None,
     leap_commands=None,
     bonds=None,
+    ensure_compatible=True,
     work_dir=None,
     property_map={},
     **kwargs,
@@ -150,7 +167,9 @@ def _parameterise_amber_protein(
     water_model : str
         The water model used to parameterise any structural ions.
         Run 'BioSimSpace.Solvent.waterModels()' to see the supported
-        water models. This is ignored if ions are not present.
+        water models. This can also be used to parameterise water molecules,
+        or lone oxygen atoms corresponding to structural (crystal) water
+        molecules.
 
     leap_commands : [str]
         An optional list of extra commands for the LEaP program. These
@@ -161,6 +180,15 @@ def _parameterise_amber_protein(
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
         should be bonded.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. Set
+        this to False is parameterising lone oxygen atoms corresponding to
+        structural (crystal) water molecules. When True, the parameterised
+        molecule will preserve the topology of the original molecule, e.g.
+        the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -211,6 +239,7 @@ def _parameterise_amber_protein(
         check_ions=True,
         leap_commands=leap_commands,
         bonds=bonds,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -223,6 +252,7 @@ def _parameterise_amber_protein(
         max_distance=max_distance,
         leap_commands=leap_commands,
         bonds=bonds,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -236,6 +266,7 @@ def gaff(
     work_dir=None,
     net_charge=None,
     charge_method="BCC",
+    ensure_compatible=True,
     property_map={},
     **kwargs,
 ):
@@ -255,6 +286,13 @@ def gaff(
     charge_method : str
             The method to use when calculating atomic charges:
             "RESP", "CM2", "MUL", "BCC", "ESP", "GAS"
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. When True,
+        the parameterised molecule will preserve the topology of the original
+        molecule, e.g. the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -278,7 +316,12 @@ def gaff(
         )
 
     # Validate arguments.
-    _validate(molecule=molecule, check_ions=False, property_map=property_map)
+    _validate(
+        molecule=molecule,
+        check_ions=False,
+        ensure_compatible=ensure_compatible,
+        property_map=property_map,
+    )
 
     if net_charge is not None:
         # Get the value of the charge.
@@ -302,6 +345,7 @@ def gaff(
         version=1,
         net_charge=net_charge,
         charge_method=charge_method,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -315,6 +359,7 @@ def gaff2(
     work_dir=None,
     net_charge=None,
     charge_method="BCC",
+    ensure_compatible=True,
     property_map={},
     **kwargs,
 ):
@@ -334,6 +379,13 @@ def gaff2(
     charge_method : str
             The method to use when calculating atomic charges:
             "RESP", "CM2", "MUL", "BCC", "ESP", "GAS"
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. When True,
+        the parameterised molecule will preserve the topology of the original
+        molecule, e.g. the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -357,7 +409,12 @@ def gaff2(
         )
 
     # Validate arguments.
-    _validate(molecule=molecule, check_ions=False, property_map=property_map)
+    _validate(
+        molecule=molecule,
+        check_ions=False,
+        ensure_compatible=ensure_compatible,
+        property_map=property_map,
+    )
 
     if net_charge is not None:
         # Get the value of the charge.
@@ -384,6 +441,7 @@ def gaff2(
         version=2,
         net_charge=net_charge,
         charge_method=charge_method,
+        ensure_compatible=ensure_compatible,
         property_map=property_map,
     )
 
@@ -393,7 +451,12 @@ def gaff2(
 
 
 def _parameterise_openff(
-    forcefield, molecule, work_dir=None, property_map={}, **kwargs
+    forcefield,
+    molecule,
+    ensure_compatible=True,
+    work_dir=None,
+    property_map={},
+    **kwargs,
 ):
     """
     Parameterise a molecule using a force field from the Open Force Field
@@ -409,6 +472,13 @@ def _parameterise_openff(
     molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, str
         The molecule to parameterise, either as a Molecule object or SMILES
         string.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. When True,
+        the parameterised molecule will preserve the topology of the original
+        molecule, e.g. the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -508,7 +578,9 @@ def _parameterise_openff(
         raise TypeError("'property_map' must be of type 'dict'")
 
     # Create a default protocol.
-    protocol = _Protocol.OpenForceField(forcefield, property_map=property_map)
+    protocol = _Protocol.OpenForceField(
+        forcefield, ensure_compatible=ensure_compatible, property_map=property_map
+    )
 
     # Run the parameterisation protocol in the background and return
     # a handle to the thread.
@@ -726,6 +798,7 @@ def _validate(
     check_ions=False,
     leap_commands=None,
     bonds=None,
+    ensure_compatible=True,
     work_dir=None,
     property_map=None,
 ):
@@ -751,7 +824,9 @@ def _validate(
     water_model : str
         The water model used to parameterise any structural ions.
         Run 'BioSimSpace.Solvent.waterModels()' to see the supported
-        water models. This is ignored if ions are not present.
+        water models. This can also be used to parameterise water molecules,
+        or lone oxygen atoms corresponding to structural (crystal) water
+        molecules.
 
     check_ions : bool
         Whether to check for the presence of structural ions. This is only
@@ -766,6 +841,15 @@ def _validate(
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
         should be bonded.
+
+    ensure_compatible : bool
+        Whether to ensure that the topology of the parameterised molecule is
+        compatible with that of the original molecule. An exception will be
+        raised if this isn't the case, e.g. if atoms have been added. Set this
+        to False is parameterising lone oxygen atoms corresponding to
+        structural (crystal) water molecules. When True, the parameterised
+        molecule will preserve the topology of the original molecule, e.g.
+        the original atom and residue names will be kept.
 
     work_dir : str
         The working directory for the process.
@@ -853,6 +937,9 @@ def _validate(
                                 "Atoms in 'bonds' don't belong to the 'molecule'."
                             )
 
+    if not isinstance(ensure_compatible, bool):
+        raise TypeError("'ensure_compatible' must be of type 'bool'.")
+
     if property_map is not None:
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'")
@@ -876,6 +963,7 @@ def _make_amber_protein_function(name):
         water_model=None,
         leap_commands=None,
         bonds=None,
+        ensure_compatible=True,
         work_dir=None,
         property_map={},
     ):
@@ -901,7 +989,9 @@ def _make_amber_protein_function(name):
         water_model : str
             The water model used to parameterise any structural ions.
             Run 'BioSimSpace.Solvent.waterModels()' to see the supported
-            water models. This is ignored if ions are not present.
+            water models. This can also be used to parameterise water molecules,
+            or lone oxygen atoms corresponding to structural (crystal) water
+            molecules.
 
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These
@@ -912,6 +1002,15 @@ def _make_amber_protein_function(name):
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
             should be bonded.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules. When True, the parameterised
+            molecule will preserve the topology of the original molecule, e.g.
+            the original atom and residue names will be kept.
 
         work_dir : str
              The working directory for the process.
@@ -935,6 +1034,7 @@ def _make_amber_protein_function(name):
             water_model=water_model,
             leap_commands=leap_commands,
             bonds=bonds,
+            ensure_compatible=ensure_compatible,
             work_dir=work_dir,
             property_map=property_map,
         )
@@ -948,7 +1048,7 @@ def _make_amber_protein_function(name):
 # it conforms to sensible function naming standards, i.e. "-" and "."
 # characters replaced by underscores.
 def _make_openff_function(name):
-    def _function(molecule, work_dir=None, property_map={}):
+    def _function(molecule, ensure_compatible=True, work_dir=None, property_map={}):
         """
         Parameterise a molecule using the named force field from the
         Open Force Field initiative.
@@ -959,6 +1059,15 @@ def _make_openff_function(name):
         molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`, str
             The molecule to parameterise, either as a Molecule object or SMILES
             string.
+
+        ensure_compatible : bool
+            Whether to ensure that the topology of the parameterised molecule is
+            compatible with that of the original molecule. An exception will be
+            raised if this isn't the case, e.g. if atoms have been added. Set
+            this to False is parameterising lone oxygen atoms corresponding to
+            structural (crystal) water molecules. When True, the parameterised
+            molecule will preserve the topology of the original molecule, e.g.
+            the original atom and residue names will be kept.
 
         work_dir : str
             The working directory for the process.
@@ -974,7 +1083,13 @@ def _make_openff_function(name):
         molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
             The parameterised molecule.
         """
-        return _parameterise_openff(name, molecule, work_dir, property_map)
+        return _parameterise_openff(
+            name,
+            molecule,
+            ensure_compatible=ensure_compatible,
+            work_dir=work_dir,
+            property_map=property_map,
+        )
 
     return _function
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
@@ -223,7 +223,16 @@ class Process:
 
             # Fix the charges so that the total is integer valued.
             if self._new_molecule is not None:
-                self._new_molecule._fixCharge(property_map=self._protocol._property_map)
+                # This is a single molecule.
+                try:
+                    self._new_molecule._fixCharge(
+                        property_map=self._protocol._property_map
+                    )
+                # This is a system object.
+                except:
+                    for mol in self._new_molecule:
+                        mol._fixCharge(property_map=self._protocol._property_map)
+                        self._new_molecule.updateMolecules(mol)
 
         # If there was an problem, return the last error.
         if self._is_error:

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -286,7 +286,7 @@ class Amber(_process.Process):
         system = system.copy()
 
         # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
+        system._set_water_topology("AMBER", property_map=self._property_map)
 
         # Check for perturbable molecules and convert to the chosen end state.
         if isinstance(self._protocol, _Protocol._FreeEnergyMixin):

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -325,7 +325,7 @@ class Gromacs(_process.Process):
             system = self._checkPerturbable(system)
 
         # Convert the water model topology so that it matches the GROMACS naming convention.
-        system._set_water_topology("GROMACS")
+        system._set_water_topology("GROMACS", property_map=self._property_map)
 
         # Check whether the system contains periodic box information.
         # For now, we'll not attempt to generate a box if the system property

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -230,7 +230,7 @@ class OpenMM(_process.Process):
         system = self._system.copy()
 
         # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
+        system._set_water_topology("AMBER", property_map=self._property_map)
 
         # Check for perturbable molecules and convert to the chosen end state.
         system = self._checkPerturbable(system)

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -353,7 +353,7 @@ class Somd(_process.Process):
             system = self._checkPerturbable(system)
 
         # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
+        system._set_water_topology("AMBER", property_map=self._property_map)
 
         # RST file (coordinates).
         try:

--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
@@ -1015,6 +1015,7 @@ def _solvate(
         # First, generate a box file corresponding to the requested geometry.
         if molecule is not None:
             # Write the molecule/system to a GRO files.
+            _property_map["crystal_water"] = "XTL"
             _IO.saveMolecules(
                 "input",
                 molecule,

--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
@@ -992,7 +992,9 @@ def _solvate(
 
             # Reformat all of the water molecules so that they match the
             # expected GROMACS topology template, but flagged as crystal.
-            molecule._set_water_topology("GROMACS", is_crystal=True)
+            molecule._set_water_topology(
+                "GROMACS", is_crystal=True, property_map=property_map
+            )
 
             # Extract the crystal waters.
             crystal_waters = molecule.getWaterMolecules()
@@ -1425,7 +1427,9 @@ def _solvate(
                                 system = molecule + flagged_waters + water_ions
                             # Update crystal waters to match the standard water topology.
                             else:
-                                molecule._set_water_topology("GROMACS")
+                                molecule._set_water_topology(
+                                    "GROMACS", property_map=property_map
+                                )
                                 system = molecule + water_ions
                         else:
                             system = molecule.toSystem() + water_ions

--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
@@ -65,6 +65,7 @@ def solvate(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -103,6 +104,10 @@ def solvate(
     is_aligned : bool
         Whether to align the principal axes of the molecule to those of the
         solvent box.
+
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
 
     work_dir : str
         The working directory for the process.
@@ -150,6 +155,7 @@ def spc(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -186,6 +192,10 @@ def spc(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -217,6 +227,7 @@ def spc(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -232,6 +243,7 @@ def spc(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -245,6 +257,7 @@ def spce(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -281,6 +294,10 @@ def spce(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -312,6 +329,7 @@ def spce(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -327,6 +345,7 @@ def spce(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -340,6 +359,7 @@ def tip3p(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -376,6 +396,10 @@ def tip3p(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -407,6 +431,7 @@ def tip3p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -422,6 +447,7 @@ def tip3p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -435,6 +461,7 @@ def tip4p(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -471,6 +498,10 @@ def tip4p(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -502,6 +533,7 @@ def tip4p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -517,6 +549,7 @@ def tip4p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -530,6 +563,7 @@ def tip5p(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -566,6 +600,10 @@ def tip5p(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -597,6 +635,7 @@ def tip5p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -612,6 +651,7 @@ def tip5p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -626,6 +666,7 @@ def _validate_input(
     ion_conc,
     is_neutral,
     is_aligned,
+    match_water,
     work_dir,
     property_map,
 ):
@@ -664,6 +705,10 @@ def _validate_input(
     is_aligned : bool
         Whether to align the principal axes of the molecule to those of the
         solvent box.
+
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
 
     work_dir : str
         The working directory for the process.
@@ -817,6 +862,9 @@ def _validate_input(
     if not isinstance(is_aligned, bool):
         raise TypeError("'is_aligned' must be of type 'bool'.")
 
+    if not isinstance(match_water, bool):
+        raise TypeError("'match_water' must be of type 'bool'.")
+
     # Check that the working directory is valid.
     if work_dir is not None and not isinstance(work_dir, str):
         raise TypeError("'work_dir' must be of type 'str'")
@@ -847,6 +895,7 @@ def _solvate(
     ion_conc,
     is_neutral,
     is_aligned,
+    match_water,
     work_dir=None,
     property_map={},
 ):
@@ -884,6 +933,10 @@ def _solvate(
     is_aligned : bool
         Whether to align the principal axes of the molecule to those of the
         solvent box.
+
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
 
     work_dir : str
         The working directory for the process.
@@ -930,16 +983,24 @@ def _solvate(
         # Center the solute in the box.
         molecule.translate(shift)
 
+        # Intitialise the original waters.
+        original_waters = None
+
         if isinstance(molecule, _System):
+            # Store the existing water molecules.
+            original_waters = molecule.getWaterMolecules()
+
             # Reformat all of the water molecules so that they match the
-            # expected GROMACS topology template.
-            molecule._set_water_topology("GROMACS")
+            # expected GROMACS topology template, but flagged as crystal.
+            molecule._set_water_topology("GROMACS", is_crystal=True)
+
+            # Extract the crystal waters.
+            crystal_waters = molecule.getWaterMolecules()
 
             # Make sure the water molecules are at the end of the topology
             # since gmx genion requires that they are contiguous.
-            waters = molecule.getWaterMolecules()
             molecule.removeWaterMolecules()
-            molecule = molecule + waters
+            molecule = molecule + crystal_waters
 
     # Create the working directory.
     work_dir = _Utils.WorkDir(work_dir)
@@ -958,7 +1019,7 @@ def _solvate(
                 "input",
                 molecule,
                 "gro87",
-                match_waters=False,
+                match_water=False,
                 property_map=_property_map,
             )
 
@@ -1131,14 +1192,14 @@ def _solvate(
                     "solvated",
                     system,
                     "gro87",
-                    match_waters=False,
+                    match_water=False,
                     property_map=_property_map,
                 )
                 _IO.saveMolecules(
                     "solvated",
                     system,
                     "grotop",
-                    match_waters=False,
+                    match_water=False,
                     property_map=_property_map,
                 )
             except Exception as e:
@@ -1344,7 +1405,27 @@ def _solvate(
                     # Create a new system by adding the water and ions to the original molecule.
                     if molecule is not None:
                         if isinstance(molecule, _System):
-                            system = molecule + water_ions
+                            # Preserve the original water naming.
+                            if match_water is False:
+                                # Flag each original water as non searchable.
+                                flagged_waters = []
+                                for water in original_waters:
+                                    water._sire_object = (
+                                        water._sire_object.edit()
+                                        .setProperty(
+                                            "is_non_searchable_water",
+                                            _SireBase.wrap(True),
+                                        )
+                                        .molecule()
+                                        .commit()
+                                    )
+                                    flagged_waters.append(water)
+                                molecule.removeWaterMolecules()
+                                system = molecule + flagged_waters + water_ions
+                            # Update crystal waters to match the standard water topology.
+                            else:
+                                molecule._set_water_topology("GROMACS")
+                                system = molecule + water_ions
                         else:
                             system = molecule.toSystem() + water_ions
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -2268,7 +2268,7 @@ class System(_SireWrapper):
         for idx in range(0, self.nMolecules()):
             self._molecule_index[self._sire_object[_SireMol.MolIdx(idx)].number()] = idx
 
-    def _set_water_topology(self, format, property_map={}):
+    def _set_water_topology(self, format, is_crystal=False, property_map={}):
         """
         Internal function to swap the water topology to AMBER or GROMACS format.
 
@@ -2277,6 +2277,9 @@ class System(_SireWrapper):
 
         format : string
             The format to convert to: either "AMBER" or "GROMACS".
+
+        is_crystal : bool
+            Whether to label as rystal waters.
 
         property_map : dict
            A dictionary that maps system "properties" to their user defined
@@ -2288,6 +2291,9 @@ class System(_SireWrapper):
 
         if not isinstance(format, str):
             raise TypeError("'format' must be of type 'str'")
+
+        if not isinstance(is_crystal, bool):
+            raise TypeError("'is_crystal' must be of type 'bool'")
 
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'")
@@ -2314,7 +2320,7 @@ class System(_SireWrapper):
                     return
 
             elif format == "GROMACS":
-                if waters[0].isGromacsWater():
+                if not is_crystal and waters[0].isGromacsWater():
                     return
 
             # There will be a "water_model" system property if this object was
@@ -2340,7 +2346,7 @@ class System(_SireWrapper):
                 )
             else:
                 self._sire_object = _SireIO.setGromacsWater(
-                    self._sire_object, water_model, property_map
+                    self._sire_object, water_model, property_map, is_crystal
                 )
 
     def _set_atom_index_tally(self):

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -1015,6 +1015,7 @@ def _solvate(
         # First, generate a box file corresponding to the requested geometry.
         if molecule is not None:
             # Write the molecule/system to a GRO files.
+            _property_map["crystal_water"] = "XTL"
             _IO.saveMolecules(
                 "input",
                 molecule,

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -992,7 +992,9 @@ def _solvate(
 
             # Reformat all of the water molecules so that they match the
             # expected GROMACS topology template, but flagged as crystal.
-            molecule._set_water_topology("GROMACS", is_crystal=True)
+            molecule._set_water_topology(
+                "GROMACS", is_crystal=True, property_map=property_map
+            )
 
             # Extract the crystal waters.
             crystal_waters = molecule.getWaterMolecules()
@@ -1425,7 +1427,9 @@ def _solvate(
                                 system = molecule + flagged_waters + water_ions
                             # Update crystal waters to match the standard water topology.
                             else:
-                                molecule._set_water_topology("GROMACS")
+                                molecule._set_water_topology(
+                                    "GROMACS", property_map=property_map
+                                )
                                 system = molecule + water_ions
                         else:
                             system = molecule.toSystem() + water_ions

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -65,6 +65,7 @@ def solvate(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -103,6 +104,10 @@ def solvate(
     is_aligned : bool
         Whether to align the principal axes of the molecule to those of the
         solvent box.
+
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
 
     work_dir : str
         The working directory for the process.
@@ -150,6 +155,7 @@ def spc(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -186,6 +192,10 @@ def spc(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -217,6 +227,7 @@ def spc(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -232,6 +243,7 @@ def spc(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -245,6 +257,7 @@ def spce(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -281,6 +294,10 @@ def spce(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -312,6 +329,7 @@ def spce(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -327,6 +345,7 @@ def spce(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -340,6 +359,7 @@ def tip3p(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -376,6 +396,10 @@ def tip3p(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -407,6 +431,7 @@ def tip3p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -422,6 +447,7 @@ def tip3p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -435,6 +461,7 @@ def tip4p(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -471,6 +498,10 @@ def tip4p(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -502,6 +533,7 @@ def tip4p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -517,6 +549,7 @@ def tip4p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -530,6 +563,7 @@ def tip5p(
     ion_conc=0,
     is_neutral=True,
     is_aligned=False,
+    match_water=True,
     work_dir=None,
     property_map={},
 ):
@@ -566,6 +600,10 @@ def tip5p(
         Whether to align the principal axes of the molecule to those of the
         solvent box.
 
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
+
     work_dir : str
         The working directory for the process.
 
@@ -597,6 +635,7 @@ def tip5p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )
@@ -612,6 +651,7 @@ def tip5p(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir=work_dir,
         property_map=property_map,
     )
@@ -626,6 +666,7 @@ def _validate_input(
     ion_conc,
     is_neutral,
     is_aligned,
+    match_water,
     work_dir,
     property_map,
 ):
@@ -664,6 +705,10 @@ def _validate_input(
     is_aligned : bool
         Whether to align the principal axes of the molecule to those of the
         solvent box.
+
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
 
     work_dir : str
         The working directory for the process.
@@ -817,6 +862,9 @@ def _validate_input(
     if not isinstance(is_aligned, bool):
         raise TypeError("'is_aligned' must be of type 'bool'.")
 
+    if not isinstance(match_water, bool):
+        raise TypeError("'match_water' must be of type 'bool'.")
+
     # Check that the working directory is valid.
     if work_dir is not None and not isinstance(work_dir, str):
         raise TypeError("'work_dir' must be of type 'str'")
@@ -847,6 +895,7 @@ def _solvate(
     ion_conc,
     is_neutral,
     is_aligned,
+    match_water,
     work_dir=None,
     property_map={},
 ):
@@ -884,6 +933,10 @@ def _solvate(
     is_aligned : bool
         Whether to align the principal axes of the molecule to those of the
         solvent box.
+
+    match_water : bool
+        Whether to update the naming of existing water molecules to match the
+        expected convention for GROMACS, which is used as the solvation engine.
 
     work_dir : str
         The working directory for the process.
@@ -930,16 +983,19 @@ def _solvate(
         # Center the solute in the box.
         molecule.translate(shift)
 
+        # Intitialise the original waters.
+        original_waters = None
+
         if isinstance(molecule, _System):
             # Reformat all of the water molecules so that they match the
             # expected GROMACS topology template.
-            molecule._set_water_topology("GROMACS")
+            molecule._set_water_topology("GROMACS", is_crystal=True)
 
             # Make sure the water molecules are at the end of the topology
             # since gmx genion requires that they are contiguous.
-            waters = molecule.getWaterMolecules()
+            original_waters = molecule.getWaterMolecules()
             molecule.removeWaterMolecules()
-            molecule = molecule + waters
+            molecule = molecule + original_waters
 
     # Create the working directory.
     work_dir = _Utils.WorkDir(work_dir)
@@ -1330,7 +1386,14 @@ def _solvate(
                     # Create a new system by adding the water and ions to the original molecule.
                     if molecule is not None:
                         if isinstance(molecule, _System):
-                            system = molecule + water_ions
+                            # Preserve the original water naming.
+                            if match_waters is False:
+                                molecule.removeWaterMolecules()
+                                system = molecule + original_waters + water_ions
+                            # Update crystal waters to match the standard water topology.
+                            else:
+                                molecule._set_water_topology("GROMACS")
+                                system = molecule + water_ions
                         else:
                             system = molecule.toSystem() + water_ions
 

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -150,7 +150,7 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
         }
 
         # Update the water topology to match topology/trajectory.
-        system = _update_water_topology(system, topology, trajectory)
+        system = _update_water_topology(system, topology, trajectory, property_map)
 
     # Try to load the frame with Sire.
     errors = []
@@ -420,6 +420,10 @@ class Trajectory:
                 "or a trajectory and topology file."
             )
 
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+        self._property_map = property_map
+
         if system is not None:
             if not isinstance(system, _System):
                 raise TypeError(
@@ -438,13 +442,17 @@ class Trajectory:
                 # If this is a GROMACS process, convert the water topology to
                 # GROMACS format. Use AMBER for everything else.
                 if process._package_name == "GROMACS":
-                    self._system._set_water_topology("GROMACS")
+                    self._system._set_water_topology(
+                        "GROMACS", property_map=process._property_map
+                    )
                 else:
-                    self._system._set_water_topology("AMBER")
+                    self._system._set_water_topology(
+                        "AMBER", property_map=process._property_map
+                    )
             else:
                 # Update the water topology to match topology/trajectory.
                 self._system = _update_water_topology(
-                    self._system, self._top_file, self._traj_file
+                    self._system, self._top_file, self._traj_file, self._property_map
                 )
 
         if not isinstance(backend, str):
@@ -456,9 +464,6 @@ class Trajectory:
         if backend not in ["AUTO"] + backends():
             _warnings.warn("Invalid trajectory format. Using default (Sire).")
             backend = "SIRE"
-
-        if not isinstance(property_map, dict):
-            raise TypeError("'property_map' must be of type 'dict'")
 
         # Get the current trajectory.
         self._trajectory = self.getTrajectory(format=backend)
@@ -1152,7 +1157,7 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
     return split_system
 
 
-def _update_water_topology(system, topology, trajectory):
+def _update_water_topology(system, topology, trajectory, property_map):
     """
     Internal helper function to update the water topology of the system
     so that it is consistent with the passed topology or trajectory.
@@ -1168,6 +1173,11 @@ def _update_water_topology(system, topology, trajectory):
 
     topology : str
         A topology file.
+
+    property_map : dict
+        A dictionary that maps system "properties" to their user defined
+        values. This allows the user to refer to properties with their
+        own naming scheme, e.g. { "charge" : "my-charge" }
 
     Returns
     -------
@@ -1185,10 +1195,13 @@ def _update_water_topology(system, topology, trajectory):
     if not isinstance(topology, str):
         raise TypeError("'topology' must be of type 'str'")
 
+    if not isinstance(property_map, dict):
+        raise TypeError("'property_map' must be of type 'dict'")
+
     # GROMACS topology file.
     try:
         top = _SireIO.GroTop(topology)
-        system._set_water_topology("GROMACS")
+        system._set_water_topology("GROMACS", property_map=property_map)
         matched_topology = True
     except:
         # GROMACS coordinate file.
@@ -1200,7 +1213,7 @@ def _update_water_topology(system, topology, trajectory):
         except:
             try:
                 top = _SireIO.AmberPrm(topology)
-                system._set_water_topology("AMBER")
+                system._set_water_topology("AMBER", property_map=property_map)
                 if top.toString() != "AmberPrm::null":
                     matched_topology = True
                 else:
@@ -1220,6 +1233,6 @@ def _update_water_topology(system, topology, trajectory):
 
     # If nothing matched, default to AMBER water format.
     if not matched_topology:
-        system._set_water_topology("AMBER")
+        system._set_water_topology("AMBER", property_map=property_map)
 
     return system

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -2216,7 +2216,7 @@ class System(_SireWrapper):
         for idx in range(0, self.nMolecules()):
             self._molecule_index[self._sire_object[_SireMol.MolIdx(idx)].number()] = idx
 
-    def _set_water_topology(self, format, property_map={}):
+    def _set_water_topology(self, format, is_crystal=False, property_map={}):
         """
         Internal function to swap the water topology to AMBER or GROMACS format.
 
@@ -2225,6 +2225,9 @@ class System(_SireWrapper):
 
         format : string
             The format to convert to: either "AMBER" or "GROMACS".
+
+        is_crystal : bool
+            Whether to label as rystal waters.
 
         property_map : dict
            A dictionary that maps system "properties" to their user defined
@@ -2236,6 +2239,9 @@ class System(_SireWrapper):
 
         if not isinstance(format, str):
             raise TypeError("'format' must be of type 'str'")
+
+        if not isinstance(is_crystal, bool):
+            raise TypeError("'is_crystal' must be of type 'bool'")
 
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'")
@@ -2262,7 +2268,7 @@ class System(_SireWrapper):
                     return
 
             elif format == "GROMACS":
-                if waters[0].isGromacsWater():
+                if not is_crystal and waters[0].isGromacsWater():
                     return
 
             # There will be a "water_model" system property if this object was
@@ -2288,7 +2294,7 @@ class System(_SireWrapper):
                 )
             else:
                 self._sire_object = _SireIO.setGromacsWater(
-                    self._sire_object, water_model, property_map
+                    self._sire_object, water_model, property_map, is_crystal
                 )
 
     def _set_atom_index_tally(self):

--- a/tests/Sandpit/Exscientia/Solvent/test_solvent.py
+++ b/tests/Sandpit/Exscientia/Solvent/test_solvent.py
@@ -1,0 +1,84 @@
+import pytest
+import tempfile
+
+from sire.legacy.IO import GroTop
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+
+from tests.Sandpit.Exscientia.conftest import has_gromacs
+
+
+@pytest.fixture(scope="module")
+def system():
+    return BSS.IO.readMolecules(
+        BSS.IO.expand(BSS.tutorialUrl(), ["ala_xtal_water.gro", "ala_xtal_water.top"])
+    )
+
+
+@pytest.mark.parametrize("match_water", [True, False])
+@pytest.mark.skipif(not has_gromacs, reason="Requires GROMACS to be installed")
+def test_crystal_water(system, match_water):
+    """
+    Test that user defined crystal waters can be preserved during
+    solvation and on write to GroTop format.
+    """
+
+    # Store the number of crystal waters.
+    if match_water:
+        num_matches = 0
+    else:
+        num_matches = len(system.search("resname COF").molecules())
+
+    # Create the box parameters.
+    box, angles = BSS.Box.cubic(3 * BSS.Units.Length.nanometer)
+
+    # Create the solvated system.
+    solvated = BSS.Solvent.tip3p(system, box, angles, match_water=match_water)
+
+    # Search for the crystal waters in the solvated system.
+    try:
+        num_cof = len(solvated.search("resname COF").molecules())
+    except:
+        num_cof = 0
+
+    # Check that the number of crystal waters is as expected.
+    assert num_cof == num_matches
+
+    # Create a temporary working directory.
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_path = tmp_dir.name
+
+    # Write to GroTop format.
+    BSS.IO.saveMolecules(
+        f"{tmp_path}/test", solvated, "grotop", match_water=match_water
+    )
+
+    # Initialise the number of crystal waters.
+    num_cof = 0
+
+    # Read back in.
+    with open(f"{tmp_path}/test.top", "r") as f:
+        for line in f:
+            if "COF" in line:
+                num_cof = int(line.strip().split()[1])
+                break
+
+    # Make sure the correct number of crystal waters are present.
+    assert num_cof == num_matches
+
+    if not match_water:
+        # Write to GroTop format, replacing the water topology.
+        BSS.IO.saveMolecules(f"{tmp_path}/test", solvated, "grotop", match_water=True)
+
+        # Initialise the number of crystal waters.
+        num_cof = 0
+
+        # Read back in.
+        with open(f"{tmp_path}/test.top", "r") as f:
+            for line in f:
+                if "COF" in line:
+                    num_cof = int(line.strip().split()[1])
+                    break
+
+        # Make sure there are no crystal waters in the file.
+        assert num_cof == 0

--- a/tests/Sandpit/Exscientia/Solvent/test_solvent.py
+++ b/tests/Sandpit/Exscientia/Solvent/test_solvent.py
@@ -11,7 +11,9 @@ from tests.Sandpit.Exscientia.conftest import has_gromacs
 @pytest.fixture(scope="module")
 def system():
     return BSS.IO.readMolecules(
-        BSS.IO.expand(BSS.tutorialUrl(), ["ala_xtal_water.gro", "ala_xtal_water.top"])
+        BSS.IO.expand(
+            BSS.tutorialUrl(), ["kigaki_xtal_water.gro", "kigaki_xtal_water.top"]
+        )
     )
 
 
@@ -30,7 +32,7 @@ def test_crystal_water(system, match_water):
         num_matches = len(system.search("resname COF").molecules())
 
     # Create the box parameters.
-    box, angles = BSS.Box.cubic(3 * BSS.Units.Length.nanometer)
+    box, angles = BSS.Box.cubic(5.5 * BSS.Units.Length.nanometer)
 
     # Create the solvated system.
     solvated = BSS.Solvent.tip3p(system, box, angles, match_water=match_water)

--- a/tests/Solvent/test_solvent.py
+++ b/tests/Solvent/test_solvent.py
@@ -11,7 +11,9 @@ from tests.conftest import has_gromacs
 @pytest.fixture(scope="module")
 def system():
     return BSS.IO.readMolecules(
-        BSS.IO.expand(BSS.tutorialUrl(), ["ala_xtal_water.gro", "ala_xtal_water.top"])
+        BSS.IO.expand(
+            BSS.tutorialUrl(), ["kigaki_xtal_water.gro", "kigaki_xtal_water.top"]
+        )
     )
 
 
@@ -30,7 +32,7 @@ def test_crystal_water(system, match_water):
         num_matches = len(system.search("resname COF").molecules())
 
     # Create the box parameters.
-    box, angles = BSS.Box.cubic(3 * BSS.Units.Length.nanometer)
+    box, angles = BSS.Box.cubic(5.5 * BSS.Units.Length.nanometer)
 
     # Create the solvated system.
     solvated = BSS.Solvent.tip3p(system, box, angles, match_water=match_water)

--- a/tests/Solvent/test_solvent.py
+++ b/tests/Solvent/test_solvent.py
@@ -1,0 +1,84 @@
+import pytest
+import tempfile
+
+from sire.legacy.IO import GroTop
+
+import BioSimSpace as BSS
+
+from tests.conftest import has_gromacs
+
+
+@pytest.fixture(scope="module")
+def system():
+    return BSS.IO.readMolecules(
+        BSS.IO.expand(BSS.tutorialUrl(), ["ala_xtal_water.gro", "ala_xtal_water.top"])
+    )
+
+
+@pytest.mark.parametrize("match_water", [True, False])
+@pytest.mark.skipif(not has_gromacs, reason="Requires GROMACS to be installed")
+def test_crystal_water(system, match_water):
+    """
+    Test that user defined crystal waters can be preserved during
+    solvation and on write to GroTop format.
+    """
+
+    # Store the number of crystal waters.
+    if match_water:
+        num_matches = 0
+    else:
+        num_matches = len(system.search("resname COF").molecules())
+
+    # Create the box parameters.
+    box, angles = BSS.Box.cubic(3 * BSS.Units.Length.nanometer)
+
+    # Create the solvated system.
+    solvated = BSS.Solvent.tip3p(system, box, angles, match_water=match_water)
+
+    # Search for the crystal waters in the solvated system.
+    try:
+        num_cof = len(solvated.search("resname COF").molecules())
+    except:
+        num_cof = 0
+
+    # Check that the number of crystal waters is as expected.
+    assert num_cof == num_matches
+
+    # Create a temporary working directory.
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_path = tmp_dir.name
+
+    # Write to GroTop format.
+    BSS.IO.saveMolecules(
+        f"{tmp_path}/test", solvated, "grotop", match_water=match_water
+    )
+
+    # Initialise the number of crystal waters.
+    num_cof = 0
+
+    # Read back in.
+    with open(f"{tmp_path}/test.top", "r") as f:
+        for line in f:
+            if "COF" in line:
+                num_cof = int(line.strip().split()[1])
+                break
+
+    # Make sure the correct number of crystal waters are present.
+    assert num_cof == num_matches
+
+    if not match_water:
+        # Write to GroTop format, replacing the water topology.
+        BSS.IO.saveMolecules(f"{tmp_path}/test", solvated, "grotop", match_water=True)
+
+        # Initialise the number of crystal waters.
+        num_cof = 0
+
+        # Read back in.
+        with open(f"{tmp_path}/test.top", "r") as f:
+            for line in f:
+                if "COF" in line:
+                    num_cof = int(line.strip().split()[1])
+                    break
+
+        # Make sure there are no crystal waters in the file.
+        assert num_cof == 0


### PR DESCRIPTION
This PR adds support for setting up simulations for systems containing crystal waters. While we have always handled existing water molecules for solvation, this update provides an easy way for users to load PDB systems with embedded crystal waters, then parameterise and solvate them. The waters need not be unique molecules, since they can be extracted using the `.extract` method, and also do not need to have hydrogen atoms. For the latter, I've added a `ensure_compatible` option to the parametise function to allow users to choose when to ignore the `makeCompatibleWith` check, e.g. when `tLEaP` adds the missing hydrogens when parameterising the solvent. (The default is `ensure_compatible=True`.) We now also make sure that `gmx genion` doesn't accidentally remove any crystal waters when adding ions during solvation. A full tutorial can be found [here](https://github.com/OpenBioSim/biosimspace/blob/feature_crystal_water/doc/source/tutorials/crystal_water.rst).

Closes michellab/BioSimSpace#32
Closes michellab/BioSimSpace#427
Closes #67
Closes #112
Closes #141
Closes #148
Closes #149

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods