### PR TITLE
Bug Fix: Avoid inserting pair into boresch_dof_data until after try-except block

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -24,6 +24,7 @@ within the biomolecular simulation community. Our software is hosted via the `Op
 * Add functionality to allow manual rotation and reduction of triclinic boxes, rather than performing automatically on read (`#175 <https://github.com/OpenBioSim/biosimspace/pull/175>`__).
 * Allow unit-based protocol options to be passed as strings (`#179 <https://github.com/OpenBioSim/biosimspace/pull/179>`__).
 * Fix assignment of ``gpu`` configuration option for SOMD (`#181 <https://github.com/OpenBioSim/biosimspace/pull/181>`__).
+* Fix bug in the BSS Boresch restraint search code (`#204 <https://github.com/OpenBioSim/biosimspace/pull/204>`__).
 
 `2023.3.1 <https://github.com/openbiosim/biosimspace/compare/2023.3.0...2023.3.1>`_ - Aug 14 2023
 -------------------------------------------------------------------------------------------------

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -1374,7 +1374,6 @@ class RestraintSearch:
                 pair_list[:no_pairs],
                 desc="Scoring candidate Boresch anchor points. Anchor set no: ",
             ):
-                boresch_dof_data[pair] = {}
                 l1_idx, r1_idx = pair
                 try:
                     _, l2_idx, l3_idx = _getAnchorAts(l1_idx, ligand_selection_str, u)
@@ -1383,6 +1382,8 @@ class RestraintSearch:
                     _AnalysisError
                 ):  # Failed to find full set of anchor points for this pair
                     continue
+
+                boresch_dof_data[pair] = {}
                 boresch_dof_data[pair]["anchor_ats"] = [
                     l1_idx,
                     l2_idx,


### PR DESCRIPTION
This fixes a bug in the restraint search algorithm for Boresch restraints. In the event that the other Boresch anchor points could not be generated for a given pair of atoms, previously the pair was inserted into `boresch_dof_data` anyway, with an empty dictionary for its value. I've shifted the insertion of the pair into the dictionary to after the try-except block, which avoids inserting failed pairs.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges, @chryswoods