### PR TITLE
Ensure that SOMD ABFE pert files are always correct

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -1269,6 +1269,9 @@ def _to_pert_file(
                     # Get the perturbed atom.
                     atom = mol.atom(idx)
 
+                    # Start atom record.
+                    file.write("    atom\n")
+
                     # Only require the initial Lennard-Jones properties.
                     LJ0 = atom.property("LJ0")
 
@@ -3002,8 +3005,8 @@ def _to_pert_file(
                             # End improper record.
                             file.write("    endimproper\n")
 
-            # End molecule record.
-            file.write("endmolecule\n")
+        # End molecule record.
+        file.write("endmolecule\n")
 
     # Finally, convert the molecule to the lambda = 0 state.
 

--- a/tests/Sandpit/Exscientia/Protocol/test_config.py
+++ b/tests/Sandpit/Exscientia/Protocol/test_config.py
@@ -373,12 +373,16 @@ class TestSomdABFE:
                 assert atom in pert_text
             # Check perturbations are correct
             lines = [
+                "molecule LIG",
+                "atom",
                 "initial_type   C1",
                 "final_type     C1",
                 "initial_LJ     3.48065 0.08688",
                 "final_LJ       3.48065 0.08688",
                 "initial_charge -0.13000",
                 "final_charge   -0.13000",
+                "endatom",
+                "endmolecule",
             ]
             for line in lines:
                 assert line in pert_text
@@ -413,12 +417,16 @@ class TestSomdABFE:
                 assert atom in pert_text
             # Check perturbations are correct
             lines = [
+                "molecule LIG",
+                "atom",
                 "initial_type   C1",
                 "final_type     C1",
                 "initial_LJ     3.48065 0.08688",
                 "final_LJ       3.48065 0.08688",
                 "initial_charge -0.13000",
                 "final_charge   -0.00000",
+                "endatom",
+                "endmolecule",
             ]
             for line in lines:
                 assert line in pert_text
@@ -453,12 +461,16 @@ class TestSomdABFE:
                 assert atom in pert_text
             # Check perturbations are correct
             lines = [
+                "molecule LIG",
+                "atom",
                 "initial_type   C1",
                 "final_type     du",
                 "initial_LJ     3.48065 0.08688",
                 "final_LJ       0.00000 0.00000",
                 "initial_charge -0.00000",
                 "final_charge   -0.00000",
+                "endatom",
+                "endmolecule",
             ]
             for line in lines:
                 assert line in pert_text
@@ -493,12 +505,16 @@ class TestSomdABFE:
                 assert atom in pert_text
             # Check perturbations are correct
             lines = [
+                "molecule LIG",
+                "atom",
                 "initial_type   C1",
                 "final_type     du",
                 "initial_LJ     3.48065 0.08688",
                 "final_LJ       0.00000 0.00000",
                 "initial_charge -0.13000",
                 "final_charge   0.00000",
+                "endatom",
+                "endmolecule",
             ]
             for line in lines:
                 assert line in pert_text


### PR DESCRIPTION
This fixes issues with the writing of SOMD pert files for ABFE calculations where "atom" could be missed from the start of the atom records and "endmolecule" was always absent. I've extended the tests to cover these sections of the pert files.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges