### PR TITLE
Fix issue #236

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -2060,9 +2060,7 @@ class Relative:
                 extra_lines=self._extra_lines,
                 property_map=self._property_map,
             )
-            if self._setup_only:
-                del first_process
-            else:
+            if not self._setup_only:
                 processes.append(first_process)
 
         # Loop over the rest of the lambda values.
@@ -2139,30 +2137,19 @@ class Relative:
                         f.write(line)
 
                 mdp = new_dir + "/gromacs.mdp"
-                mdp_out = new_dir + "/gromacs.out.mdp"
                 gro = new_dir + "/gromacs.gro"
                 top = new_dir + "/gromacs.top"
                 tpr = new_dir + "/gromacs.tpr"
 
                 # Use grompp to generate the portable binary run input file.
-                command = "%s grompp -f %s -po %s -c %s -p %s -r %s -o %s" % (
-                    _gmx_exe,
+                first_process._generate_binary_run_file(
                     mdp,
-                    mdp_out,
                     gro,
                     top,
-                    gro,
                     tpr,
-                )
-
-                # Run the command. If this worked for the first lambda value,
-                # then it should work for all others.
-                proc = _subprocess.run(
-                    _Utils.command_split(command),
-                    shell=False,
-                    text=True,
-                    stdout=_subprocess.PIPE,
-                    stderr=_subprocess.PIPE,
+                    first_process._exe,
+                    ignore_warnings=self._ignore_warnings,
+                    show_errors=self._show_errors,
                 )
 
                 # Create a copy of the process and update the working

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -2146,6 +2146,7 @@ class Relative:
                     mdp,
                     gro,
                     top,
+                    gro,
                     tpr,
                     first_process._exe,
                     ignore_warnings=self._ignore_warnings,

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -2142,7 +2142,7 @@ class Relative:
                 tpr = new_dir + "/gromacs.tpr"
 
                 # Use grompp to generate the portable binary run input file.
-                first_process._generate_binary_run_file(
+                _Process.Gromacs._generate_binary_run_file(
                     mdp,
                     gro,
                     top,

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -426,6 +426,7 @@ class Gromacs(_process.Process):
         mdp_file,
         gro_file,
         top_file,
+        ref_file,
         tpr_file,
         exe,
         checkpoint_file=None,
@@ -446,6 +447,10 @@ class Gromacs(_process.Process):
 
         top_file : str
             The path to the input topology file.
+
+        ref_file : str
+            The path to the input reference coordinate file to be used for
+            position restraints.
 
         tpr_file : str
             The path to the output binary run file.
@@ -483,6 +488,11 @@ class Gromacs(_process.Process):
         if not _os.path.isfile(top_file):
             raise IOError(f"'top_file' doesn't exist: '{top_file}'")
 
+        if not isinstance(ref_file, str):
+            raise ValueError("'ref_file' must be of type 'str'.")
+        if not _os.path.isfile(ref_file):
+            raise IOError(f"'ref_file' doesn't exist: '{ref_file}'")
+
         if not isinstance(tpr_file, str):
             raise ValueError("'tpr_file' must be of type 'str'.")
 
@@ -517,7 +527,7 @@ class Gromacs(_process.Process):
                 mdp_out,
                 gro_file,
                 top_file,
-                gro_file,
+                ref_file,
                 checkpoint_file,
                 tpr_file,
             )
@@ -528,7 +538,7 @@ class Gromacs(_process.Process):
                 mdp_out,
                 gro_file,
                 top_file,
-                gro_file,
+                ref_file,
                 tpr_file,
             )
 
@@ -614,6 +624,7 @@ class Gromacs(_process.Process):
             self._config_file,
             self._gro_file,
             self._top_file,
+            self._gro_file,
             self._tpr_file,
             self._exe,
             self._checkpoint_file,
@@ -630,6 +641,7 @@ class Gromacs(_process.Process):
             self._config_file,
             self._gro_file,
             self._top_file,
+            self._gro_file,
             self._tpr_file,
             self._exe,
             self._checkpoint_file,
@@ -657,6 +669,7 @@ class Gromacs(_process.Process):
             self._config_file,
             self._gro_file,
             self._top_file,
+            self._gro_file,
             self._tpr_file,
             self._exe,
             self._checkpoint_file,

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -421,40 +421,119 @@ class Gromacs(_process.Process):
         if isinstance(self._protocol, (_Protocol.Metadynamics, _Protocol.Steering)):
             self.setArg("-plumed", "plumed.dat")
 
-    def _generate_binary_run_file(self):
-        """Use grommp to generate the binary run input file."""
+    @staticmethod
+    def _generate_binary_run_file(
+        mdp_file,
+        gro_file,
+        top_file,
+        tpr_file,
+        exe,
+        checkpoint_file=None,
+        ignore_warnings=False,
+        show_errors=True,
+    ):
+        """
+        Use grommp to generate the binary run input file.
+
+        Parameters
+        ----------
+
+        mdp_file : str
+            The path to the input mdp file.
+
+        gro_file : str
+            The path to the input coordinate file.
+
+        top_file : str
+            The path to the input topology file.
+
+        tpr_file : str
+            The path to the output binary run file.
+
+        exe : str
+            The path to the GROMACS executable.
+
+        checkpoint_file : str
+            The path to a checkpoint file from a previous run. This can be used
+            to continue an existing simulation. Currently we only support the
+            use of checkpoint files for Equilibration protocols.
+
+        ignore_warnings : bool
+            Whether to ignore warnings when generating the binary run file
+            with 'gmx grompp'. By default, these warnings are elevated to
+            errors and will halt the program.
+
+        show_errors : bool
+            Whether to show warning/error messages when generating the binary
+            run file.
+        """
+
+        if not isinstance(mdp_file, str):
+            raise ValueError("'mdp_file' must be of type 'str'.")
+        if not _os.path.isfile(mdp_file):
+            raise IOError(f"'mdp_file' doesn't exist: '{mdp_file}'")
+
+        if not isinstance(gro_file, str):
+            raise ValueError("'gro_file' must be of type 'str'.")
+        if not _os.path.isfile(gro_file):
+            raise IOError(f"'gro_file' doesn't exist: '{gro_file}'")
+
+        if not isinstance(top_file, str):
+            raise ValueError("'top_file' must be of type 'str'.")
+        if not _os.path.isfile(top_file):
+            raise IOError(f"'top_file' doesn't exist: '{top_file}'")
+
+        if not isinstance(tpr_file, str):
+            raise ValueError("'tpr_file' must be of type 'str'.")
+
+        if not isinstance(exe, str):
+            raise ValueError("'exe' must be of type 'str'.")
+        if not _os.path.isfile(exe):
+            raise IOError(f"'exe' doesn't exist: '{exe}'")
+
+        if checkpoint_file is not None:
+            if not isinstance(checkpoint_file, str):
+                raise ValueError("'checkpoint_file' must be of type 'str'.")
+            if not _os.path.isfile(checkpoint_file):
+                raise IOError(f"'checkpoint_file' doesn't exist: '{checkpoint_file}'")
+
+        if not isinstance(ignore_warnings, bool):
+            raise ValueError("'ignore_warnings' must be of type 'bool'")
+
+        if not isinstance(show_errors, bool):
+            raise ValueError("'show_errors' must be of type 'bool'")
 
         # Create the name of the output mdp file.
         mdp_out = (
-            _os.path.dirname(self._config_file)
-            + "/%s.out.mdp" % _os.path.basename(self._config_file).split(".")[0]
+            _os.path.dirname(mdp_file)
+            + "/%s.out.mdp" % _os.path.basename(mdp_file).split(".")[0]
         )
 
         # Use grompp to generate the portable binary run input file.
-        if self._checkpoint_file is not None:
+        if checkpoint_file is not None:
             command = "%s grompp -f %s -po %s -c %s -p %s -r %s -t %s -o %s" % (
-                self._exe,
-                self._config_file,
+                exe,
+                mdp_file,
                 mdp_out,
-                self._gro_file,
-                self._top_file,
-                self._gro_file,
-                self._checkpoint_file,
-                self._tpr_file,
+                gro_file,
+                top_file,
+                gro_file,
+                checkpoint_file,
+                tpr_file,
             )
         else:
             command = "%s grompp -f %s -po %s -c %s -p %s -r %s -o %s" % (
-                self._exe,
-                self._config_file,
+                exe,
+                mdp_file,
                 mdp_out,
-                self._gro_file,
-                self._top_file,
-                self._gro_file,
-                self._tpr_file,
+                gro_file,
+                top_file,
+                gro_file,
+                tpr_file,
             )
 
         # Warnings don't trigger an error.
-        if self._ignore_warnings:
+        if ignore_warnings:
             command += " --maxwarn 9999"
 
         # Run the command.
@@ -469,7 +548,7 @@ class Gromacs(_process.Process):
         # Check that grompp ran successfully.
         if proc.returncode != 0:
             # Handle errors and warnings.
-            if self._show_errors:
+            if show_errors:
                 # Capture errors and warnings from the grompp output.
                 errors = []
                 warnings = []
@@ -531,14 +610,32 @@ class Gromacs(_process.Process):
         super().addToConfig(config)
 
         # Use grompp to generate the portable binary run input file.
-        self._generate_binary_run_file()
+        self._generate_binary_run_file(
+            self._config_file,
+            self._gro_file,
+            self._top_file,
+            self._tpr_file,
+            self._exe,
+            self._checkpoint_file,
+            self._ignore_warnings,
+            self._show_errors,
+        )
 
     def resetConfig(self):
         """Reset the configuration parameters."""
         self._generate_config()
 
         # Use grompp to generate the portable binary run input file.
-        self._generate_binary_run_file()
+        self._generate_binary_run_file(
+            self._config_file,
+            self._gro_file,
+            self._top_file,
+            self._tpr_file,
+            self._exe,
+            self._checkpoint_file,
+            self._ignore_warnings,
+            self._show_errors,
+        )
 
     def setConfig(self, config):
         """
@@ -556,7 +653,16 @@ class Gromacs(_process.Process):
         super().setConfig(config)
 
         # Use grompp to generate the portable binary run input file.
-        self._generate_binary_run_file()
+        self._generate_binary_run_file(
+            self._config_file,
+            self._gro_file,
+            self._top_file,
+            self._tpr_file,
+            self._exe,
+            self._checkpoint_file,
+            self._ignore_warnings,
+            self._show_errors,
+        )
 
     def start(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
@@ -1467,7 +1467,7 @@ class AlchemicalFreeEnergy:
                 tpr = new_dir + "/gromacs.tpr"
 
                 # Use grompp to generate the portable binary run input file.
-                first_process._generate_binary_run_file(
+                _Process.Gromacs._generate_binary_run_file(
                     mdp,
                     gro,
                     top,

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
@@ -1471,6 +1471,7 @@ class AlchemicalFreeEnergy:
                     mdp,
                     gro,
                     top,
+                    gro,
                     tpr,
                     first_process._exe,
                     ignore_warnings=self._ignore_warnings,

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
@@ -1373,7 +1373,7 @@ class AlchemicalFreeEnergy:
                 extra_lines=self._extra_lines,
             )
 
-        if self._setup_only:
+        if self._setup_only and not self._engine == "GROMACS":
             del first_process
         else:
             processes.append(first_process)
@@ -1462,30 +1462,19 @@ class AlchemicalFreeEnergy:
                         f.write(line)
 
                 mdp = new_dir + "/gromacs.mdp"
-                mdp_out = new_dir + "/gromacs.out.mdp"
                 gro = new_dir + "/gromacs.gro"
                 top = new_dir + "/gromacs.top"
                 tpr = new_dir + "/gromacs.tpr"
 
                 # Use grompp to generate the portable binary run input file.
-                command = "%s grompp -f %s -po %s -c %s -p %s -r %s -o %s" % (
-                    self._exe,
+                first_process._generate_binary_run_file(
                     mdp,
-                    mdp_out,
                     gro,
                     top,
-                    gro,
                     tpr,
-                )
-
-                # Run the command. If this worked for the first lambda value,
-                # then it should work for all others.
-                proc = _subprocess.run(
-                    _Utils.command_split(command),
-                    shell=False,
-                    text=True,
-                    stdout=_subprocess.PIPE,
-                    stderr=_subprocess.PIPE,
+                    first_process._exe,
+                    ignore_warnings=self._ignore_warnings,
+                    show_errors=self._show_errors,
                 )
 
                 # Create a copy of the process and update the working

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -517,6 +517,7 @@ class Gromacs(_process.Process):
         mdp_file,
         gro_file,
         top_file,
+        ref_file,
         tpr_file,
         exe,
         checkpoint_file=None,
@@ -537,6 +538,10 @@ class Gromacs(_process.Process):
 
         top_file : str
             The path to the input topology file.
+
+        ref_file : str
+            The path to the input reference coordinate file to be used for
+            position restraints.
 
         tpr_file : str
             The path to the output binary run file.
@@ -574,6 +579,11 @@ class Gromacs(_process.Process):
         if not _os.path.isfile(top_file):
             raise IOError(f"'top_file' doesn't exist: '{top_file}'")
 
+        if not isinstance(ref_file, str):
+            raise ValueError("'ref_file' must be of type 'str'.")
+        if not _os.path.isfile(ref_file):
+            raise IOError(f"'ref_file' doesn't exist: '{ref_file}'")
+
         if not isinstance(tpr_file, str):
             raise ValueError("'tpr_file' must be of type 'str'.")
 
@@ -608,7 +618,7 @@ class Gromacs(_process.Process):
                 mdp_out,
                 gro_file,
                 top_file,
-                gro_file,
+                ref_file,
                 checkpoint_file,
                 tpr_file,
             )
@@ -619,7 +629,7 @@ class Gromacs(_process.Process):
                 mdp_out,
                 gro_file,
                 top_file,
-                gro_file,
+                ref_file,
                 tpr_file,
             )
 
@@ -705,6 +715,7 @@ class Gromacs(_process.Process):
             self._config_file,
             self._gro_file,
             self._top_file,
+            self._ref_file,
             self._tpr_file,
             self._exe,
             checkpoint_file=self._checkpoint_file,
@@ -721,6 +732,7 @@ class Gromacs(_process.Process):
             self._config_file,
             self._gro_file,
             self._top_file,
+            self._ref_file,
             self._tpr_file,
             self._exe,
             checkpoint_file=self._checkpoint_file,
@@ -748,6 +760,7 @@ class Gromacs(_process.Process):
             self._config_file,
             self._gro_file,
             self._top_file,
+            self._ref_file,
             self._tpr_file,
             self._exe,
             checkpoint_file=self._checkpoint_file,

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -512,40 +512,119 @@ class Gromacs(_process.Process):
         if isinstance(self._protocol, (_Protocol.Metadynamics, _Protocol.Steering)):
             self.setArg("-plumed", "plumed.dat")
 
-    def _generate_binary_run_file(self):
-        """Use grommp to generate the binary run input file."""
+    @staticmethod
+    def _generate_binary_run_file(
+        mdp_file,
+        gro_file,
+        top_file,
+        tpr_file,
+        exe,
+        checkpoint_file=None,
+        ignore_warnings=False,
+        show_errors=True,
+    ):
+        """
+        Use grommp to generate the binary run input file.
+
+        Parameters
+        ----------
+
+        mdp_file : str
+            The path to the input mdp file.
+
+        gro_file : str
+            The path to the input coordinate file.
+
+        top_file : str
+            The path to the input topology file.
+
+        tpr_file : str
+            The path to the output binary run file.
+
+        exe : str
+            The path to the GROMACS executable.
+
+        checkpoint_file : str
+            The path to a checkpoint file from a previous run. This can be used
+            to continue an existing simulation. Currently we only support the
+            use of checkpoint files for Equilibration protocols.
+
+        ignore_warnings : bool
+            Whether to ignore warnings when generating the binary run file
+            with 'gmx grompp'. By default, these warnings are elevated to
+            errors and will halt the program.
+
+        show_errors : bool
+            Whether to show warning/error messages when generating the binary
+            run file.
+        """
+
+        if not isinstance(mdp_file, str):
+            raise ValueError("'mdp_file' must be of type 'str'.")
+        if not _os.path.isfile(mdp_file):
+            raise IOError(f"'mdp_file' doesn't exist: '{mdp_file}'")
+
+        if not isinstance(gro_file, str):
+            raise ValueError("'gro_file' must be of type 'str'.")
+        if not _os.path.isfile(gro_file):
+            raise IOError(f"'gro_file' doesn't exist: '{gro_file}'")
+
+        if not isinstance(top_file, str):
+            raise ValueError("'top_file' must be of type 'str'.")
+        if not _os.path.isfile(top_file):
+            raise IOError(f"'top_file' doesn't exist: '{top_file}'")
+
+        if not isinstance(tpr_file, str):
+            raise ValueError("'tpr_file' must be of type 'str'.")
+
+        if not isinstance(exe, str):
+            raise ValueError("'exe' must be of type 'str'.")
+        if not _os.path.isfile(exe):
+            raise IOError(f"'exe' doesn't exist: '{exe}'")
+
+        if checkpoint_file is not None:
+            if not isinstance(checkpoint_file, str):
+                raise ValueError("'checkpoint_file' must be of type 'str'.")
+            if not _os.path.isfile(checkpoint_file):
+                raise IOError(f"'checkpoint_file' doesn't exist: '{checkpoint_file}'")
+
+        if not isinstance(ignore_warnings, bool):
+            raise ValueError("'ignore_warnings' must be of type 'bool'")
+
+        if not isinstance(show_errors, bool):
+            raise ValueError("'show_errors' must be of type 'bool'")
 
         # Create the name of the output mdp file.
         mdp_out = (
-            _os.path.dirname(self._config_file)
-            + "/%s.out.mdp" % _os.path.basename(self._config_file).split(".")[0]
+            _os.path.dirname(mdp_file)
+            + "/%s.out.mdp" % _os.path.basename(mdp_file).split(".")[0]
         )
 
         # Use grompp to generate the portable binary run input file.
-        if self._checkpoint_file is not None:
+        if checkpoint_file is not None:
             command = "%s grompp -f %s -po %s -c %s -p %s -r %s -t %s -o %s" % (
-                self._exe,
-                self._config_file,
+                exe,
+                mdp_file,
                 mdp_out,
-                self._gro_file,
-                self._top_file,
-                self._ref_file,
-                self._checkpoint_file,
-                self._tpr_file,
+                gro_file,
+                top_file,
+                gro_file,
+                checkpoint_file,
+                tpr_file,
             )
         else:
             command = "%s grompp -f %s -po %s -c %s -p %s -r %s -o %s" % (
-                self._exe,
-                self._config_file,
+                exe,
+                mdp_file,
                 mdp_out,
-                self._gro_file,
-                self._top_file,
-                self._ref_file,
-                self._tpr_file,
+                gro_file,
+                top_file,
+                gro_file,
+                tpr_file,
             )
 
-        # Warnings don't trigger an error. Set to a suitably large number.
-        if self._ignore_warnings:
+        # Warnings don't trigger an error.
+        if ignore_warnings:
             command += " --maxwarn 9999"
 
         # Run the command.
@@ -560,7 +639,7 @@ class Gromacs(_process.Process):
         # Check that grompp ran successfully.
         if proc.returncode != 0:
             # Handle errors and warnings.
-            if self._show_errors:
+            if show_errors:
                 # Capture errors and warnings from the grompp output.
                 errors = []
                 warnings = []
@@ -622,14 +701,32 @@ class Gromacs(_process.Process):
         super().addToConfig(config)
 
         # Use grompp to generate the portable binary run input file.
-        self._generate_binary_run_file()
+        self._generate_binary_run_file(
+            self._config_file,
+            self._gro_file,
+            self._top_file,
+            self._tpr_file,
+            self._exe,
+            checkpoint_file=self._checkpoint_file,
+            ignore_warnings=self._ignore_warnings,
+            show_errors=self._show_errors,
+        )
 
     def resetConfig(self):
         """Reset the configuration parameters."""
         self._generate_config()
 
         # Use grompp to generate the portable binary run input file.
-        self._generate_binary_run_file()
+        self._generate_binary_run_file(
+            self._config_file,
+            self._gro_file,
+            self._top_file,
+            self._tpr_file,
+            self._exe,
+            checkpoint_file=self._checkpoint_file,
+            ignore_warnings=self._ignore_warnings,
+            show_errors=self._show_errors,
+        )
 
     def setConfig(self, config):
         """
@@ -647,7 +744,16 @@ class Gromacs(_process.Process):
         super().setConfig(config)
 
         # Use grompp to generate the portable binary run input file.
-        self._generate_binary_run_file()
+        self._generate_binary_run_file(
+            self._config_file,
+            self._gro_file,
+            self._top_file,
+            self._tpr_file,
+            self._exe,
+            checkpoint_file=self._checkpoint_file,
+            ignore_warnings=self._ignore_warnings,
+            show_errors=self._show_errors,
+        )
 
     def start(self):
         """

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -27,8 +27,8 @@ test:
     - SIRE_SILENT_PHONEHOME
   requires:
     - pytest
-    - black 23      # [linux and x86_64 and py==39]
-    - pytest-black  # [linux and x86_64 and py==39]
+    - black 23      # [linux and x86_64 and py==311]
+    - pytest-black  # [linux and x86_64 and py==311]
     - ambertools    # [linux and x86_64]
     - gromacs       # [linux and x86_64]
   imports:

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -26,7 +26,7 @@ test:
     - SIRE_DONT_PHONEHOME
     - SIRE_SILENT_PHONEHOME
   requires:
-    - pytest
+    - pytest <8
     - black 23      # [linux and x86_64 and py==311]
     - pytest-black  # [linux and x86_64 and py==311]
     - ambertools    # [linux and x86_64]

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -34,7 +34,7 @@ test:
   imports:
     - BioSimSpace
   source_files:
-    - python/BioSimSpace # [linux and x86_64 and py==39]
+    - python/BioSimSpace # [linux and x86_64 and py==311]
     - tests
   commands:
     - pytest -vvv --color=yes --black python/BioSimSpace # [linux and x86_64 and py==311]

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -37,7 +37,7 @@ test:
     - python/BioSimSpace # [linux and x86_64 and py==39]
     - tests
   commands:
-    - pytest -vvv --color=yes --black python/BioSimSpace # [linux and x86_64 and py==39]
+    - pytest -vvv --color=yes --black python/BioSimSpace # [linux and x86_64 and py==311]
     - pytest -vvv --color=yes --import-mode=importlib tests
 
 about:


### PR DESCRIPTION
This PR closes #236 and closes OpenBioSim/biosimspace_tutorials#23. This is achieved by making the `_generate_binary_run_file` method static, so that it can be called externally, e.g. during the `BioSimSpace.FreeEnergy.Relative` setup process. This is tested via the existing BioSimSpace tests, as well as the tutorial notebook for which the original issue was posted.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
