### PR TITLE
Feature reduce

### DIFF
--- a/doc/source/api/index_Box.rst
+++ b/doc/source/api/index_Box.rst
@@ -11,11 +11,7 @@ To support triclinic boxes that work across the range of molecular simulation
 engines that support, we represent the triclinic space in reduced form, using
 the approach documented in Appendix A of Chapter 3 from
 `"Molecular dynamics of sense and sensibility in processing and analysis of data" <https://research.rug.nl/files/2839528/01_c1.pdf>`__
-by Tsjerk A. Wassenaar. Due to the fixed-width format used to represent box
-dimensions and angles in the various molecular input files, repeated reading
-and writing can lead to oscillation of the box angles on reduction due to
-rounding precision errors. To account for this, we add a small bias so that
-we always round in a consistent direction.
+by Tsjerk A. Wassenaar.
 
 .. automodule:: BioSimSpace.Box
 

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -370,7 +370,7 @@ def readMolecules(
         aligned with the x-axis, the second vector lies in the x-y plane,
         and the third vector has a positive z-component. This is a requirement
         of certain molecular dynamics engines and is used for simulation
-        efficiency. All vector properties of the system, e.g. positions,
+        efficiency. All vector properties of the system, e.g. coordinates,
         velocities, etc., will be rotated accordingly.
 
     reduce_box : bool

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -342,7 +342,13 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
 
 
 def readMolecules(
-    files, make_whole=False, show_warnings=False, download_dir=None, property_map={}
+    files,
+    make_whole=False,
+    rotate_box=False,
+    reduce_box=False,
+    show_warnings=False,
+    download_dir=None,
+    property_map={},
 ):
     """
     Read a molecular system from file.
@@ -358,6 +364,17 @@ def readMolecules(
     make_whole : bool
         Whether to make molecules whole, i.e. unwrap those that are split across
         the periodic boundary.
+
+    rotate_box : bool
+        Rotate the box vectors of the system so that the first vector is
+        aligned with the x-axis, the second vector lies in the x-y plane,
+        and the third vector has a positive z-component. This is a requirement
+        of certain molecular dynamics engines and is used for simulation
+        efficiency. All vector properties of the system, e.g. positions,
+        velocities, etc., will be rotated accordingly.
+
+    reduce_box : bool
+        Reduce the box vectors.
 
     show_warnings : bool
         Whether to show any warnings raised during parsing of the input files.
@@ -438,6 +455,14 @@ def readMolecules(
     # Flag that we want' to unwrap molecules.
     if make_whole:
         property_map["make_whole"] = _SireBase.wrap(make_whole)
+
+    # Validate the box rotation flag.
+    if not isinstance(rotate_box, bool):
+        raise TypeError("'rotate_box' must be of type 'bool'.")
+
+    # Validate the box reduction flag.
+    if not isinstance(reduce_box, bool):
+        raise TypeError("'reduce_box' must be of type 'bool'.")
 
     # Validate the warning message flag.
     if not isinstance(show_warnings, bool):
@@ -545,7 +570,18 @@ def readMolecules(
     except:
         pass
 
-    return _System(system)
+    # Wrap the Sire system.
+    system = _System(system)
+
+    # Rotate the box vectors.
+    if rotate_box:
+        system.rotateBoxVectors()
+
+    # Reduce the box vectors.
+    if reduce_box:
+        system.reduceBoxVectors()
+
+    return system
 
 
 def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -370,7 +370,7 @@ def readMolecules(
         aligned with the x-axis, the second vector lies in the x-y plane,
         and the third vector has a positive z-component. This is a requirement
         of certain molecular dynamics engines and is used for simulation
-        efficiency. All vector properties of the system, e.g. positions,
+        efficiency. All vector properties of the system, e.g. coordinates,
         velocities, etc., will be rotated accordingly.
 
     reduce_box : bool

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -342,7 +342,13 @@ def readPDB(id, pdb4amber=False, work_dir=None, show_warnings=False, property_ma
 
 
 def readMolecules(
-    files, make_whole=False, show_warnings=False, download_dir=None, property_map={}
+    files,
+    make_whole=False,
+    rotate_box=False,
+    reduce_box=False,
+    show_warnings=False,
+    download_dir=None,
+    property_map={},
 ):
     """
     Read a molecular system from file.
@@ -358,6 +364,17 @@ def readMolecules(
     make_whole : bool
         Whether to make molecules whole, i.e. unwrap those that are split across
         the periodic boundary.
+
+    rotate_box : bool
+        Rotate the box vectors of the system so that the first vector is
+        aligned with the x-axis, the second vector lies in the x-y plane,
+        and the third vector has a positive z-component. This is a requirement
+        of certain molecular dynamics engines and is used for simulation
+        efficiency. All vector properties of the system, e.g. positions,
+        velocities, etc., will be rotated accordingly.
+
+    reduce_box : bool
+        Reduce the box vectors.
 
     show_warnings : bool
         Whether to show any warnings raised during parsing of the input files.
@@ -438,6 +455,14 @@ def readMolecules(
     # Flag that we want' to unwrap molecules.
     if make_whole:
         property_map["make_whole"] = _SireBase.wrap(make_whole)
+
+    # Validate the box rotation flag.
+    if not isinstance(rotate_box, bool):
+        raise TypeError("'rotate_box' must be of type 'bool'.")
+
+    # Validate the box reduction flag.
+    if not isinstance(reduce_box, bool):
+        raise TypeError("'reduce_box' must be of type 'bool'.")
 
     # Validate the warning message flag.
     if not isinstance(show_warnings, bool):
@@ -545,7 +570,18 @@ def readMolecules(
     except:
         pass
 
-    return _System(system)
+    # Wrap the Sire system.
+    system = _System(system)
+
+    # Rotate the box vectors.
+    if rotate_box:
+        system.rotateBoxVectors()
+
+    # Reduce the box vectors.
+    if reduce_box:
+        system.reduceBoxVectors()
+
+    return system
 
 
 def saveMolecules(filebase, system, fileformat, property_map={}, **kwargs):

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1145,7 +1145,7 @@ class System(_SireWrapper):
         except:
             return
 
-        # A rotation is only applicable to a triclinic space.
+        # A rotation is only applicable to triclinic spaces.
         if not isinstance(space, _SireVol.TriclinicBox):
             return
 
@@ -1242,7 +1242,7 @@ class System(_SireWrapper):
         except:
             return
 
-        # A rotation is only applicable to a triclinic space.
+        # A rotation is only applicable to triclinic spaces.
         if not isinstance(space, _SireVol.TriclinicBox):
             return
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -41,6 +41,7 @@ from sire.legacy import Units as _SireUnits
 from .. import _isVerbose
 from .._Exceptions import IncompatibleError as _IncompatibleError
 from ..Types import Angle as _Angle
+from ..Types import Coordinate as _Coordinate
 from ..Types import Length as _Length
 from .. import Units as _Units
 
@@ -1115,7 +1116,16 @@ class System(_SireWrapper):
         """
         return len(self.getMLMolecules())
 
-    def rotateBoxVectors(self, precision=0.0, property_map={}):
+    def rotateBoxVectors(
+        self,
+        origin=_Coordinate(
+            0 * _Units.Length.angstrom,
+            0 * _Units.Length.angstrom,
+            0 * _Units.Length.angstrom,
+        ),
+        precision=0.0,
+        property_map={},
+    ):
         """
         Rotate the box vectors of the system so that the first vector is
         aligned with the x-axis, the second vector lies in the x-y plane,
@@ -1126,6 +1136,10 @@ class System(_SireWrapper):
 
         Parameters
         ----------
+
+        origin : :class:`Coordinate <BioSimSpace.Types.Coordinate>`
+            The origin of the triclinic space. This is the point about which
+            the lattice vectors are rotated.
 
         precision : float
             The precision to use when sorting box vectors by their magnitude.
@@ -1149,6 +1163,14 @@ class System(_SireWrapper):
         if not isinstance(space, _SireVol.TriclinicBox):
             return
 
+        # Validate input.
+
+        if not isinstance(origin, _Coordinate):
+            raise TypeError("'origin' must be of type 'BioSimSpace.Types.Coordinate'")
+
+        if not isinstance(precision, float):
+            raise TypeError("'precision' must be of type 'float'")
+
         # Rotate the space according to the desired precision.
         space.rotate(precision)
 
@@ -1157,6 +1179,9 @@ class System(_SireWrapper):
 
         # Get the rotation matrix.
         rotation_matrix = space.rotationMatrix()
+
+        # Get the center of rotation, as a Sire vector.
+        center = origin.toVector()._sire_object
 
         from sire.system import System
 
@@ -1169,7 +1194,7 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("coordinates", "coordinates")
             cursor = cursor.rotate(
-                matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
             )
         except:
             pass
@@ -1178,7 +1203,7 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("velocity", "velocity")
             cursor = cursor.rotate(
-                matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
             )
         except:
             pass
@@ -1189,11 +1214,15 @@ class System(_SireWrapper):
             try:
                 prop_name = property_map.get("coordinates", "coordinates") + "0"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("coordinates", "coordinates") + "1"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
             except:
                 pass
@@ -1202,11 +1231,15 @@ class System(_SireWrapper):
             try:
                 prop_name = property_map.get("velocity", "velocity") + "0"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("velocity", "velocity") + "1"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
             except:
                 pass

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1152,6 +1152,9 @@ class System(_SireWrapper):
         # Rotate the space according to the desired precision.
         space.rotate(precision)
 
+        # Update the space property in the sire object.
+        self._sire_object.setProperty(space_prop, space)
+
         # Get the rotation matrix.
         rotation_matrix = space.rotationMatrix()
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1121,7 +1121,7 @@ class System(_SireWrapper):
         aligned with the x-axis, the second vector lies in the x-y plane,
         and the third vector has a positive z-component. This is a requirement
         of certain molecular dynamics engines and is used for simulation
-        efficiency. All vector properties of the system, e.g. positions,
+        efficiency. All vector properties of the system, e.g. coordinates,
         velocities, etc., will be rotated accordingly.
 
         Parameters

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1069,7 +1069,7 @@ class System(_SireWrapper):
         aligned with the x-axis, the second vector lies in the x-y plane,
         and the third vector has a positive z-component. This is a requirement
         of certain molecular dynamics engines and is used for simulation
-        efficiency. All vector properties of the system, e.g. positions,
+        efficiency. All vector properties of the system, e.g. coordinates,
         velocities, etc., will be rotated accordingly.
 
         Parameters

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1100,6 +1100,9 @@ class System(_SireWrapper):
         # Rotate the space according to the desired precision.
         space.rotate(precision)
 
+        # Update the space property in the sire object.
+        self._sire_object.setProperty(space_prop, space)
+
         # Get the rotation matrix.
         rotation_matrix = space.rotationMatrix()
 

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1093,7 +1093,7 @@ class System(_SireWrapper):
         except:
             return
 
-        # A rotation is only applicable to a triclinic space.
+        # A rotation is only applicable to triclinic spaces.
         if not isinstance(space, _SireVol.TriclinicBox):
             return
 
@@ -1190,7 +1190,7 @@ class System(_SireWrapper):
         except:
             return
 
-        # A rotation is only applicable to a triclinic space.
+        # A rotation is only applicable to triclinic spaces.
         if not isinstance(space, _SireVol.TriclinicBox):
             return
 

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1063,6 +1063,140 @@ class System(_SireWrapper):
         """
         return len(self.getPerturbableMolecules())
 
+    def rotateBoxVectors(self, precision=0.0, property_map={}):
+        """
+        Rotate the box vectors of the system so that the first vector is
+        aligned with the x-axis, the second vector lies in the x-y plane,
+        and the third vector has a positive z-component. This is a requirement
+        of certain molecular dynamics engines and is used for simulation
+        efficiency. All vector properties of the system, e.g. positions,
+        velocities, etc., will be rotated accordingly.
+
+        Parameters
+        ----------
+
+        precision : float
+            The precision to use when sorting box vectors by their magnitude.
+            This can be used to prevent unecessary box rotation when the
+            vectors were read from a text file with limited precision.
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+        """
+
+        # First check that the system has a space.
+        space_prop = property_map.get("space", "space")
+        try:
+            space = self._sire_object.property(space_prop)
+        except:
+            return
+
+        # A rotation is only applicable to a triclinic space.
+        if not isinstance(space, _SireVol.TriclinicBox):
+            return
+
+        # Rotate the space according to the desired precision.
+        space.rotate(precision)
+
+        # Get the rotation matrix.
+        rotation_matrix = space.rotationMatrix()
+
+        from sire.system import System
+
+        # Create a cursor.
+        cursor = System(self._sire_object).cursor()
+
+        # Rotate all vector properties.
+
+        # Coordinates.
+        try:
+            prop_name = property_map.get("coordinates", "coordinates")
+            cursor = cursor.rotate(
+                matrix=rotation_matrix, map={"coordinates": prop_name}
+            )
+        except:
+            pass
+
+        # Velocities.
+        try:
+            prop_name = property_map.get("velocity", "velocity")
+            cursor = cursor.rotate(
+                matrix=rotation_matrix, map={"coordinates": prop_name}
+            )
+        except:
+            pass
+
+        # Now deal with any perturbable molecules.
+        if self.nPerturbableMolecules() > 0:
+            # Coordinates.
+            try:
+                prop_name = property_map.get("coordinates", "coordinates") + "0"
+                cursor = cursor.rotate(
+                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                )
+                prop_name = property_map.get("coordinates", "coordinates") + "1"
+                cursor = cursor.rotate(
+                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                )
+            except:
+                pass
+
+            # Velocities.
+            try:
+                prop_name = property_map.get("velocity", "velocity") + "0"
+                cursor = cursor.rotate(
+                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                )
+                prop_name = property_map.get("velocity", "velocity") + "1"
+                cursor = cursor.rotate(
+                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                )
+            except:
+                pass
+
+        # Commit the changes.
+        self._sire_object = cursor.commit()._system
+
+    def reduceBoxVectors(self, bias=0, property_map={}):
+        """
+        Reduce the box vectors.
+
+        Parameters
+        ----------
+
+        bias : float
+            The bias to use when rounding during the lattice reduction. Negative
+            values biases towards left-tilting boxes, whereas positive values
+            biases towards right-tilting boxes. This can be used to ensure that
+            rounding is performed in a consistent direction, avoiding oscillation
+            when the box is instantiated from box vectors, or dimensions and
+            angles, that have been read from fixed-precision input files.
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+        """
+
+        # First check that the system has a space.
+        space_prop = property_map.get("space", "space")
+        try:
+            space = self._sire_object.property(space_prop)
+        except:
+            return
+
+        # A rotation is only applicable to a triclinic space.
+        if not isinstance(space, _SireVol.TriclinicBox):
+            return
+
+        # Reduce the space using the desired bias.
+        space.reduce(bias)
+
+        # Update the space property in the sire object.
+        self._sire_object.setProperty(space_prop, space)
+
     def repartitionHydrogenMass(
         self, factor=4, water="no", use_coordinates=False, property_map={}
     ):

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -41,6 +41,7 @@ from sire.legacy import Units as _SireUnits
 from .. import _isVerbose
 from .._Exceptions import IncompatibleError as _IncompatibleError
 from ..Types import Angle as _Angle
+from ..Types import Coordinate as _Coordinate
 from ..Types import Length as _Length
 from .. import Units as _Units
 
@@ -1063,7 +1064,16 @@ class System(_SireWrapper):
         """
         return len(self.getPerturbableMolecules())
 
-    def rotateBoxVectors(self, precision=0.0, property_map={}):
+    def rotateBoxVectors(
+        self,
+        origin=_Coordinate(
+            0 * _Units.Length.angstrom,
+            0 * _Units.Length.angstrom,
+            0 * _Units.Length.angstrom,
+        ),
+        precision=0.0,
+        property_map={},
+    ):
         """
         Rotate the box vectors of the system so that the first vector is
         aligned with the x-axis, the second vector lies in the x-y plane,
@@ -1074,6 +1084,10 @@ class System(_SireWrapper):
 
         Parameters
         ----------
+
+        origin : :class:`Coordinate <BioSimSpace.Types.Coordinate>`
+            The origin of the triclinic space. This is the point about which
+            the lattice vectors are rotated.
 
         precision : float
             The precision to use when sorting box vectors by their magnitude.
@@ -1097,6 +1111,14 @@ class System(_SireWrapper):
         if not isinstance(space, _SireVol.TriclinicBox):
             return
 
+        # Validate input.
+
+        if not isinstance(origin, _Coordinate):
+            raise TypeError("'origin' must be of type 'BioSimSpace.Types.Coordinate'")
+
+        if not isinstance(precision, float):
+            raise TypeError("'precision' must be of type 'float'")
+
         # Rotate the space according to the desired precision.
         space.rotate(precision)
 
@@ -1105,6 +1127,9 @@ class System(_SireWrapper):
 
         # Get the rotation matrix.
         rotation_matrix = space.rotationMatrix()
+
+        # Get the center of rotation, as a Sire vector.
+        center = origin.toVector()._sire_object
 
         from sire.system import System
 
@@ -1117,7 +1142,7 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("coordinates", "coordinates")
             cursor = cursor.rotate(
-                matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
             )
         except:
             pass
@@ -1126,7 +1151,7 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("velocity", "velocity")
             cursor = cursor.rotate(
-                matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
             )
         except:
             pass
@@ -1137,11 +1162,15 @@ class System(_SireWrapper):
             try:
                 prop_name = property_map.get("coordinates", "coordinates") + "0"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("coordinates", "coordinates") + "1"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
             except:
                 pass
@@ -1150,11 +1179,15 @@ class System(_SireWrapper):
             try:
                 prop_name = property_map.get("velocity", "velocity") + "0"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("velocity", "velocity") + "1"
                 cursor = cursor.rotate(
-                    matrix=rotation_matrix, map={"coordinates": prop_name}
+                    center=center,
+                    matrix=rotation_matrix,
+                    map={"coordinates": prop_name},
                 )
             except:
                 pass

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -274,7 +274,7 @@ def test_set_box(system):
 
     # Store the expected box dimensions and angles.
     expected_box = [30, 30, 30] * BSS.Units.Length.angstrom
-    expected_angles = [70.5288, 109.4712, 70.5288] * BSS.Units.Angle.degree
+    expected_angles = [109.4712, 109.4712, 109.4712] * BSS.Units.Angle.degree
 
     # Check that the box dimensions match.
     for b0, b1 in zip(box, expected_box):

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -1,6 +1,8 @@
 import math
 import pytest
 
+from sire.legacy.Vol import TriclinicBox
+
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_amber, has_openff
@@ -392,3 +394,52 @@ def test_velocity_removal():
 
     # Check that no molecules have a velocity property.
     assert len(new_system.search("not mol with property velocity").molecules()) == 2
+
+
+def test_rotate_box_vectors(system):
+    # Make sure that the triclinic space is rotated correctly and that vector
+    # properties (here coordinates) are updated accordingly.
+
+    # Store the initial coordinates for the first molecule.
+    coords0 = system[0].coordinates()
+
+    # Extract the space property.
+    space = system._sire_object.property("space")
+
+    # Store the box matrix.
+    box_matrix = space.boxMatrix()
+
+    # Create a triclinic box using the box matrix. This will create:
+    # TriclinicBox( ( 31.3979, 0, 0 ), ( 0, 34.1, 0 ), ( 0, 0, 29.273 ) )
+    box = TriclinicBox(box_matrix.column0(), box_matrix.column1(), box_matrix.column2())
+
+    # Update the space property.
+    system._sire_object.setProperty("space", box)
+
+    # Store the current box.
+    box0, angles0 = system.getBox()
+
+    # Rotate the box. This will create an "optimal" triclinic space, where the
+    # shortest vector is aligned with the x axis, the second vector is in the
+    # x-y plane, and the largest has positive z component.
+    system.rotateBoxVectors()
+
+    # Store the updated box.
+    box1, angles1 = system.getBox()
+
+    # Store the updated coordinates for the first molecule.
+    coords1 = system[0].coordinates()
+
+    # Make sure the box dimensions have been rotated correctly.
+    assert math.isclose(box1[0].value(), box0[2].value())
+    assert math.isclose(box1[1].value(), box0[0].value())
+    assert math.isclose(box1[2].value(), box0[1].value())
+    assert math.isclose(angles1[0].value(), angles0[0].value())
+    assert math.isclose(angles1[1].value(), angles0[1].value())
+    assert math.isclose(angles1[2].value(), angles0[2].value())
+
+    # Make sure the coordinates have been rotated correctly.
+    for c0, c1 in zip(coords0, coords1):
+        assert math.isclose(c1.x().value(), c0.z().value())
+        assert math.isclose(c1.y().value(), c0.x().value())
+        assert math.isclose(c1.z().value(), c0.y().value())

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -434,6 +434,8 @@ def test_rotate_box_vectors(system):
     assert math.isclose(box1[0].value(), box0[2].value())
     assert math.isclose(box1[1].value(), box0[0].value())
     assert math.isclose(box1[2].value(), box0[1].value())
+    # All angles should remain the same since this is a cubic system with
+    # 90 degree angles.
     assert math.isclose(angles1[0].value(), angles0[0].value())
     assert math.isclose(angles1[1].value(), angles0[1].value())
     assert math.isclose(angles1[2].value(), angles0[2].value())

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -265,6 +265,9 @@ def test_get_box(system):
 
 
 def test_set_box(system):
+    # Make a copy of the system.
+    system = system.copy()
+
     # Generate box dimensions and angles for a truncated octahedron.
     box, angles = BSS.Box.truncatedOctahedron(30 * BSS.Units.Length.angstrom)
 

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -274,7 +274,7 @@ def test_set_box(system):
 
     # Store the expected box dimensions and angles.
     expected_box = [30, 30, 30] * BSS.Units.Length.angstrom
-    expected_angles = [70.5288, 109.4712, 70.5288] * BSS.Units.Angle.degree
+    expected_angles = [109.4712, 109.4712, 109.4712] * BSS.Units.Angle.degree
 
     # Check that the box dimensions match.
     for b0, b1 in zip(box, expected_box):

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -1,6 +1,8 @@
 import math
 import pytest
 
+from sire.legacy.Vol import TriclinicBox
+
 import BioSimSpace as BSS
 
 from tests.conftest import url, has_amber, has_openff
@@ -391,3 +393,52 @@ def test_velocity_removal():
 
     # Check that no molecules have a velocity property.
     assert len(new_system.search("not mol with property velocity").molecules()) == 2
+
+
+def test_rotate_box_vectors(system):
+    # Make sure that the triclinic space is rotated correctly and that vector
+    # properties (here coordinates) are updated accordingly.
+
+    # Store the initial coordinates for the first molecule.
+    coords0 = system[0].coordinates()
+
+    # Extract the space property.
+    space = system._sire_object.property("space")
+
+    # Store the box matrix.
+    box_matrix = space.boxMatrix()
+
+    # Create a triclinic box using the box matrix. This will create:
+    # TriclinicBox( ( 31.3979, 0, 0 ), ( 0, 34.1, 0 ), ( 0, 0, 29.273 ) )
+    box = TriclinicBox(box_matrix.column0(), box_matrix.column1(), box_matrix.column2())
+
+    # Update the space property.
+    system._sire_object.setProperty("space", box)
+
+    # Store the current box.
+    box0, angles0 = system.getBox()
+
+    # Rotate the box. This will create an "optimal" triclinic space, where the
+    # shortest vector is aligned with the x axis, the second vector is in the
+    # x-y plane, and the largest has positive z component.
+    system.rotateBoxVectors()
+
+    # Store the updated box.
+    box1, angles1 = system.getBox()
+
+    # Store the updated coordinates for the first molecule.
+    coords1 = system[0].coordinates()
+
+    # Make sure the box dimensions have been rotated correctly.
+    assert math.isclose(box1[0].value(), box0[2].value())
+    assert math.isclose(box1[1].value(), box0[0].value())
+    assert math.isclose(box1[2].value(), box0[1].value())
+    assert math.isclose(angles1[0].value(), angles0[0].value())
+    assert math.isclose(angles1[1].value(), angles0[1].value())
+    assert math.isclose(angles1[2].value(), angles0[2].value())
+
+    # Make sure the coordinates have been rotated correctly.
+    for c0, c1 in zip(coords0, coords1):
+        assert math.isclose(c1.x().value(), c0.z().value())
+        assert math.isclose(c1.y().value(), c0.x().value())
+        assert math.isclose(c1.z().value(), c0.y().value())

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -433,6 +433,8 @@ def test_rotate_box_vectors(system):
     assert math.isclose(box1[0].value(), box0[2].value())
     assert math.isclose(box1[1].value(), box0[0].value())
     assert math.isclose(box1[2].value(), box0[1].value())
+    # All angles should remain the same since this is a cubic system with
+    # 90 degree angles.
     assert math.isclose(angles1[0].value(), angles0[0].value())
     assert math.isclose(angles1[1].value(), angles0[1].value())
     assert math.isclose(angles1[2].value(), angles0[2].value())

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -268,6 +268,9 @@ def test_set_box(system):
     # Generate box dimensions and angles for a truncated octahedron.
     box, angles = BSS.Box.truncatedOctahedron(30 * BSS.Units.Length.angstrom)
 
+    # Make a copy of the system.
+    system = system.copy()
+
     # Set the box dimensions in the system.
     system.setBox(box, angles)
 


### PR DESCRIPTION
This PR exposes functionality related to the changes to `sire.legacy.Vol.TriclinicBox`, allowing the user to manually rotate the space and perform a lattice reduction. Keywords have also been added to `BioSimSpace.IO.readMolecules` to allow the user to perform these operations on load.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods