### PR TITLE
Fix issue #221

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -293,7 +293,7 @@ class ConfigFactory:
                                     ]
                                 restraint_mask = "@" + ",".join(restraint_atom_names)
                             elif restraint == "heavy":
-                                restraint_mask = "!:WAT & !@H"
+                                restraint_mask = "!:WAT & !@H="
                             elif restraint == "all":
                                 restraint_mask = "!:WAT"
 

--- a/python/BioSimSpace/_Config/_amber.py
+++ b/python/BioSimSpace/_Config/_amber.py
@@ -224,7 +224,7 @@ class Amber(_Config):
                                     ]
                                 restraint_mask = "@" + ",".join(restraint_atom_names)
                             elif restraint == "heavy":
-                                restraint_mask = "!:WAT & !@H"
+                                restraint_mask = "!:WAT & !@H="
                             elif restraint == "all":
                                 restraint_mask = "!:WAT"
 


### PR DESCRIPTION
This PR closes #221 by making sure that the AMBER restraint mask matches all atom names starting with H, not just H by itself.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@xiki-tempula 