### PR TITLE
Fix a typo introduced in PR #198

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -639,11 +639,11 @@ class System(_SireWrapper):
 
             # Search for perturbable molecules with a velocity property.
             # Only consider the lambda = 0 end state.
-            has_pertrubable = False
+            has_perturbable = False
             for mol in self.getPerturbableMolecules():
                 # Add perturbable velocities.
                 if mol._sire_object.hasProperty("velocity0"):
-                    has_pertrubable = True
+                    has_perturbable = True
                     num_vels += 1
                 # Remove non-perturbable velocities to avoid double counting.
                 elif mol._sire_object.hasProperty("velocity"):


### PR DESCRIPTION
This PR fixes a typo from #198, due to manually patching the files.

* I confirm that I have merged the latest version of `main` into this branch before issuing this pull request (e.g. by running `git pull origin main`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
