### PR TITLE
bugfix: addtoconfig is not a function in _amber.py, add to protocol d…

### DIFF
--- a/python/BioSimSpace/_Config/_amber.py
+++ b/python/BioSimSpace/_Config/_amber.py
@@ -178,7 +178,7 @@ class Amber(_Config):
             protocol_dict["cut"] = "999."
             if is_pmemd:
                 # Use vacuum generalised Born model.
-                self.addToConfig("  igb=6,")
+                protocol_dict["igb"] = "6"
         else:
             # Non-bonded cut-off.
             protocol_dict["cut"] = "8.0"


### PR DESCRIPTION
…ict instead

Hello! This is a PR to fix a small bug in the amber config file writing. As there is no addToConfig() function, this throws an error. Adding to the protocol dict instead fixes this line.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges
