### PR TITLE
Fix user commands that reference mol error:

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -460,11 +460,13 @@ class AmberProtein(_protocol.Protocol):
                     file.write("source leaprc.water.tip4pew\n")
                 else:
                     file.write("source leaprc.water.%s\n" % self._water_model)
+            # If user commands reference mol, this needs to be first
+            file.write("mol = loadPdb leap.pdb\n")
             # Write extra user commands.
             if self._leap_commands is not None:
                 for command in self._leap_commands:
                     file.write("%s\n" % command)
-            file.write("mol = loadPdb leap.pdb\n")
+            # file.write("mol = loadPdb leap.pdb\n")
             # Add any disulphide bond records.
             for bond in disulphide_bonds:
                 file.write("%s\n" % bond)


### PR DESCRIPTION
Code caused "Argument #1 is of type String must be of type: [unit]" error because 'mol =' was being added to leap.txt after the user commands.  So any user commands that referenced it failed (e.g. solvateBox).

# Is this pull request to fix a bug, or to introduce new functionality?

## If this is to fix a bug...

This pull request fixes issue Not a recorded issue I could find.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y/n] y
* I confirm that I have permission to release this code under the GPL3 license: [y/n] y

## If this introduces new functionality...

Changes proposed in this pull request:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y/n] y
* I confirm that I have added a test for any new functionality in this pull request: [y/n] y
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y/n] y
* I confirm that I have permission to release this code under the GPL3 license: [y/n] y

## Suggested reviewers:
@lohedges, @chryswoods

## Any additional context of information?

(you can also attach files by dragging & dropping)
