### PR TITLE
Fix  issue #159

### DIFF
--- a/python/BioSimSpace/Convert/_convert.py
+++ b/python/BioSimSpace/Convert/_convert.py
@@ -49,6 +49,7 @@ from sire import smiles as _sire_smiles
 
 import sire.legacy.Mol as _SireMol
 import sire.legacy.System as _SireSystem
+import sire.legacy.Vol as _SireVol
 
 import sire.system as _NewSireSystem
 
@@ -205,13 +206,27 @@ def to(obj, format="biosimspace", property_map={}):
                 try:
                     obj = obj.toSystem()
                 except:
-                    # Otherwise, convert residues/atoms to a molecule.
+                    # Otherwise, convert residues/atoms to a molecule, then a system.
                     try:
-                        obj = obj.toMolecule()
+                        obj = obj.toMolecule().toSystem()
                     except:
                         raise _ConversionError(
                             "Unable to convert object to OpenMM format!"
                         )
+
+            # Get the user-defined space property name.
+            prop = property_map.get("space", "space")
+
+            # Try to get the space property. Use an infinite cartesian space
+            # if none is present.
+            try:
+                space = obj._sire_object.property(prop)
+            except:
+                space = _SireVol.Cartesian()
+
+            # Set a shared space property.
+            obj._sire_object.addSharedProperty(prop)
+            obj._sire_object.setSharedProperty(prop, space)
 
             # Now try to convert the object to OpenMM format.
             try:

--- a/python/BioSimSpace/Convert/_convert.py
+++ b/python/BioSimSpace/Convert/_convert.py
@@ -225,8 +225,7 @@ def to(obj, format="biosimspace", property_map={}):
                 space = _SireVol.Cartesian()
 
             # Set a shared space property.
-            obj._sire_object.addSharedProperty(prop)
-            obj._sire_object.setSharedProperty(prop, space)
+            obj._sire_object.addSharedProperty(prop, space)
 
             # Now try to convert the object to OpenMM format.
             try:

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -524,8 +524,27 @@ def readMolecules(
                     raise IOError(msg) from None
 
     # Add a file format shared property.
-    system.addSharedProperty("fileformat")
-    system.setSharedProperty("fileformat", system.property("fileformat"))
+    prop = property_map.get("fileformat", "fileformat")
+    system.addSharedProperty(prop)
+    system.setSharedProperty(prop, system.property(prop))
+
+    # Remove "space" and "time" shared properties since this causes incorrect
+    # behaviour when extracting molecules and recombining them to make other
+    # systems.
+    try:
+        # Space.
+        prop = property_map.get("space", "space")
+        space = system.property(prop)
+        system.removeSharedProperty(prop)
+        system.setProperty(prop, space)
+
+        # Time.
+        prop = property_map.get("time", "time")
+        time = system.property(prop)
+        system.removeSharedProperty(prop)
+        system.setProperties(prop, time)
+    except:
+        pass
 
     return _System(system)
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -523,6 +523,10 @@ def readMolecules(
                 else:
                     raise IOError(msg) from None
 
+    # Add a file format shared property.
+    system.addSharedProperty("fileformat")
+    system.setSharedProperty("fileformat", system.property("fileformat"))
+
     return _System(system)
 
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -525,8 +525,7 @@ def readMolecules(
 
     # Add a file format shared property.
     prop = property_map.get("fileformat", "fileformat")
-    system.addSharedProperty(prop)
-    system.setSharedProperty(prop, system.property(prop))
+    system.addSharedProperty(prop, system.property(prop))
 
     # Remove "space" and "time" shared properties since this causes incorrect
     # behaviour when extracting molecules and recombining them to make other

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
@@ -49,6 +49,7 @@ from sire import smiles as _sire_smiles
 
 import sire.legacy.Mol as _SireMol
 import sire.legacy.System as _SireSystem
+import sire.legacy.Vol as _SireVol
 
 import sire.system as _NewSireSystem
 
@@ -205,13 +206,27 @@ def to(obj, format="biosimspace", property_map={}):
                 try:
                     obj = obj.toSystem()
                 except:
-                    # Otherwise, convert residues/atoms to a molecule.
+                    # Otherwise, convert residues/atoms to a molecule, then a system.
                     try:
-                        obj = obj.toMolecule()
+                        obj = obj.toMolecule().toSystem()
                     except:
                         raise _ConversionError(
                             "Unable to convert object to OpenMM format!"
                         )
+
+            # Get the user-defined space property name.
+            prop = property_map.get("space", "space")
+
+            # Try to get the space property. Use an infinite cartesian space
+            # if none is present.
+            try:
+                space = obj._sire_object.property(prop)
+            except:
+                space = _SireVol.Cartesian()
+
+            # Set a shared space property.
+            obj._sire_object.addSharedProperty(prop)
+            obj._sire_object.setSharedProperty(prop, space)
 
             # Now try to convert the object to OpenMM format.
             try:

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
@@ -225,8 +225,7 @@ def to(obj, format="biosimspace", property_map={}):
                 space = _SireVol.Cartesian()
 
             # Set a shared space property.
-            obj._sire_object.addSharedProperty(prop)
-            obj._sire_object.setSharedProperty(prop, space)
+            obj._sire_object.addSharedProperty(prop, space)
 
             # Now try to convert the object to OpenMM format.
             try:

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -524,8 +524,27 @@ def readMolecules(
                     raise IOError(msg) from None
 
     # Add a file format shared property.
-    system.addSharedProperty("fileformat")
-    system.setSharedProperty("fileformat", system.property("fileformat"))
+    prop = property_map.get("fileformat", "fileformat")
+    system.addSharedProperty(prop)
+    system.setSharedProperty(prop, system.property(prop))
+
+    # Remove "space" and "time" shared properties since this causes incorrect
+    # behaviour when extracting molecules and recombining them to make other
+    # systems.
+    try:
+        # Space.
+        prop = property_map.get("space", "space")
+        space = system.property(prop)
+        system.removeSharedProperty(prop)
+        system.setProperty(prop, space)
+
+        # Time.
+        prop = property_map.get("time", "time")
+        time = system.property(prop)
+        system.removeSharedProperty(prop)
+        system.setProperties(prop, time)
+    except:
+        pass
 
     return _System(system)
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -523,6 +523,10 @@ def readMolecules(
                 else:
                     raise IOError(msg) from None
 
+    # Add a file format shared property.
+    system.addSharedProperty("fileformat")
+    system.setSharedProperty("fileformat", system.property("fileformat"))
+
     return _System(system)
 
 

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -525,8 +525,7 @@ def readMolecules(
 
     # Add a file format shared property.
     prop = property_map.get("fileformat", "fileformat")
-    system.addSharedProperty(prop)
-    system.setSharedProperty(prop, system.property(prop))
+    system.addSharedProperty(prop, system.property(prop))
 
     # Remove "space" and "time" shared properties since this causes incorrect
     # behaviour when extracting molecules and recombining them to make other

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -136,23 +136,6 @@ class System(_SireWrapper):
         # Initialise the iterator counter.
         self._iter_count = 0
 
-        # Copy any fileformat property to each molecule.
-        if "fileformat" in self._sire_object.propertyKeys():
-            fileformat = self._sire_object.property("fileformat")
-            for num in self._mol_nums:
-                edit_mol = self._sire_object[num].edit()
-                edit_mol = edit_mol.setProperty("fileformat", fileformat)
-                self._sire_object.update(edit_mol.commit())
-        else:
-            # If a molecule has a fileformat property, use the first
-            # that we find.
-            for mol in self:
-                if mol._sire_object.hasProperty("fileformat"):
-                    self._sire_object.setProperty(
-                        "fileformat", mol._sire_object.property("fileformat")
-                    )
-                    break
-
         # Reset the index mappings.
         self._reset_mappings()
 

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -136,23 +136,6 @@ class System(_SireWrapper):
         # Initialise the iterator counter.
         self._iter_count = 0
 
-        # Copy any fileformat property to each molecule.
-        if "fileformat" in self._sire_object.propertyKeys():
-            fileformat = self._sire_object.property("fileformat")
-            for num in self._mol_nums:
-                edit_mol = self._sire_object[num].edit()
-                edit_mol = edit_mol.setProperty("fileformat", fileformat)
-                self._sire_object.update(edit_mol.commit())
-        else:
-            # If a molecule has a fileformat property, use the first
-            # that we find.
-            for mol in self:
-                if mol._sire_object.hasProperty("fileformat"):
-                    self._sire_object.setProperty(
-                        "fileformat", mol._sire_object.property("fileformat")
-                    )
-                    break
-
         # Reset the index mappings.
         self._reset_mappings()
 


### PR DESCRIPTION
This PR closes #159. On conversion to OpenMM format we set a shared space property if one isn't already present. If there isn't one, then we use an infinite Cartesian space. On read, systems are automatically assigned a shared space property, since we wrap the new `sr.load` code. In order to preserve the existing BioSimSpace behaviour related to extraction and recombination of molecules, I've needed to remove these shared properties, adding them back as regular system properties. This avoids situations where multiple molecules in a new system have a _different_ space property, or an incompatible space property being applied to a system on conversion to OpenMM when a vacuum simulation would be expected.

I've also updated the code to use a shared property on read for the `fileformat`. (Previously this was done in a manual way.) This is useful so that extracted molecules passed on to certain parameterisation functions retain information that specifies the format from which they were loaded, i.e. if `SDF` then we can safely write back to the same format in knowledge that all information is preserved.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods