### PR TITLE
Allow unit-based protocol options to be passed as strings

### DIFF
--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_distance.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_distance.py
@@ -189,6 +189,22 @@ class Distance(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._atom0 == other._atom0
+            and self._atom1 == other._atom1
+            and self._weights0 == other._weights0
+            and self._weights1 == other._weights1
+            and self._is_com0 == other._is_com0
+            and self._is_com1 == other._is_com1
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+            and self._component == other._component
+            and self._pbc == other._pbc
+        )
+
     def setAtom0(self, atom0):
         """
         Set the atom, atoms, or coordinate from which the distance will be

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
@@ -178,6 +178,21 @@ class Funnel(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._atoms0 == other._atoms0
+            and self._atoms1 == other._atoms1
+            and self._width == other._width
+            and self._buffer == other._buffer
+            and self._steepness == other._steepness
+            and self._inflection == other._inflection
+            and self._hill_width == other._hill_width
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+        )
+
     def setAtoms0(self, atoms0):
         """
         Set the list of atom indices whose center-of-mass define the origin

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
@@ -348,6 +348,18 @@ class RMSD(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._reference == other._reference
+            and self._hill_width == other._hill_width
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+            and self._alignment_type == other._alignment_type
+            and self._pbc == other._pbc
+        )
+
     def getReferencePDB(self):
         """
         Return the reference PDB file as a list of strings.

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
@@ -451,6 +451,7 @@ class RMSD(_CollectiveVariable):
         to the reference.
 
         Returns
+        -------
 
         reference_index : int
             The index of the molecule in the system that corresponds to

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_torsion.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_torsion.py
@@ -123,6 +123,17 @@ class Torsion(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._atoms == other._atoms
+            and self._hill_width == other._hill_width
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+            and self._pbc == other._pbc
+        )
+
     def setAtoms(self, atoms):
         """
         Set the atoms for which the torsion will be calculated.

--- a/python/BioSimSpace/Metadynamics/_bound.py
+++ b/python/BioSimSpace/Metadynamics/_bound.py
@@ -79,6 +79,15 @@ class Bound:
         """Return a human readable string representation of the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._value == other._value
+            and self._force_constant == other._force_constant
+            and self._exponent == other._exponent
+            and self._epsilon == other._epsilon
+        )
+
     def setValue(self, value):
         """
         Set the value of the bound.

--- a/python/BioSimSpace/Metadynamics/_grid.py
+++ b/python/BioSimSpace/Metadynamics/_grid.py
@@ -76,6 +76,14 @@ class Grid:
         """Return a human readable string representation of the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._minimum == other._minimum
+            and self._maximum == other._maximum
+            and self._num_bins == other._num_bins
+        )
+
     def setMinimum(self, minimum):
         """
         Set the minimum value of the grid.

--- a/python/BioSimSpace/Metadynamics/_restraint.py
+++ b/python/BioSimSpace/Metadynamics/_restraint.py
@@ -73,6 +73,14 @@ class Restraint:
         """Return a human readable string representation of the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._value == other._value
+            and self._force_constant == other._force_constant
+            and self._slope == other._slope
+        )
+
     def setValue(self, value):
         """
         Set the value of the bound.

--- a/python/BioSimSpace/Protocol/_custom.py
+++ b/python/BioSimSpace/Protocol/_custom.py
@@ -62,6 +62,10 @@ class Custom(_Protocol):
         """Return a string showing how to instantiate the object."""
         return "<BioSimSpace.Protocol.Custom>"
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return self._config == other._config
+
     def getConfig(self):
         """
         Return the custom configuration.

--- a/python/BioSimSpace/Protocol/_equilibration.py
+++ b/python/BioSimSpace/Protocol/_equilibration.py
@@ -166,6 +166,7 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
             f"temperature_start={self._temperature_start}, "
             f"temperature_end={self._temperature_end}, "
             f"pressure={self._pressure}, "
+            f"thermostat_time_constant={self._thermostat_time_constant}, "
             f"report_interval={self._report_interval}, "
             f"restart_interval={self._restart_interval}, "
             + _PositionRestraintMixin._get_parm(self)
@@ -200,6 +201,7 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
             and self._temperature_start == other._temperature_start
             and self._temperature_end == other._temperature_end
             and self._pressure == other._pressure
+            and self._thermostat_time_constant == other._thermostat_time_constant
             and self._report_interval == other._report_interval
             and self._restart_interval == other._restart_interval
             and _PositionRestraintMixin.__eq__(self, other)

--- a/python/BioSimSpace/Protocol/_equilibration.py
+++ b/python/BioSimSpace/Protocol/_equilibration.py
@@ -185,6 +185,26 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         else:
             return f"BioSimSpace.Protocol.Equilibration({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Equilibration):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature_start == other._temperature_start
+            and self._temperature_end == other._temperature_end
+            and self._pressure == other._pressure
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+            and _PositionRestraintMixin.__eq__(self, other)
+        )
+
     def getTimeStep(self):
         """
         Return the time step.
@@ -204,13 +224,20 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        time : :class:`Time <BioSimSpace.Types.Time>`
+        time : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getRunTime(self):
         """
@@ -231,13 +258,20 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getStartTemperature(self):
         """
@@ -258,18 +292,23 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The starting temperature.
         """
 
-        if isinstance(temperature, _Types.Temperature):
-            if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
-                temperature._value = 0.01
-            self._temperature_start = temperature
-        else:
+        if isinstance(temperature, str):
+            try:
+                temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif not isinstance(temperature, _Types.Temperature):
             raise TypeError(
-                "'temperature_start' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
+
+        if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
+            temperature._value = 0.01
+        self._temperature_start = temperature
 
     def getEndTemperature(self):
         """
@@ -290,17 +329,22 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The final temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
-            if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
-                temperature._value = 0.01
-            self._temperature_end = temperature
-        else:
+        if isinstance(temperature, str):
+            try:
+                temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif not isinstance(temperature, _Types.Temperature):
             raise TypeError(
-                "'temperature_end' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
+
+        if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
+            temperature._value = 0.01
+        self._temperature_end = temperature
 
     def getPressure(self):
         """
@@ -321,13 +365,20 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getThermostatTimeConstant(self):
         """
@@ -348,14 +399,21 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+        thermostat_time_constant : str, :class:`Time <BioSimSpace.Types.Time>`
             The time constant for the thermostat.
         """
-        if isinstance(thermostat_time_constant, _Types.Time):
+        if isinstance(thermostat_time_constant, str):
+            try:
+                self._thermostat_time_constant = _Types.Time(thermostat_time_constant)
+            except:
+                raise ValueError(
+                    "Unable to parse 'thermostat_time_constant' string."
+                ) from None
+        elif isinstance(thermostat_time_constant, _Types.Time):
             self._thermostat_time_constant = thermostat_time_constant
         else:
             raise TypeError(
-                "'thermostat_time_constant' must be of type 'BioSimSpace.Types.Time'"
+                "'thermostat_time_constant' must be of type 'str' or 'BioSimSpace.Types.Time'"
             )
 
     def getReportInterval(self):

--- a/python/BioSimSpace/Protocol/_free_energy_equilibration.py
+++ b/python/BioSimSpace/Protocol/_free_energy_equilibration.py
@@ -188,6 +188,19 @@ class FreeEnergyEquilibration(_Equilibration, _FreeEnergyMixin):
         else:
             return f"BioSimSpace.Protocol.FreeEnergyEquilibration({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, FreeEnergyEquilibration):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return _Equilibration.__eq__(self, other) and _FreeEnergyMixin.__eq__(
+            self, other
+        )
+
     def _to_regular_protocol(self):
         """
         Convert to a regular equilibration protocol. This can be used to run

--- a/python/BioSimSpace/Protocol/_free_energy_minimisation.py
+++ b/python/BioSimSpace/Protocol/_free_energy_minimisation.py
@@ -140,6 +140,19 @@ class FreeEnergyMinimisation(_Minimisation, _FreeEnergyMixin):
         else:
             return f"BioSimSpace.Protocol.FreeEnergyMinimisation({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, FreeEnergyMinimisation):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return _Minimisation.__eq__(self, other) and _FreeEnergyMixin.__eq__(
+            self, other
+        )
+
     def _to_regular_protocol(self):
         """
         Convert to a regular minimisation protocol. This can be used to run

--- a/python/BioSimSpace/Protocol/_free_energy_mixin.py
+++ b/python/BioSimSpace/Protocol/_free_energy_mixin.py
@@ -102,6 +102,18 @@ class _FreeEnergyMixin:
         """Return a string showing how to instantiate the object."""
         return f"BioSimSpace.Protocol._FreeEnergyMixin({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, _FreeEnergyMixin):
+            return False
+
+        return (
+            self._lambda == other._lambda
+            and self._lambda_vals == other._lambda_vals
+            and self._perturbation_type == other._perturbation_type
+        )
+
     def getPerturbationType(self):
         """
         Get the perturbation type.

--- a/python/BioSimSpace/Protocol/_free_energy_production.py
+++ b/python/BioSimSpace/Protocol/_free_energy_production.py
@@ -179,6 +179,17 @@ class FreeEnergyProduction(_Production, _FreeEnergyMixin):
         else:
             return f"BioSimSpace.Protocol.FreeEnergyProduction({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, FreeEnergyProduction):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return _Production.__eq__(self, other) and _FreeEnergyMixin.__eq__(self, other)
+
 
 # Alias the class for consistency with the old API.
 FreeEnergy = FreeEnergyProduction

--- a/python/BioSimSpace/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Protocol/_metadynamics.py
@@ -162,6 +162,28 @@ class Metadynamics(_Protocol):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Metadynamics):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._collective_variable == other._collective_variable
+            and self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature == other._temperature
+            and self._pressure == other._pressure
+            and self._hill_height == other._hill_height
+            and self._hill_frequency == other._hill_frequency
+            and self._bias_factor == other._bias_factor
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+        )
+
     def getCollectiveVariable(self):
         """
         Return the collective variable (or variables).
@@ -245,13 +267,20 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        timestep : :class:`Time <BioSimSpace.Types.Time>`
+        timestep : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getRunTime(self):
         """
@@ -272,13 +301,20 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getTemperature(self):
         """
@@ -299,14 +335,19 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The simulation temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
+        if isinstance(temperature, str):
+            try:
+                self._temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(
-                "'temperature' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
 
     def getPressure(self):
@@ -328,13 +369,20 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getHillHeight(self):
         """
@@ -355,12 +403,19 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        hill_height : :class:`Energy <BioSimSpace.Types.Energy>`
+        hill_height : str, :class:`Energy <BioSimSpace.Types.Energy>`
             The hill height.
         """
 
-        if not isinstance(hill_height, _Types.Energy):
-            raise TypeError("'hill_height' must be of type 'BioSimSpace.Types.Energy'")
+        if isinstance(hill_height, str):
+            try:
+                hill_height = _Types.Energy(hill_height)
+            except:
+                raise ValueError("Unable to parse 'hill_height' string.") from None
+        elif not isinstance(hill_height, _Types.Energy):
+            raise TypeError(
+                "'hill_height' must be of type 'str' or 'BioSimSpace.Types.Energy'"
+            )
 
         # Check that heights is greater than zero.
         if hill_height.value() <= 0:

--- a/python/BioSimSpace/Protocol/_minimisation.py
+++ b/python/BioSimSpace/Protocol/_minimisation.py
@@ -99,6 +99,19 @@ class Minimisation(_Protocol, _PositionRestraintMixin):
         else:
             return f"BioSimSpace.Protocol.Minimisation({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Minimisation):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return self._steps == other._steps and _PositionRestraintMixin.__eq__(
+            self, other
+        )
+
     def getSteps(self):
         """
         Return the maximum number of steps.

--- a/python/BioSimSpace/Protocol/_position_restraint_mixin.py
+++ b/python/BioSimSpace/Protocol/_position_restraint_mixin.py
@@ -98,6 +98,17 @@ class _PositionRestraintMixin:
         """Return a string showing how to instantiate the object."""
         return f"BioSimSpace.Protocol._PositionRestraintMixin({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, _PositionRestraintMixin):
+            return False
+
+        return (
+            self._restraint == other._restraint
+            and self._force_constant == other._force_constant
+        )
+
     def getRestraint(self):
         """Return the type of restraint..
 
@@ -162,7 +173,7 @@ class _PositionRestraintMixin:
         Returns
         -------
 
-        force_constant : class:`GeneralUnit <BioSimSpace.Types._GeneralUnit>`
+        force_constant : float, str, class:`GeneralUnit <BioSimSpace.Types._GeneralUnit>`
             The force constant for the restraint, in units of
             kcal_per_mol/angstrom**2.
         """
@@ -175,7 +186,7 @@ class _PositionRestraintMixin:
         Parameters
         ----------
 
-        force_constant : :class:`GeneralUnit <BioSimSpace.Types._GeneralUnit>`, float
+        force_constant : int, float, str, :class:`GeneralUnit <BioSimSpace.Types._GeneralUnit>`, float
             The force constant for the restraint, in units of
             kcal_per_mol/angstrom**2.
         """
@@ -188,18 +199,26 @@ class _PositionRestraintMixin:
             # Use default units.
             force_constant *= _Units.Energy.kcal_per_mol / _Units.Area.angstrom2
 
-        elif isinstance(force_constant, _Types._GeneralUnit):
+        else:
+            if isinstance(force_constant, str):
+                try:
+                    force_constant = _Types._GeneralUnit(force_constant)
+                except Exception:
+                    raise ValueError(
+                        "Unable to parse 'force_constant' string."
+                    ) from None
+
+            elif not isinstance(force_constant, _Types._GeneralUnit):
+                raise TypeError(
+                    "'force_constant' must be of type 'BioSimSpace.Types._GeneralUnit', 'str', or 'float'."
+                )
+
             # Validate the dimensions.
             if force_constant.dimensions() != (0, 0, 0, 1, -1, 0, -2):
                 raise ValueError(
                     "'force_constant' has invalid dimensions! "
                     f"Expected dimensions are 'M Q-1 T-2', found '{force_constant.unit()}'"
                 )
-
-        else:
-            raise TypeError(
-                "'force_constant' must be of type 'BioSimSpace.Types._GeneralUnit', or 'float'."
-            )
 
         self._force_constant = force_constant
 

--- a/python/BioSimSpace/Protocol/_production.py
+++ b/python/BioSimSpace/Protocol/_production.py
@@ -145,6 +145,7 @@ class Production(_Protocol, _PositionRestraintMixin):
             f"runtime={self._runtime}, "
             f"temperature={self._temperature}, "
             f"pressure={self._pressure}, "
+            f"thermostat_time_constant={self._thermostat_time_constant}, "
             f"report_interval={self._report_interval}, "
             f"restart_interval={self._restart_interval}, "
             f"restart={self._restart}, " + _PositionRestraintMixin._get_parm(self)
@@ -178,6 +179,7 @@ class Production(_Protocol, _PositionRestraintMixin):
             and self._runtime == other._runtime
             and self._temperature == other._temperature
             and self._pressure == other._pressure
+            and self._thermostat_time_constant == other._thermostat_time_constant
             and self._report_interval == other._report_interval
             and self._restart_interval == other._restart_interval
             and self._restart == other._restart

--- a/python/BioSimSpace/Protocol/_production.py
+++ b/python/BioSimSpace/Protocol/_production.py
@@ -164,6 +164,26 @@ class Production(_Protocol, _PositionRestraintMixin):
         else:
             return f"BioSimSpace.Protocol.Production({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Production):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature == other._temperature
+            and self._pressure == other._pressure
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+            and self._restart == other._restart
+            and _PositionRestraintMixin.__eq__(self, other)
+        )
+
     def getTimeStep(self):
         """
         Return the time step.
@@ -183,13 +203,20 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        timestep : :class:`Time <BioSimSpace.Types.Time>`
+        timestep : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getRunTime(self):
         """
@@ -210,13 +237,20 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getTemperature(self):
         """
@@ -237,14 +271,19 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The simulation temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
+        if isinstance(temperature, str):
+            try:
+                self._temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(
-                "'temperature' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
 
     def getPressure(self):
@@ -266,13 +305,20 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getThermostatTimeConstant(self):
         """
@@ -293,10 +339,17 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+        thermostat_time_constant : str, :class:`Time <BioSimSpace.Types.Time>`
             The time constant for the thermostat.
         """
-        if isinstance(thermostat_time_constant, _Types.Time):
+        if isinstance(thermostat_time_constant, str):
+            try:
+                self._thermostat_time_constant = _Types.Time(thermostat_time_constant)
+            except:
+                raise ValueError(
+                    "Unable to parse 'thermostat_time_constant' string."
+                ) from None
+        elif isinstance(thermostat_time_constant, _Types.Time):
             self._thermostat_time_constant = thermostat_time_constant
         else:
             raise TypeError(

--- a/python/BioSimSpace/Protocol/_steering.py
+++ b/python/BioSimSpace/Protocol/_steering.py
@@ -182,6 +182,28 @@ class Steering(_Protocol):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Steering):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._collective_variable == other._collective_variable
+            and self._schedule == other._schedule
+            and self._restraints == other._restraints
+            and self._verse == other._verse
+            and self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature == other._temperature
+            and self._pressure == other._pressure
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+        )
+
     def getCollectiveVariable(self):
         """
         Return the collective variable (or variables).
@@ -451,13 +473,20 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        timestep : :class:`Time <BioSimSpace.Types.Time>`
+        timestep : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
         # If the object has already been created, then check that other member
         # data is consistent.
@@ -483,13 +512,20 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
         # If the object has already been created, then check that other member
         # data is consistent.
@@ -515,10 +551,15 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The simulation temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
+        if isinstance(temperature, str):
+            try:
+                self._temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(
@@ -544,13 +585,20 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getThermostatTimeConstant(self):
         """
@@ -571,14 +619,21 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+        thermostat_time_constant : str, :class:`Time <BioSimSpace.Types.Time>`
             The time constant for the thermostat.
         """
-        if isinstance(thermostat_time_constant, _Types.Time):
+        if isinstance(thermostat_time_constant, str):
+            try:
+                self._thermostat_time_constant = _Types.Time(thermostat_time_constant)
+            except:
+                raise ValueError(
+                    "Unable to parse 'thermostat_time_constant' string."
+                ) from None
+        elif isinstance(thermostat_time_constant, _Types.Time):
             self._thermostat_time_constant = thermostat_time_constant
         else:
             raise TypeError(
-                "'thermostat_time_constant' must be of type 'BioSimSpace.Types.Time'"
+                "'thermostat_time_constant' must be of type 'str' or 'BioSimSpace.Types.Time'"
             )
 
     def getReportInterval(self):

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_distance.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_distance.py
@@ -189,6 +189,22 @@ class Distance(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._atom0 == other._atom0
+            and self._atom1 == other._atom1
+            and self._weights0 == other._weights0
+            and self._weights1 == other._weights1
+            and self._is_com0 == other._is_com0
+            and self._is_com1 == other._is_com1
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+            and self._component == other._component
+            and self._pbc == other._pbc
+        )
+
     def setAtom0(self, atom0):
         """
         Set the atom, atoms, or coordinate from which the distance will be

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
@@ -178,6 +178,21 @@ class Funnel(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._atoms0 == other._atoms0
+            and self._atoms1 == other._atoms1
+            and self._width == other._width
+            and self._buffer == other._buffer
+            and self._steepness == other._steepness
+            and self._inflection == other._inflection
+            and self._hill_width == other._hill_width
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+        )
+
     def setAtoms0(self, atoms0):
         """
         Set the list of atom indices whose center-of-mass define the origin

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
@@ -348,6 +348,18 @@ class RMSD(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._reference == other._reference
+            and self._hill_width == other._hill_width
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+            and self._alignment_type == other._alignment_type
+            and self._pbc == other._pbc
+        )
+
     def getReferencePDB(self):
         """
         Return the reference PDB file as a list of strings.

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
@@ -451,6 +451,7 @@ class RMSD(_CollectiveVariable):
         to the reference.
 
         Returns
+        -------
 
         reference_index : int
             The index of the molecule in the system that corresponds to

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_torsion.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_torsion.py
@@ -123,6 +123,17 @@ class Torsion(_CollectiveVariable):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._atoms == other._atoms
+            and self._hill_width == other._hill_width
+            and self._lower_bound == other._lower_bound
+            and self._upper_bound == other._upper_bound
+            and self._grid == other._grid
+            and self._pbc == other._pbc
+        )
+
     def setAtoms(self, atoms):
         """
         Set the atoms for which the torsion will be calculated.
@@ -164,6 +175,9 @@ class Torsion(_CollectiveVariable):
         """
         Set the width of the Gaussian hills used to bias this collective
         variable.
+
+        Parameters
+        ----------
 
         hill_width : :class:`Angle <BioSimSpace.Types.Angle>`
             The width of the Gaussian hill.

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_bound.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_bound.py
@@ -79,6 +79,15 @@ class Bound:
         """Return a human readable string representation of the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._value == other._value
+            and self._force_constant == other._force_constant
+            and self._exponent == other._exponent
+            and self._epsilon == other._epsilon
+        )
+
     def setValue(self, value):
         """
         Set the value of the bound.

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_grid.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_grid.py
@@ -76,6 +76,14 @@ class Grid:
         """Return a human readable string representation of the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._minimum == other._minimum
+            and self._maximum == other._maximum
+            and self._num_bins == other._num_bins
+        )
+
     def setMinimum(self, minimum):
         """
         Set the minimum value of the grid.

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_restraint.py
@@ -73,6 +73,14 @@ class Restraint:
         """Return a human readable string representation of the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+        return (
+            self._value == other._value
+            and self._force_constant == other._force_constant
+            and self._slope == other._slope
+        )
+
     def setValue(self, value):
         """
         Set the value of the bound.

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_equilibration.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_equilibration.py
@@ -215,13 +215,20 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        time : :class:`Time <BioSimSpace.Types.Time>`
+        time : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getRunTime(self):
         """
@@ -242,13 +249,20 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getStartTemperature(self):
         """
@@ -269,18 +283,23 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The starting temperature.
         """
 
-        if isinstance(temperature, _Types.Temperature):
-            if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
-                temperature._value = 0.01
-            self._temperature_start = temperature
-        else:
+        if isinstance(temperature, str):
+            try:
+                temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif not isinstance(temperature, _Types.Temperature):
             raise TypeError(
-                "'temperature_start' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
+
+        if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
+            temperature._value = 0.01
+        self._temperature_start = temperature
 
     def getEndTemperature(self):
         """
@@ -301,17 +320,22 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The final temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
-            if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
-                temperature._value = 0.01
-            self._temperature_end = temperature
-        else:
+        if isinstance(temperature, str):
+            try:
+                temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif not isinstance(temperature, _Types.Temperature):
             raise TypeError(
-                "'temperature_end' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
+
+        if _math.isclose(temperature.kelvin().value(), 0, rel_tol=1e-6):
+            temperature._value = 0.01
+        self._temperature_end = temperature
 
     def getTauT(self):
         """
@@ -332,13 +356,18 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        tau_t : :class:`Time <BioSimSpace.Types.Time>`
+        tau_t : str, :class:`Time <BioSimSpace.Types.Time>`
             The time constant for the thermostat.
         """
-        if isinstance(tau_t, _Types.Time):
+        if isinstance(tau_t, str):
+            try:
+                self._tau_t = _Types.Time(tau_t)
+            except:
+                raise ValueError("Unable to parse 'tau_t' string.") from None
+        elif isinstance(tau_t, _Types.Time):
             self._tau_t = tau_t
         else:
-            raise TypeError("'tau_t' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError("'tau_t' must be of type 'str' or 'BioSimSpace.Types.Time'")
 
     def getPressure(self):
         """
@@ -359,13 +388,20 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getReportInterval(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_equilibration.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_equilibration.py
@@ -177,6 +177,7 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
             f"temperature_start={self._temperature_start}, "
             f"temperature_end={self._temperature_end}, "
             f"pressure={self._pressure}, "
+            f"tau_t={self._tau_t}, "
             f"report_interval={self._report_interval}, "
             f"restart_interval={self._restart_interval}, "
             f"restart={self._restart}, " + _PositionRestraintMixin._get_parm(self)
@@ -195,6 +196,28 @@ class Equilibration(_Protocol, _PositionRestraintMixin):
             return "BioSimSpace.Protocol.Custom"
         else:
             return f"BioSimSpace.Protocol.Equilibration({self._get_parm()})"
+
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Equilibration):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature_start == other._temperature_start
+            and self._temperature_end == other._temperature_end
+            and self._pressure == other._pressure
+            and self._tau_t == other._tau_t
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+            and self._restart == other._restart
+            and _PositionRestraintMixin.__eq__(self, other)
+        )
 
     def getTimeStep(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy.py
@@ -184,3 +184,14 @@ class FreeEnergy(_Production, _FreeEnergyMixin):
             return "BioSimSpace.Protocol.Custom"
         else:
             return f"BioSimSpace.Protocol.FreeEnergy({self._get_parm()})"
+
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, FreeEnergy):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return _Production.__eq__(self, other) and _FreeEnergyMixin.__eq__(self, other)

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_equilibration.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_equilibration.py
@@ -167,3 +167,16 @@ class FreeEnergyEquilibration(_Equilibration, _FreeEnergyMixin):
             return "<BioSimSpace.Protocol.Custom>"
         else:
             return f"BioSimSpace.Protocol.FreeEnergyEquilibration({self._get_parm()})"
+
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, FreeEnergyEquilibration):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return _Equilibration.__eq__(self, other) and _FreeEnergyMixin.__eq__(
+            self, other
+        )

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_minimisation.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_minimisation.py
@@ -117,3 +117,16 @@ class FreeEnergyMinimisation(_Minimisation, _FreeEnergyMixin):
             return "BioSimSpace.Protocol.Custom"
         else:
             return f"BioSimSpace.Protocol.FreeEnergyMinimisation({self._get_parm()})"
+
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, FreeEnergyMinimisation):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return _Minimisation.__eq__(self, other) and _FreeEnergyMixin.__eq__(
+            self, other
+        )

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_mixin.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_mixin.py
@@ -85,6 +85,18 @@ class _FreeEnergyMixin(_Protocol):
         else:
             return f"BioSimSpace.Protocol._FreeEnergyMixin({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, _FreeEnergyMixin):
+            return False
+
+        return (
+            self._lambda == other._lambda
+            and self._lambda_vals == other._lambda_vals
+            and self._perturbation_type == other._perturbation_type
+        )
+
     def getPerturbationType(self):
         """
         Get the perturbation type.

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
@@ -48,7 +48,6 @@ class Metadynamics(_Protocol):
         runtime=_Types.Time(1, "nanosecond"),
         temperature=_Types.Temperature(300, "kelvin"),
         pressure=_Types.Pressure(1, "atmosphere"),
-        thermostat_time_constant=_Types.Time(1, "picosecond"),
         hill_height=_Types.Energy(1, "kj per mol"),
         hill_frequency=1000,
         report_interval=1000,
@@ -76,9 +75,6 @@ class Metadynamics(_Protocol):
 
         pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure. Pass pressure=None to use the NVT ensemble.
-
-        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
-            Time constant for thermostat coupling.
 
         hill_height : :class:`Energy <BioSimSpace.Types.Energy>`
             The height of the Gaussian hills.
@@ -127,9 +123,6 @@ class Metadynamics(_Protocol):
         else:
             self._pressure = None
 
-        # Set the thermostat time constant.
-        self.setThermostatTimeConstant(thermostat_time_constant)
-
         # Set the hill parameters: height, frequency.
         self.setHillHeight(hill_height)
         self.setHillFrequency(hill_frequency)
@@ -168,6 +161,28 @@ class Metadynamics(_Protocol):
     def __repr__(self):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
+
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Metadynamics):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._collective_variable == other._collective_variable
+            and self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature == other._temperature
+            and self._pressure == other._pressure
+            and self._hill_height == other._hill_height
+            and self._hill_frequency == other._hill_frequency
+            and self._bias_factor == other._bias_factor
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+        )
 
     def getCollectiveVariable(self):
         """
@@ -354,7 +369,7 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
         if isinstance(pressure, str):
@@ -367,42 +382,6 @@ class Metadynamics(_Protocol):
         else:
             raise TypeError(
                 "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
-            )
-
-    def getThermostatTimeConstant(self):
-        """
-        Return the time constant for the thermostat.
-
-        Returns
-        -------
-
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
-            The time constant for the thermostat.
-        """
-        return self._thermostat_time_constant
-
-    def setThermostatTimeConstant(self, thermostat_time_constant):
-        """
-        Set the time constant for the thermostat.
-
-        Parameters
-        ----------
-
-        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
-            The time constant for the thermostat.
-        """
-        if isinstance(thermostat_time_constant, str):
-            try:
-                self._thermostat_time_constant = _Types.Time(thermostat_time_constant)
-            except:
-                raise ValueError(
-                    "Unable to parse 'thermostat_time_constant' string."
-                ) from None
-        elif isinstance(thermostat_time_constant, _Types.Time):
-            self._thermostat_time_constant = thermostat_time_constant
-        else:
-            raise TypeError(
-                "'thermostat_time_constant' must be of type 'str' or 'BioSimSpace.Types.Time'"
             )
 
     def getHillHeight(self):
@@ -424,9 +403,10 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        hill_height : :class:`Energy <BioSimSpace.Types.Energy>`
+        hill_height : str, :class:`Energy <BioSimSpace.Types.Energy>`
             The hill height.
         """
+
         if isinstance(hill_height, str):
             try:
                 hill_height = _Types.Energy(hill_height)

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
@@ -252,13 +252,20 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        timestep : :class:`Time <BioSimSpace.Types.Time>`
+        timestep : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getRunTime(self):
         """
@@ -279,13 +286,20 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getTemperature(self):
         """
@@ -306,14 +320,19 @@ class Metadynamics(_Protocol):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The simulation temperature.
         """
+        if isinstance(temperature, str):
+            try:
+                self._temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
         if isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(
-                "'temperature' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
 
     def getPressure(self):
@@ -338,10 +357,17 @@ class Metadynamics(_Protocol):
         pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getThermostatTimeConstant(self):
         """
@@ -365,11 +391,18 @@ class Metadynamics(_Protocol):
         thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
             The time constant for the thermostat.
         """
-        if isinstance(thermostat_time_constant, _Types.Time):
+        if isinstance(thermostat_time_constant, str):
+            try:
+                self._thermostat_time_constant = _Types.Time(thermostat_time_constant)
+            except:
+                raise ValueError(
+                    "Unable to parse 'thermostat_time_constant' string."
+                ) from None
+        elif isinstance(thermostat_time_constant, _Types.Time):
             self._thermostat_time_constant = thermostat_time_constant
         else:
             raise TypeError(
-                "'thermostat_time_constant' must be of type 'BioSimSpace.Types.Time'"
+                "'thermostat_time_constant' must be of type 'str' or 'BioSimSpace.Types.Time'"
             )
 
     def getHillHeight(self):
@@ -394,9 +427,15 @@ class Metadynamics(_Protocol):
         hill_height : :class:`Energy <BioSimSpace.Types.Energy>`
             The hill height.
         """
-
-        if not isinstance(hill_height, _Types.Energy):
-            raise TypeError("'hill_height' must be of type 'BioSimSpace.Types.Energy'")
+        if isinstance(hill_height, str):
+            try:
+                hill_height = _Types.Energy(hill_height)
+            except:
+                raise ValueError("Unable to parse 'hill_height' string.") from None
+        elif not isinstance(hill_height, _Types.Energy):
+            raise TypeError(
+                "'hill_height' must be of type 'str' or 'BioSimSpace.Types.Energy'"
+            )
 
         # Check that heights is greater than zero.
         if hill_height.value() <= 0:

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
@@ -328,7 +328,7 @@ class Metadynamics(_Protocol):
                 self._temperature = _Types.Temperature(temperature)
             except:
                 raise ValueError("Unable to parse 'temperature' string.") from None
-        if isinstance(temperature, _Types.Temperature):
+        elif isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_minimisation.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_minimisation.py
@@ -98,6 +98,19 @@ class Minimisation(_Protocol, _PositionRestraintMixin):
         else:
             return f"BioSimSpace.Protocol.Minimisation({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Minimisation):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return self._steps == other._steps and _PositionRestraintMixin.__eq__(
+            self, other
+        )
+
     def getSteps(self):
         """
         Return the maximum number of steps.

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
@@ -148,7 +148,7 @@ class _PositionRestraintMixin:
         Parameters
         ----------
 
-        force_constant : :class:`GeneralUnit <BioSimSpace.Types._GeneralUnit>`, float
+        force_constant : :class:`GeneralUnit <BioSimSpace.Types._GeneralUnit>`, float, str
         """
 
         # Convert int to float.
@@ -159,18 +159,26 @@ class _PositionRestraintMixin:
             # Use default units.
             force_constant *= _Units.Energy.kcal_per_mol / _Units.Area.angstrom2
 
-        elif isinstance(force_constant, _Types._GeneralUnit):
+        else:
+            if isinstance(force_constant, str):
+                try:
+                    force_constant = _Units._GeneralUnit(force_constant)
+                except:
+                    raise ValueError(
+                        f"Unable to parse force constant '{force_constant}' string."
+                    ) from None
+
+            elif not isinstance(force_constant, _Types._GeneralUnit):
+                raise TypeError(
+                    "'force_constant' must be of type 'BioSimSpace.Types._GeneralUnit', or 'float'."
+                )
+
             # Validate the dimensions.
             if force_constant.dimensions() != (0, 0, 0, 1, -1, 0, -2):
                 raise ValueError(
                     "'force_constant' has invalid dimensions! "
                     f"Expected dimensions are 'M Q-1 T-2', found '{force_constant.unit()}'"
                 )
-
-        else:
-            raise TypeError(
-                "'force_constant' must be of type 'BioSimSpace.Types._GeneralUnit', or 'float'."
-            )
 
         self._force_constant = force_constant
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
@@ -165,7 +165,7 @@ class _PositionRestraintMixin:
                     force_constant = _Units._GeneralUnit(force_constant)
                 except:
                     raise ValueError(
-                        f"Unable to parse force constant '{force_constant}' string."
+                        f"Unable to parse 'force_constant' string."
                     ) from None
 
             elif not isinstance(force_constant, _Types._GeneralUnit):

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
@@ -72,6 +72,17 @@ class _PositionRestraintMixin:
         else:
             return f"BioSimSpace.Protocol._PositionRestraintMixin({self._get_parm()})"
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, _PositionRestraintMixin):
+            return False
+
+        return (
+            self._restraint == other._restraint
+            and self._force_constant == other._force_constant
+        )
+
     def getRestraint(self):
         """Return the type of restraint..
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
@@ -162,7 +162,7 @@ class _PositionRestraintMixin:
         else:
             if isinstance(force_constant, str):
                 try:
-                    force_constant = _Units._GeneralUnit(force_constant)
+                    force_constant = _Types._GeneralUnit(force_constant)
                 except:
                     raise ValueError(
                         f"Unable to parse 'force_constant' string."

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_production.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_production.py
@@ -188,13 +188,20 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        timestep : :class:`Time <BioSimSpace.Types.Time>`
+        timestep : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getRunTime(self):
         """
