### PR TITLE
Pass match_water parameter to specialised solvation functions

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
@@ -142,6 +142,7 @@ def solvate(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -142,6 +142,7 @@ def solvate(
         ion_conc,
         is_neutral,
         is_aligned,
+        match_water,
         work_dir,
         property_map,
     )

--- a/tests/Sandpit/Exscientia/Solvent/test_solvent.py
+++ b/tests/Sandpit/Exscientia/Solvent/test_solvent.py
@@ -1,11 +1,13 @@
 import pytest
 import tempfile
 
+from functools import partial
+
 from sire.legacy.IO import GroTop
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 
-from tests.Sandpit.Exscientia.conftest import has_gromacs
+from tests.conftest import has_gromacs
 
 
 @pytest.fixture(scope="module")
@@ -18,8 +20,12 @@ def system():
 
 
 @pytest.mark.parametrize("match_water", [True, False])
+@pytest.mark.parametrize(
+    "function",
+    [partial(BSS.Solvent.solvate, "tip3p"), BSS.Solvent.tip3p],
+)
 @pytest.mark.skipif(not has_gromacs, reason="Requires GROMACS to be installed")
-def test_crystal_water(system, match_water):
+def test_crystal_water(system, match_water, function):
     """
     Test that user defined crystal waters can be preserved during
     solvation and on write to GroTop format.
@@ -35,7 +41,7 @@ def test_crystal_water(system, match_water):
     box, angles = BSS.Box.cubic(5.5 * BSS.Units.Length.nanometer)
 
     # Create the solvated system.
-    solvated = BSS.Solvent.tip3p(system, box, angles, match_water=match_water)
+    solvated = function(system, box, angles, match_water=match_water)
 
     # Search for the crystal waters in the solvated system.
     try:

--- a/tests/Solvent/test_solvent.py
+++ b/tests/Solvent/test_solvent.py
@@ -1,6 +1,8 @@
 import pytest
 import tempfile
 
+from functools import partial
+
 from sire.legacy.IO import GroTop
 
 import BioSimSpace as BSS
@@ -18,8 +20,12 @@ def system():
 
 
 @pytest.mark.parametrize("match_water", [True, False])
+@pytest.mark.parametrize(
+    "function",
+    [partial(BSS.Solvent.solvate, "tip3p"), BSS.Solvent.tip3p],
+)
 @pytest.mark.skipif(not has_gromacs, reason="Requires GROMACS to be installed")
-def test_crystal_water(system, match_water):
+def test_crystal_water(system, match_water, function):
     """
     Test that user defined crystal waters can be preserved during
     solvation and on write to GroTop format.
@@ -35,7 +41,7 @@ def test_crystal_water(system, match_water):
     box, angles = BSS.Box.cubic(5.5 * BSS.Units.Length.nanometer)
 
     # Create the solvated system.
-    solvated = BSS.Solvent.tip3p(system, box, angles, match_water=match_water)
+    solvated = function(system, box, angles, match_water=match_water)
 
     # Search for the crystal waters in the solvated system.
     try:


### PR DESCRIPTION
This PR fixes a bug where the `match_water` parameter wasn't passed from the generic `BioSimSpace.Solvent.solvate` function through to the specialised functions for the supported water models. I've generalised the test so it uses both function types so that we catch similarly missed parameters in future, e.g. when anything else is added.

Closes #185.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods