### PR TITLE
Internal updates due to Sire API fixes

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -1123,7 +1123,7 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
         # Get the box dimensions and angles.
         degree = _SireUnits.degree
         dimensions = [x.value() for x in frame.box_dimensions()]
-        angles = [x.to(degree) for x in frame.box_angles()]
+        angles = [x.to(degree) * degree for x in frame.box_angles()]
         box = _SireVol.TriclinicBox(*dimensions, *angles)
     else:
         box = _SireVol.TriclinicBox(frame.box_v1(), frame.box_v2(), frame.box_v3())

--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -1120,11 +1120,10 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
 
     # Create a triclinic space from the information in the frame file.
     if isinstance(frame, _SireIO.AmberRst7):
-        # Get the box dimensions and angles. Take the values, since the
-        # units are wrong.
+        # Get the box dimensions and angles.
         degree = _SireUnits.degree
         dimensions = [x.value() for x in frame.box_dimensions()]
-        angles = [x.value() * degree for x in frame.box_angles()]
+        angles = [x.to(degree) for x in frame.box_angles()]
         box = _SireVol.TriclinicBox(*dimensions, *angles)
     else:
         box = _SireVol.TriclinicBox(frame.box_v1(), frame.box_v2(), frame.box_v3())

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1228,7 +1228,10 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("velocity", "velocity")
             cursor = cursor.rotate(
-                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center,
+                matrix=rotation_matrix,
+                rotate_velocities=False,
+                map={"coordinates": prop_name},
             )
         except:
             pass
@@ -1241,12 +1244,14 @@ class System(_SireWrapper):
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("coordinates", "coordinates") + "1"
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
             except:
@@ -1258,12 +1263,14 @@ class System(_SireWrapper):
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("velocity", "velocity") + "1"
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
             except:

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -1123,7 +1123,7 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
         # Get the box dimensions and angles.
         degree = _SireUnits.degree
         dimensions = [x.value() for x in frame.box_dimensions()]
-        angles = [x.to(degree) for x in frame.box_angles()]
+        angles = [x.to(degree) * degree for x in frame.box_angles()]
         box = _SireVol.TriclinicBox(*dimensions, *angles)
     else:
         box = _SireVol.TriclinicBox(frame.box_v1(), frame.box_v2(), frame.box_v3())

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -1120,11 +1120,10 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
 
     # Create a triclinic space from the information in the frame file.
     if isinstance(frame, _SireIO.AmberRst7):
-        # Get the box dimensions and angles. Take the values, since the
-        # units are wrong.
+        # Get the box dimensions and angles.
         degree = _SireUnits.degree
         dimensions = [x.value() for x in frame.box_dimensions()]
-        angles = [x.value() * degree for x in frame.box_angles()]
+        angles = [x.to(degree) for x in frame.box_angles()]
         box = _SireVol.TriclinicBox(*dimensions, *angles)
     else:
         box = _SireVol.TriclinicBox(frame.box_v1(), frame.box_v2(), frame.box_v3())

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1167,7 +1167,10 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("coordinates", "coordinates")
             cursor = cursor.rotate(
-                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center,
+                matrix=rotation_matrix,
+                rotate_velocities=False,
+                map={"coordinates": prop_name},
             )
         except:
             pass
@@ -1176,7 +1179,10 @@ class System(_SireWrapper):
         try:
             prop_name = property_map.get("velocity", "velocity")
             cursor = cursor.rotate(
-                center=center, matrix=rotation_matrix, map={"coordinates": prop_name}
+                center=center,
+                matrix=rotation_matrix,
+                rotate_velocities=False,
+                map={"coordinates": prop_name},
             )
         except:
             pass
@@ -1189,12 +1195,14 @@ class System(_SireWrapper):
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("coordinates", "coordinates") + "1"
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
             except:
@@ -1206,12 +1214,14 @@ class System(_SireWrapper):
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
                 prop_name = property_map.get("velocity", "velocity") + "1"
                 cursor = cursor.rotate(
                     center=center,
                     matrix=rotation_matrix,
+                    rotate_velocities=False,
                     map={"coordinates": prop_name},
                 )
             except:


### PR DESCRIPTION
This PR applies some internal updates due to Sire changes introduced via OpenBioSim/sire#119 and OpenBioSim/sire#120. For the `cursor.rotate` update I've chosen (for now) to use `rotate_velocities=False` and manually rotate the velocities using the property map, i.e. adjusting what `coordinates` is mapped to. This is so the user can rename things how they like. I also manually apply a rotation for both end states when perturbable molecules are present. By adding`rotate_velocities=False` I'm simply making sure that I don't perform a double rotation. (Note that I could use the end state linking functionality, but this is simpler for now.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
