### PR TITLE
Fix issue #200

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
@@ -388,26 +388,6 @@ class Type:
         else:
             return False
 
-    def __ne__(self, other):
-        """Not equals to operator."""
-
-        # Compare to another object of the same type.
-        if type(other) is type(self):
-            return _math.isclose(
-                self._to_default_unit().value(),
-                other._to_default_unit().value(),
-            )
-
-        # Compare with a string.
-        elif isinstance(other, str):
-            return not _math.isclose(
-                self._to_default_unit().value(),
-                self._from_string(other)._to_default_unit().value(),
-            )
-
-        else:
-            return True
-
     def __ge__(self, other):
         """Greater than or equal to operator."""
 

--- a/python/BioSimSpace/Types/_type.py
+++ b/python/BioSimSpace/Types/_type.py
@@ -388,26 +388,6 @@ class Type:
         else:
             return False
 
-    def __ne__(self, other):
-        """Not equals to operator."""
-
-        # Compare to another object of the same type.
-        if type(other) is type(self):
-            return _math.isclose(
-                self._to_default_unit().value(),
-                other._to_default_unit().value(),
-            )
-
-        # Compare with a string.
-        elif isinstance(other, str):
-            return not _math.isclose(
-                self._to_default_unit().value(),
-                self._from_string(other)._to_default_unit().value(),
-            )
-
-        else:
-            return True
-
     def __ge__(self, other):
         """Greater than or equal to operator."""
 

--- a/tests/Sandpit/Exscientia/Types/test_types.py
+++ b/tests/Sandpit/Exscientia/Types/test_types.py
@@ -134,3 +134,21 @@ def test_container_mul(Type):
 
     # Assert we have a container of the original type.
     assert all(isinstance(x, Type) for x in container)
+
+
+@pytest.mark.parametrize("Type", types)
+def test_equality(Type):
+    """Test equality operators."""
+
+    t0 = Type(1.0, Type._default_unit)
+    t1 = Type(2.0, Type._default_unit)
+    t2 = Type(3.0, Type._default_unit)
+
+    assert t0 == t0
+    assert t0 <= t0
+    assert t0 >= t0
+    assert t0 != t1
+    assert t0 < t1
+    assert t1 > t0
+    assert t1 < t2
+    assert t2 > t1

--- a/tests/Sandpit/Exscientia/Types/test_types.py
+++ b/tests/Sandpit/Exscientia/Types/test_types.py
@@ -137,8 +137,8 @@ def test_container_mul(Type):
 
 
 @pytest.mark.parametrize("Type", types)
-def test_equality(Type):
-    """Test equality operators."""
+def test_operators(Type):
+    """Test equality/inequality operators."""
 
     t0 = Type(1.0, Type._default_unit)
     t1 = Type(2.0, Type._default_unit)

--- a/tests/Types/test_types.py
+++ b/tests/Types/test_types.py
@@ -134,3 +134,21 @@ def test_container_mul(Type):
 
     # Assert we have a container of the original type.
     assert all(isinstance(x, Type) for x in container)
+
+
+@pytest.mark.parametrize("Type", types)
+def test_equality(Type):
+    """Test equality operators."""
+
+    t0 = Type(1.0, Type._default_unit)
+    t1 = Type(2.0, Type._default_unit)
+    t2 = Type(3.0, Type._default_unit)
+
+    assert t0 == t0
+    assert t0 <= t0
+    assert t0 >= t0
+    assert t0 != t1
+    assert t0 < t1
+    assert t1 > t0
+    assert t1 < t2
+    assert t2 > t1

--- a/tests/Types/test_types.py
+++ b/tests/Types/test_types.py
@@ -137,8 +137,8 @@ def test_container_mul(Type):
 
 
 @pytest.mark.parametrize("Type", types)
-def test_equality(Type):
-    """Test equality operators."""
+def test_operators(Type):
+    """Test equality/inequality operators."""
 
     t0 = Type(1.0, Type._default_unit)
     t1 = Type(2.0, Type._default_unit)


### PR DESCRIPTION
This PR closes #200 by removing the redundant `BioSimSpace.Types.Type.__ne__` operator. I've also added a test to make sure all of the equality and inequality operators work as expected for all derived classes.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods