### PR TITLE
Fix issue #225

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -227,14 +227,30 @@ class AmberProtein(_protocol.Protocol):
                     raise TypeError(
                         "'custom_parameters' must be a 'list' of 'str' types."
                     )
+                validated_parameters = []
                 for x in custom_parameters:
-                    if not os.path.isfile(x):
-                        raise ValueError(f"Custom parameter file does not exist: '{x}'")
+                    x.replace(" ", "")
+                    # Try to find built in force field files.
+                    if "leaprc" in x:
+                        ff = x.replace("leaprc.", "")
+                        try:
+                            ff = _find_force_field(ff)
+                            validated_parameters.append(f"source {ff}")
+                        except:
+                            raise ValueError(
+                                f"Custom parameter file does not exist: '{x}'"
+                            )
+                    else:
+                        if not _os.path.isfile(x):
+                            raise ValueError(
+                                f"Custom parameter file does not exist: '{x}'"
+                            )
+                        else:
+                            validated_parameters.append(
+                                f"loadAmberParams {_os.path.abspath(x)}"
+                            )
 
-            # Convert to absolute paths.
-            self._custom_parameters = []
-            for x in enumerate(custom_parameters):
-                self._custom_parameters.append(_os.path.abspath(x))
+            self._custom_parameters = validated_parameters
         else:
             self._custom_parameters = None
 

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -122,8 +122,8 @@ class AmberProtein(_protocol.Protocol):
         tolerance=1.2,
         max_distance=_Length(6, "A"),
         water_model=None,
-        custom_parameters=None,
-        leap_commands=None,
+        pre_mol_commands=None,
+        post_mol_commands=None,
         bonds=None,
         ensure_compatible=True,
         property_map={},
@@ -155,17 +155,17 @@ class AmberProtein(_protocol.Protocol):
             Run 'BioSimSpace.Solvent.waterModels()' to see the supported
             water models.
 
-        custom_parameters: [str]
-            A list of paths to custom parameter files. These can be user-defined
-            parameter files files that are loaded with loadAmberParams, or the names
-            of additional internal leaprc scripts, which will be sourced, e.g.
-            'leaprc.gaff'. When this option is set, we can no longer fall back on
-            GROMACS's pdb2gmx.
+        pre_mol_commands : [str]
+            A list of custom LEaP commands to be executed before loading the molecule.
+            This can be used for loading custom parameter files, or sourcing additional
+            scripts. Make sure to use absolute paths when specifying any external files.
+            When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-        leap_commands : [str]
-            An optional list of extra commands for the LEaP program. These
-            will be added after any default commands. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+        post_mol_commands : [str]
+            A list of custom LEaP commands to be executed after loading the molecule.
+            This allows the use of additional commands that operate on the molecule,
+            which is named "mol". When this option is set, we can no longer fall
+            back on GROMACS's pdb2gmx.
 
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
@@ -221,50 +221,25 @@ class AmberProtein(_protocol.Protocol):
         else:
             self._water_model = water_model
 
-        # Validate the custom parameter file list.
-        if custom_parameters is not None:
-            if not isinstance(custom_parameters, (list, tuple)):
-                raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
-            else:
-                if not all(isinstance(x, str) for x in custom_parameters):
-                    raise TypeError(
-                        "'custom_parameters' must be a 'list' of 'str' types."
-                    )
-                validated_parameters = []
-                for x in custom_parameters:
-                    x.replace(" ", "")
-                    # Try to find built in force field files.
-                    if "leaprc" in x:
-                        ff = x.replace("leaprc.", "")
-                        try:
-                            ff = _find_force_field(ff)
-                            validated_parameters.append(f"source {ff}")
-                        except:
-                            raise ValueError(
-                                f"Custom parameter file does not exist: '{x}'"
-                            )
-                    else:
-                        if not _os.path.isfile(x):
-                            raise ValueError(
-                                f"Custom parameter file does not exist: '{x}'"
-                            )
-                        else:
-                            validated_parameters.append(
-                                f"loadAmberParams {_os.path.abspath(x)}"
-                            )
-
-            self._custom_parameters = validated_parameters
-        else:
-            self._custom_parameters = None
-
         # Validate the additional leap commands.
-        if leap_commands is not None:
-            if not isinstance(leap_commands, (list, tuple)):
-                raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
+        if pre_mol_commands is not None:
+            if not isinstance(pre_mol_commands, (list, tuple)):
+                raise TypeError("'pre_mol_commands must be a 'list' of 'str' types.")
             else:
-                if not all(isinstance(x, str) for x in leap_commands):
-                    raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
-        self._leap_commands = leap_commands
+                if not all(isinstance(x, str) for x in pre_mol_commands):
+                    raise TypeError(
+                        "'pre_mol_commands' must be a 'list' of 'str' types."
+                    )
+        self._pre_mol_commands = pre_mol_commands
+        if post_mol_commands is not None:
+            if not isinstance(post_mol_commands, (list, tuple)):
+                raise TypeError("'post_mol_commands must be a 'list' of 'str' types.")
+            else:
+                if not all(isinstance(x, str) for x in post_mol_commands):
+                    raise TypeError(
+                        "'post_mol_commands' must be a 'list' of 'str' types."
+                    )
+        self._post_mol_commands = post_mol_commands
 
         # Validate the bond records.
         if bonds is not None:
