### PR TITLE
Fix handling of connectivity changes during molecular perturbations

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -1016,6 +1016,23 @@ def readPerturbableSystem(top0, coords0, top1, coords1, property_map={}):
     mol.setProperty("molecule0", system0[idx]._sire_object)
     mol.setProperty("molecule1", system1[idx]._sire_object)
 
+    # Get the connectivity property name.
+    conn_prop = property_map.get("connectivity", "connectivity")
+
+    # Get the connectivity from the end states.
+    conn0 = mol.property(conn_prop + "0")
+    conn1 = mol.property(conn_prop + "1")
+
+    # Check whether the connectivity is the same.
+    if conn0 == conn1:
+        # The connectivity is the same, so we can use the connectivity
+        # from the lambda=0 end state.
+        mol = mol.setProperty(conn_prop, conn0).molecule()
+
+        # Delete the end state properties.
+        mol = mol.removeProperty(conn_prop + "0").molecule()
+        mol = mol.removeProperty(conn_prop + "1").molecule()
+
     # Commit the changes.
     mol = _Molecule(mol.commit())
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -1016,6 +1016,23 @@ def readPerturbableSystem(top0, coords0, top1, coords1, property_map={}):
     mol.setProperty("molecule0", system0[idx]._sire_object)
     mol.setProperty("molecule1", system1[idx]._sire_object)
 
+    # Get the connectivity property name.
+    conn_prop = property_map.get("connectivity", "connectivity")
+
+    # Get the connectivity from the end states.
+    conn0 = mol.property(conn_prop + "0")
+    conn1 = mol.property(conn_prop + "1")
+
+    # Check whether the connectivity is the same.
+    if conn0 == conn1:
+        # The connectivity is the same, so we can use the connectivity
+        # from the lambda=0 end state.
+        mol = mol.setProperty(conn_prop, conn0).molecule()
+
+        # Delete the end state properties.
+        mol = mol.removeProperty(conn_prop + "0").molecule()
+        mol = mol.removeProperty(conn_prop + "1").molecule()
+
     # Commit the changes.
     mol = _Molecule(mol.commit())
 

--- a/tests/IO/test_perturbable.py
+++ b/tests/IO/test_perturbable.py
@@ -1,0 +1,27 @@
+import pytest
+
+import BioSimSpace as BSS
+
+from tests.conftest import url
+
+
+@pytest.fixture(scope="module")
+def perturbable_molecule():
+    """Re-use the same perturbable system for each test."""
+    return BSS.IO.readPerturbableSystem(
+        f"{url}/perturbable_system0.prm7",
+        f"{url}/perturbable_system0.rst7",
+        f"{url}/perturbable_system1.prm7",
+        f"{url}/perturbable_system1.rst7",
+    ).getMolecules()[0]
+
+
+def test_connectivity(perturbable_molecule):
+    """
+    Make sure there is a single connectivity property when the end states
+    have the same bonding.
+    """
+
+    assert perturbable_molecule._sire_object.hasProperty("connectivity")
+    assert not perturbable_molecule._sire_object.hasProperty("connectivity0")
+    assert not perturbable_molecule._sire_object.hasProperty("connectivity1")

--- a/tests/Sandpit/Exscientia/IO/test_perturbable.py
+++ b/tests/Sandpit/Exscientia/IO/test_perturbable.py
@@ -1,0 +1,27 @@
+import pytest
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+
+from tests.Sandpit.Exscientia.conftest import url
+
+
+@pytest.fixture(scope="module")
+def perturbable_molecule():
+    """Re-use the same perturbable system for each test."""
+    return BSS.IO.readPerturbableSystem(
+        f"{url}/perturbable_system0.prm7",
+        f"{url}/perturbable_system0.rst7",
+        f"{url}/perturbable_system1.prm7",
+        f"{url}/perturbable_system1.rst7",
+    ).getMolecules()[0]
+
+
+def test_connectivity(perturbable_molecule):
+    """
+    Make sure there is a single connectivity property when the end states
+    have the same bonding.
+    """
+
+    assert perturbable_molecule._sire_object.hasProperty("connectivity")
+    assert not perturbable_molecule._sire_object.hasProperty("connectivity0")
+    assert not perturbable_molecule._sire_object.hasProperty("connectivity1")


### PR DESCRIPTION
This PR makes some fixes associated with the _connectivity_ of merged molecules:

* In the `BioSimSpace.IO.readPerturbableSystem` function we now set a _single_ `connectivity` property if `connectivity0` and `connectivity1` of the two loaded end states are the same. This means that the resulting system is consistent with the _original_ perturbable system, and what would be obtained when streaming to/from a `.bss` file.
* Merges that _do_ change connectivity are now checked for in the correct way, i.e. by creating a unique connectivity object for both end states and seeing how the connectivity changes between them. (Previously this was done using a single connectivity for both end states.) If the connectivity _does_ change between end states, then we do attach two properties to the molecule, i.e. `connectivity0` and `connectivity1`.
* The logic for the `intrascale` matrix generation has been updated to handle different connectivities. This is the exact same approach as already used in the Exscientia Sandpit for their "region of interest" merge, which can be used for mutations. (I'm not yet sure if this is correct in all cases, but it is certainly more correct than what we have now.)

(I've not ported the updates to the merge code to the Exscientia sandpit since they already have their own functionality for handling perturbations of this nature.)

## Checklist

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods