### PR TITLE
Make sure disulphide search is converted to a SelectorBond.

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -725,7 +725,7 @@ class AmberProtein(_protocol.Protocol):
 
         # Try searching for disulphide bonds.
         try:
-            disulphides = query(mol, property_map)
+            disulphides = query(mol, property_map).bonds()
         except:
             disulphides = []
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -725,7 +725,7 @@ class AmberProtein(_protocol.Protocol):
 
         # Try searching for disulphide bonds.
         try:
-            disulphides = query(mol, property_map)
+            disulphides = query(mol, property_map).bonds()
         except:
             disulphides = []
 


### PR DESCRIPTION
This PR closes #223 and closes OpenBioSim/biosimspace_tutorials#20 by making sure any (succesful) search for disulphide bonds is converted to a `SelectorBond`, thus is iterable. At present, if a single result is found, then it is returned as a `Bond`, hence the logic that follows the search will fail, i.e. getting an item from will extract an `Atom`, not a `Bond`.

I've tested the search logic for other bonds in a molecule, e.g. those between specific atom names, or indices. I don't (yet) have a single disulphide bond test molecule to add.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