@@ -292,7 +267,7 @@ class AmberProtein(_protocol.Protocol):
 
         # Set the compatibility flags.
         self._tleap = True
-        if self._custom_parameters is not None or self._leap_commands is not None:
+        if self._pre_mol_commands is not None or self._post_mol_commands is not None:
             self._pdb2gmx = False
 
     def run(self, molecule, work_dir=None, queue=None):
@@ -531,10 +506,10 @@ class AmberProtein(_protocol.Protocol):
                     file.write("source leaprc.water.tip4pew\n")
                 else:
                     file.write("source leaprc.water.%s\n" % self._water_model)
-            # Write custom parameters.
-            if self._custom_parameters is not None:
-                for param in self._custom_parameters:
-                    file.write("%s\n" % param)
+            # Write pre-mol user leap commands.
+            if self._pre_mol_commands is not None:
+                for command in self._pre_mol_commands:
+                    file.write("%s\n" % command)
             file.write("mol = loadPdb leap.pdb\n")
             # Add any disulphide bond records.
             for bond in disulphide_bonds:
@@ -542,9 +517,9 @@ class AmberProtein(_protocol.Protocol):
             # Add any additional bond records.
             for bond in pruned_bond_records:
                 file.write("%s\n" % bond)
-            # Write user leap commands.
-            if self._leap_commands is not None:
-                for command in self._leap_commands:
+            # Write post-mol user leap commands.
+            if self._post_mol_commands is not None:
+                for command in self._post_mol_commands:
                     file.write("%s\n" % command)
             file.write("saveAmberParm mol leap.top leap.crd\n")
             file.write("quit")

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -156,8 +156,11 @@ class AmberProtein(_protocol.Protocol):
             water models.
 
         custom_parameters: [str]
-            A list of paths to custom parameter files. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+            A list of paths to custom parameter files. These can be user-defined
+            parameter files files that are loaded with loadAmberParams, or the names
+            of additional internal leaprc scripts, which will be sourced, e.g.
+            'leaprc.gaff'. When this option is set, we can no longer fall back on
+            GROMACS's pdb2gmx.
 
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -906,13 +906,16 @@ def _validate(
             )
 
     if custom_parameters is not None:
+        import os as _os
+
         if not isinstance(custom_parameters, (list, tuple)):
             raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
         else:
             if not all(isinstance(x, str) for x in custom_parameters):
                 raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
             for x in custom_parameters:
-                if not os.path.isfile(x):
+                # Built-in parameter files are named 'leaprc.*' and are handled separately.
+                if not "leaprc" in x and not _os.path.isfile(x):
                     raise ValueError(f"Custom parameter file does not exist: '{x}'")
 
     if leap_commands is not None:
@@ -981,6 +984,7 @@ def _make_amber_protein_function(name):
         tolerance=1.2,
         max_distance=_Length(6, "A"),
         water_model=None,
+        custom_parameters=None,
         leap_commands=None,
         bonds=None,
         ensure_compatible=True,
@@ -1013,11 +1017,14 @@ def _make_amber_protein_function(name):
             or lone oxygen atoms corresponding to structural (crystal) water
             molecules.
 
+        custom_parameters: [str]
+            A list of paths to custom parameter files. When this option is set,
+            we can no longer fall back on GROMACS's pdb2gmx.
+
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These
-            will be added after any default commands and can be used to, e.g.,
-            load additional parameter files. When this option is set, we can no
-            longer fall back on GROMACS's pdb2gmx.
+            will be added after any default commands. When this option is set,
+            we can no longer fall back on GROMACS's pdb2gmx.
 
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
@@ -1052,6 +1059,7 @@ def _make_amber_protein_function(name):
             tolerance=tolerance,
             max_distance=max_distance,
             water_model=water_model,
+            custom_parameters=custom_parameters,
             leap_commands=leap_commands,
             bonds=bonds,
             ensure_compatible=ensure_compatible,

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -173,8 +173,11 @@ def _parameterise_amber_protein(
         molecules.
 
     custom_parameters: [str]
-        A list of paths to custom parameter files. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+        A list of paths to custom parameter files. These can be user-defined
+        parameter files files that are loaded with loadAmberParams, or the names
+        of additional internal leaprc scripts, which will be sourced, e.g.
+        'leaprc.gaff'. When this option is set, we can no longer fall back on
+        GROMACS's pdb2gmx.
 
     leap_commands : [str]
         An optional list of extra commands for the LEaP program. These
@@ -1018,8 +1021,11 @@ def _make_amber_protein_function(name):
             molecules.
 
         custom_parameters: [str]
-            A list of paths to custom parameter files. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+            A list of paths to custom parameter files. These can be user-defined
+            parameter files files that are loaded with loadAmberParams, or the names
+            of additional internal leaprc scripts, which will be sourced, e.g.
+            'leaprc.gaff'. When this option is set, we can no longer fall back on
+            GROMACS's pdb2gmx.
 
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -135,8 +135,8 @@ def _parameterise_amber_protein(
     tolerance=1.2,
     max_distance=_Length(6, "A"),
     water_model=None,
-    custom_parameters=None,
-    leap_commands=None,
+    pre_mol_commands=None,
+    post_mol_commands=None,
     bonds=None,
     ensure_compatible=True,
     work_dir=None,
@@ -172,17 +172,17 @@ def _parameterise_amber_protein(
         or lone oxygen atoms corresponding to structural (crystal) water
         molecules.
 
-    custom_parameters: [str]
-        A list of paths to custom parameter files. These can be user-defined
-        parameter files files that are loaded with loadAmberParams, or the names
-        of additional internal leaprc scripts, which will be sourced, e.g.
-        'leaprc.gaff'. When this option is set, we can no longer fall back on
-        GROMACS's pdb2gmx.
+    pre_mol_commands : [str]
+        A list of custom LEaP commands to be executed before loading the molecule.
+        This can be used for loading custom parameter files, or sourcing additional
+        scripts. Make sure to use absolute paths when specifying any external files.
+        When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-    leap_commands : [str]
-        An optional list of extra commands for the LEaP program. These
-        will be added after any default commands. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+    post_mol_commands : [str]
+        A list of custom LEaP commands to be executed after loading the molecule.
+        This allows the use of additional commands that operate on the molecule,
+        which is named "mol". When this option is set, we can no longer fall
+        back on GROMACS's pdb2gmx.
 
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
@@ -244,8 +244,8 @@ def _parameterise_amber_protein(
         max_distance=max_distance,
         water_model=water_model,
         check_ions=True,
-        custom_parameters=custom_parameters,
-        leap_commands=leap_commands,
+        pre_mol_commands=pre_mol_commands,
+        post_mol_commands=post_mol_commands,
         bonds=bonds,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
@@ -258,8 +258,8 @@ def _parameterise_amber_protein(
         tolerance=tolerance,
         water_model=water_model,
         max_distance=max_distance,
-        custom_parameters=custom_parameters,
-        leap_commands=leap_commands,
+        pre_mol_commands=pre_mol_commands,
+        post_mol_commands=post_mol_commands,
         bonds=bonds,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
@@ -805,8 +805,8 @@ def _validate(
     max_distance=None,
     water_model=None,
     check_ions=False,
-    custom_parameters=None,
-    leap_commands=None,
+    pre_mol_commands=None,
+    post_mol_commands=None,
     bonds=None,
     ensure_compatible=True,
     work_dir=None,
@@ -842,14 +842,17 @@ def _validate(
         Whether to check for the presence of structural ions. This is only
         required when parameterising with protein force fields.
 
-    custom_parameters: [str]
-        A list of paths to custom parameter files. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+    pre_mol_commands : [str]
+        A list of custom LEaP commands to be executed before loading the molecule.
+        This can be used for loading custom parameter files, or sourcing additional
+        scripts. Make sure to use absolute paths when specifying any external files.
+        When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-    leap_commands : [str]
-        An optional list of extra commands for the LEaP program. These
-        will be added after any default commands. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+    post_mol_commands : [str]
+        A list of custom LEaP commands to be executed after loading the molecule.
+        This allows the use of additional commands that operate on the molecule,
+        which is named "mol". When this option is set, we can no longer fall
+        back on GROMACS's pdb2gmx.
 
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
@@ -908,25 +911,19 @@ def _validate(
                 "Please choose a 'water_model' for the ion parameters."
             )
 
-    if custom_parameters is not None:
-        import os as _os
-
-        if not isinstance(custom_parameters, (list, tuple)):
-            raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
+    if pre_mol_commands is not None:
+        if not isinstance(pre_mol_commands, (list, tuple)):
+            raise TypeError("'pre_mol_commands' must be a 'list' of 'str' types.")
         else:
-            if not all(isinstance(x, str) for x in custom_parameters):
-                raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
-            for x in custom_parameters:
-                # Built-in parameter files are named 'leaprc.*' and are handled separately.
-                if not "leaprc" in x and not _os.path.isfile(x):
-                    raise ValueError(f"Custom parameter file does not exist: '{x}'")
+            if not all(isinstance(x, str) for x in pre_mol_commands):
+                raise TypeError("'pre_mol_commands' must be a 'list' of 'str' types.")
 
-    if leap_commands is not None:
-        if not isinstance(leap_commands, (list, tuple)):
-            raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
+    if post_mol_commands is not None:
+        if not isinstance(post_mol_commands, (list, tuple)):
+            raise TypeError("'post_mol_commands' must be a 'list' of 'str' types.")
         else:
-            if not all(isinstance(x, str) for x in leap_commands):
-                raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
+            if not all(isinstance(x, str) for x in post_mol_commands):
+                raise TypeError("'post_mol_commands' must be a 'list' of 'str' types.")
 
     if bonds is not None:
         if molecule is None:
@@ -987,8 +984,8 @@ def _make_amber_protein_function(name):
         tolerance=1.2,
         max_distance=_Length(6, "A"),
         water_model=None,
-        custom_parameters=None,
-        leap_commands=None,
+        pre_mol_commands=None,
+        post_mol_commands=None,
         bonds=None,
         ensure_compatible=True,
         work_dir=None,
@@ -1020,17 +1017,17 @@ def _make_amber_protein_function(name):
             or lone oxygen atoms corresponding to structural (crystal) water
             molecules.
 
-        custom_parameters: [str]
-            A list of paths to custom parameter files. These can be user-defined
-            parameter files files that are loaded with loadAmberParams, or the names
-            of additional internal leaprc scripts, which will be sourced, e.g.
-            'leaprc.gaff'. When this option is set, we can no longer fall back on
-            GROMACS's pdb2gmx.
+        pre_mol_commands : [str]
+            A list of custom LEaP commands to be executed before loading the molecule.
+            This can be used for loading custom parameter files, or sourcing additional
+            scripts. Make sure to use absolute paths when specifying any external files.
+            When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-        leap_commands : [str]
-            An optional list of extra commands for the LEaP program. These
-            will be added after any default commands. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+        post_mol_commands : [str]
+            A list of custom LEaP commands to be executed after loading the molecule.
+            This allows the use of additional commands that operate on the molecule,
+            which is named "mol". When this option is set, we can no longer fall
+            back on GROMACS's pdb2gmx.
 
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
@@ -1065,8 +1062,8 @@ def _make_amber_protein_function(name):
             tolerance=tolerance,
             max_distance=max_distance,
             water_model=water_model,
-            custom_parameters=custom_parameters,
-            leap_commands=leap_commands,
+            pre_mol_commands=pre_mol_commands,
+            post_mol_commands=post_mol_commands,
             bonds=bonds,
             ensure_compatible=ensure_compatible,
             work_dir=work_dir,

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -227,14 +227,30 @@ class AmberProtein(_protocol.Protocol):
                     raise TypeError(
                         "'custom_parameters' must be a 'list' of 'str' types."
                     )
+                validated_parameters = []
                 for x in custom_parameters:
-                    if not os.path.isfile(x):
-                        raise ValueError(f"Custom parameter file does not exist: '{x}'")
+                    x.replace(" ", "")
+                    # Try to find built in force field files.
+                    if "leaprc" in x:
+                        ff = x.replace("leaprc.", "")
+                        try:
+                            ff = _find_force_field(ff)
+                            validated_parameters.append(f"source {ff}")
+                        except:
+                            raise ValueError(
+                                f"Custom parameter file does not exist: '{x}'"
+                            )
+                    else:
+                        if not _os.path.isfile(x):
+                            raise ValueError(
+                                f"Custom parameter file does not exist: '{x}'"
+                            )
+                        else:
+                            validated_parameters.append(
+                                f"loadAmberParams {_os.path.abspath(x)}"
+                            )
 
-            # Convert to absolute paths.
-            self._custom_parameters = []
-            for x in enumerate(custom_parameters):
-                self._custom_parameters.append(_os.path.abspath(x))
+            self._custom_parameters = validated_parameters
         else:
             self._custom_parameters = None
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -122,8 +122,8 @@ class AmberProtein(_protocol.Protocol):
         tolerance=1.2,
         max_distance=_Length(6, "A"),
         water_model=None,
-        custom_parameters=None,
-        leap_commands=None,
+        pre_mol_commands=None,
+        post_mol_commands=None,
         bonds=None,
         ensure_compatible=True,
         property_map={},
@@ -155,17 +155,17 @@ class AmberProtein(_protocol.Protocol):
             Run 'BioSimSpace.Solvent.waterModels()' to see the supported
             water models.
 
-        custom_parameters: [str]
-            A list of paths to custom parameter files. These can be user-defined
-            parameter files files that are loaded with loadAmberParams, or the names
-            of additional internal leaprc scripts, which will be sourced, e.g.
-            'leaprc.gaff'. When this option is set, we can no longer fall back on
-            GROMACS's pdb2gmx.
+        pre_mol_commands : [str]
+            A list of custom LEaP commands to be executed before loading the molecule.
+            This can be used for loading custom parameter files, or sourcing additional
+            scripts. Make sure to use absolute paths when specifying any external files.
+            When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-        leap_commands : [str]
-            An optional list of extra commands for the LEaP program. These
-            will be added after any default commands. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+        post_mol_commands : [str]
+            A list of custom LEaP commands to be executed after loading the molecule.
+            This allows the use of additional commands that operate on the molecule,
+            which is named "mol". When this option is set, we can no longer fall
+            back on GROMACS's pdb2gmx.
 
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
@@ -221,50 +221,25 @@ class AmberProtein(_protocol.Protocol):
         else:
             self._water_model = water_model
 
-        # Validate the custom parameter file list.
-        if custom_parameters is not None:
-            if not isinstance(custom_parameters, (list, tuple)):
-                raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
-            else:
-                if not all(isinstance(x, str) for x in custom_parameters):
-                    raise TypeError(
-                        "'custom_parameters' must be a 'list' of 'str' types."
-                    )
-                validated_parameters = []
-                for x in custom_parameters:
-                    x.replace(" ", "")
-                    # Try to find built in force field files.
-                    if "leaprc" in x:
-                        ff = x.replace("leaprc.", "")
-                        try:
-                            ff = _find_force_field(ff)
-                            validated_parameters.append(f"source {ff}")
-                        except:
-                            raise ValueError(
-                                f"Custom parameter file does not exist: '{x}'"
-                            )
-                    else:
-                        if not _os.path.isfile(x):
-                            raise ValueError(
-                                f"Custom parameter file does not exist: '{x}'"
-                            )
-                        else:
-                            validated_parameters.append(
-                                f"loadAmberParams {_os.path.abspath(x)}"
-                            )
-
-            self._custom_parameters = validated_parameters
-        else:
-            self._custom_parameters = None
-
         # Validate the additional leap commands.
-        if leap_commands is not None:
-            if not isinstance(leap_commands, (list, tuple)):
-                raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
+        if pre_mol_commands is not None:
+            if not isinstance(pre_mol_commands, (list, tuple)):
+                raise TypeError("'pre_mol_commands must be a 'list' of 'str' types.")
             else:
-                if not all(isinstance(x, str) for x in leap_commands):
-                    raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
-        self._leap_commands = leap_commands
+                if not all(isinstance(x, str) for x in pre_mol_commands):
+                    raise TypeError(
+                        "'pre_mol_commands' must be a 'list' of 'str' types."
+                    )
+        self._pre_mol_commands = pre_mol_commands
+        if post_mol_commands is not None:
+            if not isinstance(post_mol_commands, (list, tuple)):
+                raise TypeError("'post_mol_commands must be a 'list' of 'str' types.")
+            else:
+                if not all(isinstance(x, str) for x in post_mol_commands):
+                    raise TypeError(
+                        "'post_mol_commands' must be a 'list' of 'str' types."
+                    )
+        self._post_mol_commands = post_mol_commands
 
         # Validate the bond records.
         if bonds is not None:
@@ -292,7 +267,7 @@ class AmberProtein(_protocol.Protocol):
 
         # Set the compatibility flags.
         self._tleap = True
-        if self._custom_parameters is not None or self._leap_commands is not None:
+        if self._pre_mol_commands is not None or self._post_mol_commands is not None:
             self._pdb2gmx = False
 
     def run(self, molecule, work_dir=None, queue=None):
@@ -531,10 +506,10 @@ class AmberProtein(_protocol.Protocol):
                     file.write("source leaprc.water.tip4pew\n")
                 else:
                     file.write("source leaprc.water.%s\n" % self._water_model)
-            # Write custom parameters.
-            if self._custom_parameters is not None:
-                for param in self._custom_parameters:
-                    file.write("%s\n" % param)
+            # Write pre-mol user leap commands.
+            if self._pre_mol_commands is not None:
+                for command in self._pre_mol_commands:
+                    file.write("%s\n" % command)
             file.write("mol = loadPdb leap.pdb\n")
             # Add any disulphide bond records.
             for bond in disulphide_bonds:
@@ -542,9 +517,9 @@ class AmberProtein(_protocol.Protocol):
             # Add any additional bond records.
             for bond in pruned_bond_records:
                 file.write("%s\n" % bond)
-            # Write user leap commands.
-            if self._leap_commands is not None:
-                for command in self._leap_commands:
+            # Write post-mol user leap commands.
+            if self._post_mol_commands is not None:
+                for command in self._post_mol_commands:
                     file.write("%s\n" % command)
             file.write("saveAmberParm mol leap.top leap.crd\n")
             file.write("quit")

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -156,8 +156,11 @@ class AmberProtein(_protocol.Protocol):
             water models.
 
         custom_parameters: [str]
-            A list of paths to custom parameter files. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+            A list of paths to custom parameter files. These can be user-defined
+            parameter files files that are loaded with loadAmberParams, or the names
+            of additional internal leaprc scripts, which will be sourced, e.g.
+            'leaprc.gaff'. When this option is set, we can no longer fall back on
+            GROMACS's pdb2gmx.
 
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -906,13 +906,16 @@ def _validate(
             )
 
     if custom_parameters is not None:
+        import os as _os
+
         if not isinstance(custom_parameters, (list, tuple)):
             raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
         else:
             if not all(isinstance(x, str) for x in custom_parameters):
                 raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
             for x in custom_parameters:
-                if not os.path.isfile(x):
+                # Built-in parameter files are named 'leaprc.*' and are handled separately.
+                if not "leaprc" in x and not _os.path.isfile(x):
                     raise ValueError(f"Custom parameter file does not exist: '{x}'")
 
     if leap_commands is not None:
@@ -981,6 +984,7 @@ def _make_amber_protein_function(name):
         tolerance=1.2,
         max_distance=_Length(6, "A"),
         water_model=None,
+        custom_parameters=None,
         leap_commands=None,
         bonds=None,
         ensure_compatible=True,
@@ -1013,11 +1017,14 @@ def _make_amber_protein_function(name):
             or lone oxygen atoms corresponding to structural (crystal) water
             molecules.
 
+        custom_parameters: [str]
+            A list of paths to custom parameter files. When this option is set,
+            we can no longer fall back on GROMACS's pdb2gmx.
+
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These
-            will be added after any default commands and can be used to, e.g.,
-            load additional parameter files. When this option is set, we can no
-            longer fall back on GROMACS's pdb2gmx.
+            will be added after any default commands. When this option is set,
+            we can no longer fall back on GROMACS's pdb2gmx.
 
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
@@ -1052,6 +1059,7 @@ def _make_amber_protein_function(name):
             tolerance=tolerance,
             max_distance=max_distance,
             water_model=water_model,
+            custom_parameters=custom_parameters,
             leap_commands=leap_commands,
             bonds=bonds,
             ensure_compatible=ensure_compatible,

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -173,8 +173,11 @@ def _parameterise_amber_protein(
         molecules.
 
     custom_parameters: [str]
-        A list of paths to custom parameter files. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+        A list of paths to custom parameter files. These can be user-defined
+        parameter files files that are loaded with loadAmberParams, or the names
+        of additional internal leaprc scripts, which will be sourced, e.g.
+        'leaprc.gaff'. When this option is set, we can no longer fall back on
+        GROMACS's pdb2gmx.
 
     leap_commands : [str]
         An optional list of extra commands for the LEaP program. These
@@ -1018,8 +1021,11 @@ def _make_amber_protein_function(name):
             molecules.
 
         custom_parameters: [str]
-            A list of paths to custom parameter files. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+            A list of paths to custom parameter files. These can be user-defined
+            parameter files files that are loaded with loadAmberParams, or the names
+            of additional internal leaprc scripts, which will be sourced, e.g.
+            'leaprc.gaff'. When this option is set, we can no longer fall back on
+            GROMACS's pdb2gmx.
 
         leap_commands : [str]
             An optional list of extra commands for the LEaP program. These

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -135,8 +135,8 @@ def _parameterise_amber_protein(
     tolerance=1.2,
     max_distance=_Length(6, "A"),
     water_model=None,
-    custom_parameters=None,
-    leap_commands=None,
+    pre_mol_commands=None,
+    post_mol_commands=None,
     bonds=None,
     ensure_compatible=True,
     work_dir=None,
@@ -172,17 +172,17 @@ def _parameterise_amber_protein(
         or lone oxygen atoms corresponding to structural (crystal) water
         molecules.
 
-    custom_parameters: [str]
-        A list of paths to custom parameter files. These can be user-defined
-        parameter files files that are loaded with loadAmberParams, or the names
-        of additional internal leaprc scripts, which will be sourced, e.g.
-        'leaprc.gaff'. When this option is set, we can no longer fall back on
-        GROMACS's pdb2gmx.
+    pre_mol_commands : [str]
+        A list of custom LEaP commands to be executed before loading the molecule.
+        This can be used for loading custom parameter files, or sourcing additional
+        scripts. Make sure to use absolute paths when specifying any external files.
+        When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-    leap_commands : [str]
-        An optional list of extra commands for the LEaP program. These
-        will be added after any default commands. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+    post_mol_commands : [str]
+        A list of custom LEaP commands to be executed after loading the molecule.
+        This allows the use of additional commands that operate on the molecule,
+        which is named "mol". When this option is set, we can no longer fall
+        back on GROMACS's pdb2gmx.
 
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
@@ -244,8 +244,8 @@ def _parameterise_amber_protein(
         max_distance=max_distance,
         water_model=water_model,
         check_ions=True,
-        custom_parameters=custom_parameters,
-        leap_commands=leap_commands,
+        pre_mol_commands=pre_mol_commands,
+        post_mol_commands=post_mol_commands,
         bonds=bonds,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
@@ -258,8 +258,8 @@ def _parameterise_amber_protein(
         tolerance=tolerance,
         water_model=water_model,
         max_distance=max_distance,
-        custom_parameters=custom_parameters,
-        leap_commands=leap_commands,
+        pre_mol_commands=pre_mol_commands,
+        post_mol_commands=post_mol_commands,
         bonds=bonds,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
@@ -805,8 +805,8 @@ def _validate(
     max_distance=None,
     water_model=None,
     check_ions=False,
-    custom_parameters=None,
-    leap_commands=None,
+    pre_mol_commands=None,
+    post_mol_commands=None,
     bonds=None,
     ensure_compatible=True,
     work_dir=None,
@@ -842,14 +842,17 @@ def _validate(
         Whether to check for the presence of structural ions. This is only
         required when parameterising with protein force fields.
 
-    custom_parameters: [str]
-        A list of paths to custom parameter files. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+    pre_mol_commands : [str]
+        A list of custom LEaP commands to be executed before loading the molecule.
+        This can be used for loading custom parameter files, or sourcing additional
+        scripts. Make sure to use absolute paths when specifying any external files.
+        When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-    leap_commands : [str]
-        An optional list of extra commands for the LEaP program. These
-        will be added after any default commands. When this option is set,
-        we can no longer fall back on GROMACS's pdb2gmx.
+    post_mol_commands : [str]
+        A list of custom LEaP commands to be executed after loading the molecule.
+        This allows the use of additional commands that operate on the molecule,
+        which is named "mol". When this option is set, we can no longer fall
+        back on GROMACS's pdb2gmx.
 
     bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
         An optional tuple of atom pairs to specify additional atoms that
@@ -908,25 +911,19 @@ def _validate(
                 "Please choose a 'water_model' for the ion parameters."
             )
 
-    if custom_parameters is not None:
-        import os as _os
-
-        if not isinstance(custom_parameters, (list, tuple)):
-            raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
+    if pre_mol_commands is not None:
+        if not isinstance(pre_mol_commands, (list, tuple)):
+            raise TypeError("'pre_mol_commands' must be a 'list' of 'str' types.")
         else:
-            if not all(isinstance(x, str) for x in custom_parameters):
-                raise TypeError("'custom_parameters' must be a 'list' of 'str' types.")
-            for x in custom_parameters:
-                # Built-in parameter files are named 'leaprc.*' and are handled separately.
-                if not "leaprc" in x and not _os.path.isfile(x):
-                    raise ValueError(f"Custom parameter file does not exist: '{x}'")
+            if not all(isinstance(x, str) for x in pre_mol_commands):
+                raise TypeError("'pre_mol_commands' must be a 'list' of 'str' types.")
 
-    if leap_commands is not None:
-        if not isinstance(leap_commands, (list, tuple)):
-            raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
+    if post_mol_commands is not None:
+        if not isinstance(post_mol_commands, (list, tuple)):
+            raise TypeError("'post_mol_commands' must be a 'list' of 'str' types.")
         else:
-            if not all(isinstance(x, str) for x in leap_commands):
-                raise TypeError("'leap_commands' must be a 'list' of 'str' types.")
+            if not all(isinstance(x, str) for x in post_mol_commands):
+                raise TypeError("'post_mol_commands' must be a 'list' of 'str' types.")
 
     if bonds is not None:
         if molecule is None:
@@ -987,8 +984,8 @@ def _make_amber_protein_function(name):
         tolerance=1.2,
         max_distance=_Length(6, "A"),
         water_model=None,
-        custom_parameters=None,
-        leap_commands=None,
+        pre_mol_commands=None,
+        post_mol_commands=None,
         bonds=None,
         ensure_compatible=True,
         work_dir=None,
@@ -1020,17 +1017,17 @@ def _make_amber_protein_function(name):
             or lone oxygen atoms corresponding to structural (crystal) water
             molecules.
 
-        custom_parameters: [str]
-            A list of paths to custom parameter files. These can be user-defined
-            parameter files files that are loaded with loadAmberParams, or the names
-            of additional internal leaprc scripts, which will be sourced, e.g.
-            'leaprc.gaff'. When this option is set, we can no longer fall back on
-            GROMACS's pdb2gmx.
+        pre_mol_commands : [str]
+            A list of custom LEaP commands to be executed before loading the molecule.
+            This can be used for loading custom parameter files, or sourcing additional
+            scripts. Make sure to use absolute paths when specifying any external files.
+            When this option is set, we can no longer fall back on GROMACS's pdb2gmx.
 
-        leap_commands : [str]
-            An optional list of extra commands for the LEaP program. These
-            will be added after any default commands. When this option is set,
-            we can no longer fall back on GROMACS's pdb2gmx.
+        post_mol_commands : [str]
+            A list of custom LEaP commands to be executed after loading the molecule.
+            This allows the use of additional commands that operate on the molecule,
+            which is named "mol". When this option is set, we can no longer fall
+            back on GROMACS's pdb2gmx.
 
         bonds : ((class:`Atom <BioSimSpace._SireWrappers.Atom>`, class:`Atom <BioSimSpace._SireWrappers.Atom>`))
             An optional tuple of atom pairs to specify additional atoms that
@@ -1065,8 +1062,8 @@ def _make_amber_protein_function(name):
             tolerance=tolerance,
             max_distance=max_distance,
             water_model=water_model,
-            custom_parameters=custom_parameters,
-            leap_commands=leap_commands,
+            pre_mol_commands=pre_mol_commands,
+            post_mol_commands=post_mol_commands,
             bonds=bonds,
             ensure_compatible=ensure_compatible,
             work_dir=work_dir,

--- a/tests/Parameters/test_parameters.py
+++ b/tests/Parameters/test_parameters.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+import tempfile
 
 import BioSimSpace as BSS
 
@@ -77,3 +79,60 @@ def test_molecule_rename():
 
     # Make sure the name is correct.
     assert mol._sire_object.name().value() == "smiles:[C@@H](C(F)(F)F)(OC(F)F)Cl"
+
+
+@pytest.mark.skipif(
+    has_antechamber is False or has_tleap is False,
+    reason="Requires AmberTools/antechamber and tLEaP to be installed.",
+)
+def test_custom_parameters():
+    """
+    Test that custom parameters are correctly inserted into the LEaP input
+    script.
+    """
+
+    # First parameterise a molecule with the GAFF force field.
+    mol = BSS.Parameters.gaff("C").getMolecule()
+
+    # Now try to parameterise with a protein force field, also including the
+    # GAFF parameters and a custom parameter file. Note that we only validate
+    # that the file exists and LEaP won't error if it doesn't contain relevant
+    # parameters.
+
+    # The path to this file.
+    file_path = os.path.realpath(__file__)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # This will fail, but we only care about the LEaP input script.
+        try:
+            mol = BSS.Parameters.ff14SB(
+                mol,
+                work_dir=tmp,
+                custom_parameters=["leaprc.gaff", file_path],
+            ).getMolecule()
+        except:
+            pass
+
+        # Load the script and check that the custom parameters are present and
+        # in the correct order.
+        with open(f"{tmp}/leap.txt", "r") as f:
+            script = f.readlines()
+            line_gaff = 0
+            line_file = 0
+            line_mol = 0
+            for x, line in enumerate(script):
+                line = line.strip()
+                if line == "source leaprc.gaff":
+                    line_gaff = x
+                elif line == f"loadAmberParams {file_path}":
+                    line_file = x
+                elif line == "mol = loadPdb leap.pdb":
+                    line_mol = x
+
+            # Make sure the lines are found.
+            assert line_gaff != 0
+            assert line_file != 0
+            assert line_mol != 0
+
+            # Make sure the lines are in the correct order.
+            assert line_gaff < line_file < line_mol

--- a/tests/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/tests/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import tempfile
 
@@ -90,30 +89,24 @@ def test_molecule_rename():
     has_antechamber is False or has_tleap is False,
     reason="Requires AmberTools/antechamber and tLEaP to be installed.",
 )
-def test_custom_parameters():
+def test_leap_commands(molecule0):
     """
-    Test that custom parameters are correctly inserted into the LEaP input
+    Test that custom commands are correctly inserted into the LEaP input
     script.
     """
 
-    # First parameterise a molecule with the GAFF force field.
-    mol = BSS.Parameters.gaff("C").getMolecule()
-
-    # Now try to parameterise with a protein force field, also including the
-    # GAFF parameters and a custom parameter file. Note that we only validate
-    # that the file exists and LEaP won't error if it doesn't contain relevant
-    # parameters.
-
-    # The path to this file.
-    file_path = os.path.realpath(__file__)
+    # Create lists of pre- and post-commands.
+    pre_mol_commands = ["command1", "command2"]
+    post_mol_commands = ["command3", "command4"]
 
     with tempfile.TemporaryDirectory() as tmp:
-        # This will fail, but we only care about the LEaP input script.
+        # This will fail, but we only want to check the LEaP script.
         try:
             mol = BSS.Parameters.ff14SB(
-                mol,
+                molecule0,
                 work_dir=tmp,
-                custom_parameters=["leaprc.gaff", file_path],
+                pre_mol_commands=pre_mol_commands,
+                post_mol_commands=post_mol_commands,
             ).getMolecule()
         except:
             pass
@@ -122,22 +115,30 @@ def test_custom_parameters():
         # in the correct order.
         with open(f"{tmp}/leap.txt", "r") as f:
             script = f.readlines()
-            line_gaff = 0
-            line_file = 0
-            line_mol = 0
+
+            # Create lists to store the indices of the custom commands.
+            line_pre = [-1 for _ in range(len(pre_mol_commands))]
+            line_post = [-1 for _ in range(len(post_mol_commands))]
+
+            # Loop over the lines in the script and store the line numbers
+            # where the custom commands are found.
             for x, line in enumerate(script):
-                line = line.strip()
-                if line == "source leaprc.gaff":
-                    line_gaff = x
-                elif line == f"loadAmberParams {file_path}":
-                    line_file = x
-                elif line == "mol = loadPdb leap.pdb":
-                    line_mol = x
+                for y, command in enumerate(pre_mol_commands):
+                    if command in line:
+                        line_pre[y] = x
+                for y, command in enumerate(post_mol_commands):
+                    if command in line:
+                        line_post[y] = x
 
             # Make sure the lines are found.
-            assert line_gaff != 0
-            assert line_file != 0
-            assert line_mol != 0
+            for line in line_pre:
+                assert line != -1
+            for line in line_post:
+                assert line != -1
 
             # Make sure the lines are in the correct order.
-            assert line_gaff < line_file < line_mol
+            for x in range(len(line_pre) - 1):
+                assert line_pre[x] < line_pre[x + 1]
+            assert line_pre[-1] < line_post[0]
+            for x in range(len(line_post) - 1):
+                assert line_post[x] < line_post[x + 1]


### PR DESCRIPTION
This PR closes #225, by fixing the `custom_parameters` keyword argument for AMBER protein force fields. This option was added when decoupling from the additional `leap_commands` option, which now allows the user to reference the loaded molecule. Importantly, `custom_parameters` must be placed at the start of the LEaP script, i.e. before the molecule is loaded. The option should be passed as a list of paths to custom parameter files, which will be loaded with `loadAmberParams`, or the names of additional internal `leaprc` files, e.g. `leaprc.gaff`, which will be sourced with `source`. I've added a test that validates that both types of file can be handled and that the output in the `LEaP` script is in the correct order.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@xiki-tempula 