@@ -215,13 +222,20 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
     def getTauT(self):
         """
@@ -242,13 +256,18 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        tau_t : :class:`Time <BioSimSpace.Types.Time>`
+        tau_t : str, :class:`Time <BioSimSpace.Types.Time>`
             The time constant for the thermostat.
         """
-        if isinstance(tau_t, _Types.Time):
+        if isinstance(tau_t, str):
+            try:
+                self._tau_t = _Types.Time(tau_t)
+            except:
+                raise ValueError("Unable to parse 'tau_t' string.") from None
+        elif isinstance(tau_t, _Types.Time):
             self._tau_t = tau_t
         else:
-            raise TypeError("'tau_t' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError("'tau_t' must be of type 'str' or 'BioSimSpace.Types.Time'")
 
     def getTemperature(self):
         """
@@ -269,14 +288,19 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The simulation temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
+        if isinstance(temperature, str):
+            try:
+                self._temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(
-                "'temperature' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
 
     def getPressure(self):
@@ -298,13 +322,20 @@ class Production(_Protocol, _PositionRestraintMixin):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getReportInterval(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_production.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_production.py
@@ -149,6 +149,7 @@ class Production(_Protocol, _PositionRestraintMixin):
             f"runtime={self._runtime}, "
             f"temperature={self._temperature}, "
             f"pressure={self._pressure}, "
+            f"tau_t={self._tau_t}, "
             f"report_interval={self._report_interval}, "
             f"restart_interval={self._restart_interval}, "
             f"first_step={self._first_step}, "
@@ -168,6 +169,28 @@ class Production(_Protocol, _PositionRestraintMixin):
             return "BioSimSpace.Protocol.Custom"
         else:
             return f"BioSimSpace.Protocol.Production({self._get_parm()})"
+
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Production):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature == other._temperature
+            and self._pressure == other._pressure
+            and self._tau_t == other._tau_t
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+            and self._restart == other._restart
+            and self._first_step == other._first_step
+            and _PositionRestraintMixin.__eq__(self, other)
+        )
 
     def getTimeStep(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_steering.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_steering.py
@@ -175,6 +175,28 @@ class Steering(_Protocol):
         """Return a string showing how to instantiate the object."""
         return self.__str__()
 
+    def __eq__(self, other):
+        """Equality operator."""
+
+        if not isinstance(other, Steering):
+            return False
+
+        if self._is_customised or other._is_customised:
+            return False
+
+        return (
+            self._collective_variable == other._collective_variable
+            and self._schedule == other._schedule
+            and self._restraints == other._restraints
+            and self._verse == other._verse
+            and self._timestep == other._timestep
+            and self._runtime == other._runtime
+            and self._temperature == other._temperature
+            and self._pressure == other._pressure
+            and self._report_interval == other._report_interval
+            and self._restart_interval == other._restart_interval
+        )
+
     def getCollectiveVariable(self):
         """
         Return the collective variable (or variables).

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_steering.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_steering.py
@@ -444,13 +444,20 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        timestep : :class:`Time <BioSimSpace.Types.Time>`
+        timestep : str, :class:`Time <BioSimSpace.Types.Time>`
             The integration time step.
         """
-        if isinstance(timestep, _Types.Time):
+        if isinstance(timestep, str):
+            try:
+                self._timestep = _Types.Time(timestep)
+            except:
+                raise ValueError("Unable to parse 'timestep' string.") from None
+        elif isinstance(timestep, _Types.Time):
             self._timestep = timestep
         else:
-            raise TypeError("'timestep' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'timestep' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
         # If the object has already been created, then check that other member
         # data is consistent.
@@ -476,13 +483,20 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        runtime : :class:`Time <BioSimSpace.Types.Time>`
+        runtime : str, :class:`Time <BioSimSpace.Types.Time>`
             The simulation run time.
         """
-        if isinstance(runtime, _Types.Time):
+        if isinstance(runtime, str):
+            try:
+                self._runtime = _Types.Time(runtime)
+            except:
+                raise ValueError("Unable to parse 'runtime' string.") from None
+        elif isinstance(runtime, _Types.Time):
             self._runtime = runtime
         else:
-            raise TypeError("'runtime' must be of type 'BioSimSpace.Types.Time'")
+            raise TypeError(
+                "'runtime' must be of type 'str' or 'BioSimSpace.Types.Time'"
+            )
 
         # If the object has already been created, then check that other member
         # data is consistent.
@@ -508,14 +522,19 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        temperature : :class:`Temperature <BioSimSpace.Types.Temperature>`
+        temperature : str, :class:`Temperature <BioSimSpace.Types.Temperature>`
             The simulation temperature.
         """
-        if isinstance(temperature, _Types.Temperature):
+        if isinstance(temperature, str):
+            try:
+                self._temperature = _Types.Temperature(temperature)
+            except:
+                raise ValueError("Unable to parse 'temperature' string.") from None
+        elif isinstance(temperature, _Types.Temperature):
             self._temperature = temperature
         else:
             raise TypeError(
-                "'temperature' must be of type 'BioSimSpace.Types.Temperature'"
+                "'temperature' must be of type 'str' or 'BioSimSpace.Types.Temperature'"
             )
 
     def getPressure(self):
@@ -537,13 +556,20 @@ class Steering(_Protocol):
         Parameters
         ----------
 
-        pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
+        pressure : str, :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure.
         """
-        if isinstance(pressure, _Types.Pressure):
+        if isinstance(pressure, str):
+            try:
+                self._pressure = _Types.Pressure(pressure)
+            except:
+                raise ValueError("Unable to parse 'pressure' string.") from None
+        elif isinstance(pressure, _Types.Pressure):
             self._pressure = pressure
         else:
-            raise TypeError("'pressure' must be of type 'BioSimSpace.Types.Pressure'")
+            raise TypeError(
+                "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
 
     def getReportInterval(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -26,6 +26,8 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["GeneralUnit"]
 
+import math as _math
+
 from sire.legacy.Units import GeneralUnit as _GeneralUnit
 
 from ._base_units import *
@@ -502,13 +504,13 @@ class GeneralUnit(_Type):
 
         # Compare to another object of the same type and dimensions.
         if isinstance(other, _Type) and other._dimensions == self._dimensions:
-            return self._value == other._value
+            return _math.isclose(self._value, other._value)
 
         # Compare with a string.
         elif isinstance(other, str):
             other = self._from_string(other)
             if other._dimensions == self._dimensions:
-                return self._value == other._value
+                return _math.isclose(self._value, other._value)
             else:
                 return False
 
@@ -520,13 +522,13 @@ class GeneralUnit(_Type):
 
         # Compare to another object of the same type and dimensions.
         if isinstance(other, _Type) and other._dimensions == self._dimensions:
-            return self._value != other._value
+            return not _math.isclose(self._value, other._value)
 
         # Compare with a string.
         elif isinstance(other, str):
             other = self._from_string(other)
             if other._dimensions == self._dimensions:
-                return self._value != other._value
+                return not _math.isclose(self._value, other._value)
             else:
                 return True
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
@@ -26,6 +26,7 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["Type"]
 
+import math as _math
 import re as _re
 
 from sire.legacy import Units as _SireUnits
@@ -372,13 +373,16 @@ class Type:
 
         # Compare to another object of the same type.
         if type(other) is type(self):
-            return self._to_default_unit().value() == other._to_default_unit().value()
+            return _math.isclose(
+                self._to_default_unit().value(),
+                other._to_default_unit().value(),
+            )
 
         # Compare with a string.
         elif isinstance(other, str):
-            return (
-                self._to_default_unit().value()
-                == self._from_string(other)._to_default_unit().value()
+            return _math.isclose(
+                self._to_default_unit().value(),
+                self._from_string(other)._to_default_unit().value(),
             )
 
         else:
@@ -389,13 +393,16 @@ class Type:
 
         # Compare to another object of the same type.
         if type(other) is type(self):
-            return self._to_default_unit().value() != other._to_default_unit().value()
+            return _math.isclose(
+                self._to_default_unit().value(),
+                other._to_default_unit().value(),
+            )
 
         # Compare with a string.
         elif isinstance(other, str):
-            return (
-                self._to_default_unit().value()
-                != self._from_string(other)._to_default_unit().value()
+            return not _math.isclose(
+                self._to_default_unit().value(),
+                self._from_string(other)._to_default_unit().value(),
             )
 
         else:

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -26,6 +26,8 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["GeneralUnit"]
 
+import math as _math
+
 from sire.legacy.Units import GeneralUnit as _GeneralUnit
 
 from ._base_units import *
@@ -502,13 +504,13 @@ class GeneralUnit(_Type):
 
         # Compare to another object of the same type and dimensions.
         if isinstance(other, _Type) and other._dimensions == self._dimensions:
-            return self._value == other._value
+            return _math.isclose(self._value, other._value)
 
         # Compare with a string.
         elif isinstance(other, str):
             other = self._from_string(other)
             if other._dimensions == self._dimensions:
-                return self._value == other._value
+                return _math.isclose(self._value, other._value)
             else:
                 return False
 
@@ -520,13 +522,13 @@ class GeneralUnit(_Type):
 
         # Compare to another object of the same type and dimensions.
         if isinstance(other, _Type) and other._dimensions == self._dimensions:
-            return self._value != other._value
+            return not _math.isclose(self._value, other._value)
 
         # Compare with a string.
         elif isinstance(other, str):
             other = self._from_string(other)
             if other._dimensions == self._dimensions:
-                return self._value != other._value
+                return not _math.isclose(self._value, other._value)
             else:
                 return True
 

--- a/python/BioSimSpace/Types/_type.py
+++ b/python/BioSimSpace/Types/_type.py
@@ -26,6 +26,7 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["Type"]
 
+import math as _math
 import re as _re
 
 from sire.legacy import Units as _SireUnits
@@ -372,13 +373,16 @@ class Type:
 
         # Compare to another object of the same type.
         if type(other) is type(self):
-            return self._to_default_unit().value() == other._to_default_unit().value()
+            return _math.isclose(
+                self._to_default_unit().value(),
+                other._to_default_unit().value(),
+            )
 
         # Compare with a string.
         elif isinstance(other, str):
-            return (
-                self._to_default_unit().value()
-                == self._from_string(other)._to_default_unit().value()
+            return _math.isclose(
+                self._to_default_unit().value(),
+                self._from_string(other)._to_default_unit().value(),
             )
 
         else:
@@ -389,13 +393,16 @@ class Type:
 
         # Compare to another object of the same type.
         if type(other) is type(self):
-            return self._to_default_unit().value() != other._to_default_unit().value()
+            return _math.isclose(
+                self._to_default_unit().value(),
+                other._to_default_unit().value(),
+            )
 
         # Compare with a string.
         elif isinstance(other, str):
-            return (
-                self._to_default_unit().value()
-                != self._from_string(other)._to_default_unit().value()
+            return not _math.isclose(
+                self._to_default_unit().value(),
+                self._from_string(other)._to_default_unit().value(),
             )
 
         else:

--- a/tests/Protocol/test_protocol.py
+++ b/tests/Protocol/test_protocol.py
@@ -1,0 +1,164 @@
+import pytest
+
+import BioSimSpace as BSS
+
+# Unit tests for equivalence of protocol settings when instantiated
+# using strings of unit-based types.
+
+
+@pytest.fixture(scope="session")
+def system():
+    """Re-use the same molecuar system for each test."""
+    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+
+
+def test_equilibration():
+    # Instantiate from types.
+    p0 = BSS.Protocol.Equilibration(
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature_start=0 * BSS.Units.Temperature.kelvin,
+        temperature_end=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+        restraint="backbone",
+        force_constant=100
+        * BSS.Units.Energy.kj_per_mol
+        / BSS.Units.Length.nanometer**2,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Equilibration(
+        timestep="1fs",
+        runtime="100ps",
+        temperature_start="0K",
+        temperature_end="298K",
+        pressure="1atm",
+        restraint="backbone",
+        force_constant="100 kJ / (mol nm^2)",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_production():
+    # Instantiate from types.
+    p0 = BSS.Protocol.Production(
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+        restraint="backbone",
+        force_constant=100
+        * BSS.Units.Energy.kj_per_mol
+        / BSS.Units.Length.nanometer**2,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Production(
+        timestep="1fs",
+        runtime="100ps",
+        temperature="298K",
+        pressure="1atm",
+        restraint="backbone",
+        force_constant="100 kJ / (mol nm^2)",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_free_energy():
+    # Instantiate from types.
+    p0 = BSS.Protocol.FreeEnergy(
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+        restraint="backbone",
+        force_constant=100
+        * BSS.Units.Energy.kj_per_mol
+        / BSS.Units.Length.nanometer**2,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.FreeEnergy(
+        timestep="1fs",
+        runtime="100ps",
+        temperature="298K",
+        pressure="1atm",
+        restraint="backbone",
+        force_constant="100 kJ / (mol nm^2)",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_metadynamics():
+    # Create a collective variable so we can instantiate a metadynamics protocol.
+    cv = BSS.Metadynamics.CollectiveVariable.Torsion(atoms=[0, 1, 2, 3])
+
+    # Instantiate from types.
+    p0 = BSS.Protocol.Metadynamics(
+        collective_variable=cv,
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Metadynamics(
+        collective_variable=cv,
+        timestep="1fs",
+        runtime="100ps",
+        temperature="298K",
+        pressure="1atm",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_steering(system):
+    # Create a collective variable so we can instantiate a steering protocol.
+    cv = BSS.Metadynamics.CollectiveVariable.RMSD(system, system[0], [0, 1, 2, 3])
+
+    # Create a schedule.
+    start = 0 * BSS.Units.Time.nanosecond
+    apply_force = 4 * BSS.Units.Time.picosecond
+    steer = 150 * BSS.Units.Time.nanosecond
+    relax = 152 * BSS.Units.Time.nanosecond
+
+    # Create restraints.
+    nm = BSS.Units.Length.nanometer
+    restraint0 = BSS.Metadynamics.Restraint(cv.getInitialValue(), 0)
+    restraint1 = BSS.Metadynamics.Restraint(cv.getInitialValue(), 3500)
+    restraint2 = BSS.Metadynamics.Restraint(0 * nm, 3500)
+    restraint3 = BSS.Metadynamics.Restraint(0 * nm, 0)
+
+    # Instantiate from types.
+    p0 = BSS.Protocol.Steering(
+        cv,
+        [start, apply_force, steer, relax],
+        [restraint0, restraint1, restraint2, restraint3],
+        timestep=2 * BSS.Units.Time.femtosecond,
+        runtime=200 * BSS.Units.Time.nanosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Steering(
+        cv,
+        [start, apply_force, steer, relax],
+        [restraint0, restraint1, restraint2, restraint3],
+        timestep="2fs",
+        runtime="200ns",
+        temperature="298K",
+        pressure="1atm",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1

--- a/tests/Sandpit/Exscientia/Protocol/test_protocol.py
+++ b/tests/Sandpit/Exscientia/Protocol/test_protocol.py
@@ -1,0 +1,164 @@
+import pytest
+
+import BioSimSpace as BSS
+
+# Unit tests for equivalence of protocol settings when instantiated
+# using strings of unit-based types.
+
+
+@pytest.fixture(scope="session")
+def system():
+    """Re-use the same molecuar system for each test."""
+    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+
+
+def test_equilibration():
+    # Instantiate from types.
+    p0 = BSS.Protocol.Equilibration(
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature_start=0 * BSS.Units.Temperature.kelvin,
+        temperature_end=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+        restraint="backbone",
+        force_constant=100
+        * BSS.Units.Energy.kj_per_mol
+        / BSS.Units.Length.nanometer**2,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Equilibration(
+        timestep="1fs",
+        runtime="100ps",
+        temperature_start="0K",
+        temperature_end="298K",
+        pressure="1atm",
+        restraint="backbone",
+        force_constant="100 kJ / (mol nm^2)",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_production():
+    # Instantiate from types.
+    p0 = BSS.Protocol.Production(
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+        restraint="backbone",
+        force_constant=100
+        * BSS.Units.Energy.kj_per_mol
+        / BSS.Units.Length.nanometer**2,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Production(
+        timestep="1fs",
+        runtime="100ps",
+        temperature="298K",
+        pressure="1atm",
+        restraint="backbone",
+        force_constant="100 kJ / (mol nm^2)",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_free_energy():
+    # Instantiate from types.
+    p0 = BSS.Protocol.FreeEnergy(
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+        restraint="backbone",
+        force_constant=100
+        * BSS.Units.Energy.kj_per_mol
+        / BSS.Units.Length.nanometer**2,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.FreeEnergy(
+        timestep="1fs",
+        runtime="100ps",
+        temperature="298K",
+        pressure="1atm",
+        restraint="backbone",
+        force_constant="100 kJ / (mol nm^2)",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_metadynamics():
+    # Create a collective variable so we can instantiate a metadynamics protocol.
+    cv = BSS.Metadynamics.CollectiveVariable.Torsion(atoms=[0, 1, 2, 3])
+
+    # Instantiate from types.
+    p0 = BSS.Protocol.Metadynamics(
+        collective_variable=cv,
+        timestep=1 * BSS.Units.Time.femtosecond,
+        runtime=100 * BSS.Units.Time.picosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Metadynamics(
+        collective_variable=cv,
+        timestep="1fs",
+        runtime="100ps",
+        temperature="298K",
+        pressure="1atm",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1
+
+
+def test_steering(system):
+    # Create a collective variable so we can instantiate a steering protocol.
+    cv = BSS.Metadynamics.CollectiveVariable.RMSD(system, system[0], [0, 1, 2, 3])
+
+    # Create a schedule.
+    start = 0 * BSS.Units.Time.nanosecond
+    apply_force = 4 * BSS.Units.Time.picosecond
+    steer = 150 * BSS.Units.Time.nanosecond
+    relax = 152 * BSS.Units.Time.nanosecond
+
+    # Create restraints.
+    nm = BSS.Units.Length.nanometer
+    restraint0 = BSS.Metadynamics.Restraint(cv.getInitialValue(), 0)
+    restraint1 = BSS.Metadynamics.Restraint(cv.getInitialValue(), 3500)
+    restraint2 = BSS.Metadynamics.Restraint(0 * nm, 3500)
+    restraint3 = BSS.Metadynamics.Restraint(0 * nm, 0)
+
+    # Instantiate from types.
+    p0 = BSS.Protocol.Steering(
+        cv,
+        [start, apply_force, steer, relax],
+        [restraint0, restraint1, restraint2, restraint3],
+        timestep=2 * BSS.Units.Time.femtosecond,
+        runtime=200 * BSS.Units.Time.nanosecond,
+        temperature=298 * BSS.Units.Temperature.kelvin,
+        pressure=1 * BSS.Units.Pressure.atm,
+    )
+
+    # Instantiate from strings.
+    p1 = BSS.Protocol.Steering(
+        cv,
+        [start, apply_force, steer, relax],
+        [restraint0, restraint1, restraint2, restraint3],
+        timestep="2fs",
+        runtime="200ns",
+        temperature="298K",
+        pressure="1atm",
+    )
+
+    # Make sure the protocols are equivalent.
+    assert p0 == p1


### PR DESCRIPTION
This PR enables unit-based protocol options to be passed as strings, e.g:

```python
# These are equivalent.

# Instantiate from types.
p0 = BSS.Protocol.Equilibration(
    timestep=1 * BSS.Units.Time.femtosecond,
    runtime=100 * BSS.Units.Time.picosecond,
    temperature_start=0 * BSS.Units.Temperature.kelvin,
    temperature_end=298 * BSS.Units.Temperature.kelvin,
    pressure=1 * BSS.Units.Pressure.atm,
    restraint="backbone",
    force_constant=100
    * BSS.Units.Energy.kj_per_mol
    / BSS.Units.Length.nanometer**2,
)

# Instantiate from strings.
p1 = BSS.Protocol.Equilibration(
    timestep="1fs",
    runtime="100ps",
    temperature_start="0K",
    temperature_end="298K",
    pressure="1atm",
    restraint="backbone",
    force_constant="100 kJ / (mol nm^2)",
)
```

This means less typing and makes it easier to instantiate a protocol using settings in a configuration file. (Although none of this is a problem if using nodes.) There are other places in the code where the same approach could be applied, but this is the main point of friction. (I'll update the others as I refactor other parts.)

I've taken the opportunity to add some equality operators to make the testing easier. A lot of the changes are boiler-plate around that.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods