### PR TITLE
Update makeCompatibleWith to use the new AtomCoordMatcher

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -787,9 +787,8 @@ class Molecule(_SireWrapper):
 
             # Have we matched all of the atoms?
             if len(matches) < num_atoms0:
-                # Atom names might have changed. Try to match by residue index
-                # and coordinates.
-                matcher = _SireMol.ResIdxAtomCoordMatcher()
+                # Atom names or order might have changed. Try to match by coordinates.
+                matcher = _SireMol.AtomCoordMatcher()
                 matches = matcher.match(mol0, mol1)
 
                 # We need to rename the atoms.
@@ -989,9 +988,6 @@ class Molecule(_SireWrapper):
             # Tally counter for the total number of matches.
             num_matches = 0
 
-            # Initialise the offset.
-            offset = 0
-
             # Get the molecule numbers in the system.
             mol_nums = mol1.molNums()
 
@@ -1001,15 +997,12 @@ class Molecule(_SireWrapper):
                 mol = mol1[num]
 
                 # Initialise the matcher.
-                matcher = _SireMol.ResIdxAtomCoordMatcher(_SireMol.ResIdx(offset))
+                matcher = _SireMol.AtomCoordMatcher()
 
                 # Get the matches for this molecule and append to the list.
                 match = matcher.match(mol0, mol)
                 matches.append(match)
                 num_matches += len(match)
-
-                # Increment the offset.
-                offset += mol.nResidues()
 
             # Have we matched all of the atoms?
             if num_matches < num_atoms0:

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -743,9 +743,8 @@ class Molecule(_SireWrapper):
 
             # Have we matched all of the atoms?
             if len(matches) < num_atoms0:
-                # Atom names might have changed. Try to match by residue index
-                # and coordinates.
-                matcher = _SireMol.ResIdxAtomCoordMatcher()
+                # Atom names or order might have changed. Try to match by coordinates.
+                matcher = _SireMol.AtomCoordMatcher()
                 matches = matcher.match(mol0, mol1)
 
                 # We need to rename the atoms.
@@ -945,9 +944,6 @@ class Molecule(_SireWrapper):
             # Tally counter for the total number of matches.
             num_matches = 0
 
-            # Initialise the offset.
-            offset = 0
-
             # Get the molecule numbers in the system.
             mol_nums = mol1.molNums()
 
@@ -957,15 +953,12 @@ class Molecule(_SireWrapper):
                 mol = mol1[num]
 
                 # Initialise the matcher.
-                matcher = _SireMol.ResIdxAtomCoordMatcher(_SireMol.ResIdx(offset))
+                matcher = _SireMol.AtomCoordMatcher()
 
                 # Get the matches for this molecule and append to the list.
                 match = matcher.match(mol0, mol)
                 matches.append(match)
                 num_matches += len(match)
-
-                # Increment the offset.
-                offset += mol.nResidues()
 
             # Have we matched all of the atoms?
             if num_matches < num_atoms0:


### PR DESCRIPTION
This PR updates the `makeCompatibleWith` function to use the new `AtomCoordMatcher`, which should hopefully fix issues where `tLEaP` moves a atom between residues. I'd like some time to test this before the next release in case there are some unforeseen consequences of this switch, or edge cases that aren't covered by the existing tests. It might be necessary to use the old match as a starting point, then fall back on this one if it fails.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods

@msuruzhon: Tagging you in since this is relevant to your work.