### PR TITLE
Fix issue #218

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -921,9 +921,9 @@ class Trajectory:
             The number of trajectory frames.
         """
 
-        # First get the current MDTraj object.
+        # First get the current trajectory object using the existing backend.
         if self._process is not None and self._process.isRunning():
-            self._trajectory = self.getTrajectory()
+            self._trajectory = self.getTrajectory(format=self._backend)
 
         # There is no trajectory.
         if self._trajectory is None:

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -921,9 +921,9 @@ class Trajectory:
             The number of trajectory frames.
         """
 
-        # First get the current MDTraj object.
+        # First get the current trajectory object using the existing backend.
         if self._process is not None and self._process.isRunning():
-            self._trajectory = self.getTrajectory()
+            self._trajectory = self.getTrajectory(format=self._backend)
 
         # There is no trajectory.
         if self._trajectory is None:


### PR DESCRIPTION
This PR closes #218 by making sure that the _existing_ trajectory backend is used to get the number of trajectory frames from a running process. This fixes the issue reported at OpenBioSim/biosimspace_tutorials#17 and has been tested using the notebook referenced there.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
