### PR TITLE
Fix issue #172

### DIFF
--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -442,9 +442,10 @@ class Amber(_process.Process):
             # Update the box information in the original system.
             if "space" in new_system._sire_object.propertyKeys():
                 box = new_system._sire_object.property("space")
-                old_system._sire_object.setProperty(
-                    self._property_map.get("space", "space"), box
-                )
+                if box.isPeriodic():
+                    old_system._sire_object.setProperty(
+                        self._property_map.get("space", "space"), box
+                    )
 
             return old_system
 

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -2537,9 +2537,10 @@ class Gromacs(_process.Process):
                     and space_prop in new_system._sire_object.propertyKeys()
                 ):
                     box = new_system._sire_object.property("space")
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+                    if box.isPeriodic():
+                        old_system._sire_object.setProperty(
+                            self._property_map.get("space", "space"), box
+                        )
 
                 # If this is a vacuum simulation, then translate the centre of mass
                 # of the system back to the origin.

--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -789,9 +789,10 @@ class Namd(_process.Process):
                 # Update the box information in the original system.
                 if "space" in new_system._sire_object.propertyKeys():
                     box = new_system._sire_object.property("space")
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+                    if box.isPeriodic():
+                        old_system._sire_object.setProperty(
+                            self._property_map.get("space", "space"), box
+                        )
 
                 return old_system
 

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1318,9 +1318,10 @@ class OpenMM(_process.Process):
                 # Update the box information in the original system.
                 if "space" in new_system._sire_object.propertyKeys():
                     box = new_system._sire_object.property("space")
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+                    if box.isPeriodic():
+                        old_system._sire_object.setProperty(
+                            self._property_map.get("space", "space"), box
+                        )
 
                 return old_system
 

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -566,9 +566,10 @@ class Somd(_process.Process):
             # Update the box information in the original system.
             if "space" in new_system._sire_object.propertyKeys():
                 box = new_system._sire_object.property("space")
-                old_system._sire_object.setProperty(
-                    self._property_map.get("space", "space"), box
-                )
+                if box.isPeriodic():
+                    old_system._sire_object.setProperty(
+                        self._property_map.get("space", "space"), box
+                    )
 
             return old_system
 

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -540,6 +540,13 @@ class Somd(_process.Process):
 
             new_system = _IO.readMolecules(self._restart_file)
 
+            # Try loading the trajectory file to get the box information.
+            try:
+                frame = self.getTrajectory().getFrames(-1)
+                box = frame._sire_object.property("space")
+            except:
+                box = None
+
             # Since SOMD requires specific residue and water naming we copy the
             # coordinates back into the original system.
             old_system = self._system.copy()
@@ -564,12 +571,10 @@ class Somd(_process.Process):
             self._mapping = mapping
 
             # Update the box information in the original system.
-            if "space" in new_system._sire_object.propertyKeys():
-                box = new_system._sire_object.property("space")
-                if box.isPeriodic():
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+            if box and box.isPeriodic():
+                old_system._sire_object.setProperty(
+                    self._property_map.get("space", "space"), box
+                )
 
             return old_system
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -693,9 +693,10 @@ class Amber(_process.Process):
             # Update the box information in the original system.
             if "space" in new_system._sire_object.propertyKeys():
                 box = new_system._sire_object.property("space")
-                old_system._sire_object.setProperty(
-                    self._property_map.get("space", "space"), box
-                )
+                if box.isPeriodic():
+                    old_system._sire_object.setProperty(
+                        self._property_map.get("space", "space"), box
+                    )
 
             return old_system
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2597,9 +2597,10 @@ class Gromacs(_process.Process):
                     and space_prop in new_system._sire_object.propertyKeys()
                 ):
                     box = new_system._sire_object.property("space")
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+                    if box.isPeriodic():
+                        old_system._sire_object.setProperty(
+                            self._property_map.get("space", "space"), box
+                        )
 
                 # If this is a vacuum simulation, then translate the centre of mass
                 # of the system back to the origin.

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
@@ -787,9 +787,10 @@ class Namd(_process.Process):
                 # Update the box information in the original system.
                 if "space" in new_system._sire_object.propertyKeys():
                     box = new_system._sire_object.property("space")
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+                    if box.isPeriodic():
+                        old_system._sire_object.setProperty(
+                            self._property_map.get("space", "space"), box
+                        )
 
                 return old_system
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -1322,9 +1322,10 @@ class OpenMM(_process.Process):
                 # Update the box information in the original system.
                 if "space" in new_system._sire_object.propertyKeys():
                     box = new_system._sire_object.property("space")
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+                    if box.isPeriodic():
+                        old_system._sire_object.setProperty(
+                            self._property_map.get("space", "space"), box
+                        )
 
                 return old_system
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -585,9 +585,10 @@ class Somd(_process.Process):
             # Update the box information in the original system.
             if "space" in new_system._sire_object.propertyKeys():
                 box = new_system._sire_object.property("space")
-                old_system._sire_object.setProperty(
-                    self._property_map.get("space", "space"), box
-                )
+                if box.isPeriodic():
+                    old_system._sire_object.setProperty(
+                        self._property_map.get("space", "space"), box
+                    )
 
             return old_system
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -559,6 +559,13 @@ class Somd(_process.Process):
 
             new_system = _IO.readMolecules(self._restart_file)
 
+            # Try loading the trajectory file to get the box information.
+            try:
+                frame = self.getTrajectory().getFrames(-1)
+                box = frame._sire_object.property("space")
+            except:
+                box = None
+
             # Since SOMD requires specific residue and water naming we copy the
             # coordinates back into the original system.
             old_system = self._system.copy()
@@ -583,12 +590,10 @@ class Somd(_process.Process):
             self._mapping = mapping
 
             # Update the box information in the original system.
-            if "space" in new_system._sire_object.propertyKeys():
-                box = new_system._sire_object.property("space")
-                if box.isPeriodic():
-                    old_system._sire_object.setProperty(
-                        self._property_map.get("space", "space"), box
-                    )
+            if box and box.isPeriodic():
+                old_system._sire_object.setProperty(
+                    self._property_map.get("space", "space"), box
+                )
 
             return old_system
 

--- a/tests/Process/test_somd.py
+++ b/tests/Process/test_somd.py
@@ -175,5 +175,11 @@ def run_process(system, protocol):
     # Make sure the process didn't error.
     assert not res
 
-    # Make sure that we get a molecular system back.
-    assert process.getSystem() is not None
+    # Get the updated system.
+    new_system = process.getSystem()
+
+    # Make sure that we got a molecular system back.
+    assert new_system is not None
+
+    # Make sure the space is valid.
+    assert new_system._sire_object.property("space").isPeriodic()

--- a/tests/Sandpit/Exscientia/Process/test_somd.py
+++ b/tests/Sandpit/Exscientia/Process/test_somd.py
@@ -220,5 +220,12 @@ def run_process(system, protocol, **kwargs):
     # Make sure the process didn't error.
     assert not res
 
-    # Make sure that we get a molecular system back.
-    assert process.getSystem() is not None
+    # Get the updated system.
+    new_system = process.getSystem()
+
+    # Make sure that we got a molecular system back.
+    assert new_system is not None
+
+    # Make sure the space is valid.
+    if system.getBox()[0] is not None:
+        assert new_system._sire_object.property("space").isPeriodic()


### PR DESCRIPTION
This PR closes #172. We now check that the space of any loaded system is periodic before updating the property in the original system, e.g. when calling `getSystem()` on a process, or when parsing trajectory frames with reference to an existing system. This avoids the space being replaced by a `sire.legacy.Vol.Cartesian` space if the file format used to load the new system doesn't contain space information, which is the case for SOMD.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods