### PR TITLE
Fix issues #241, #242, and #243

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -566,7 +566,7 @@ def readMolecules(
         prop = property_map.get("time", "time")
         time = system.property(prop)
         system.removeSharedProperty(prop)
-        system.setProperties(prop, time)
+        system.setProperty(prop, time)
     except:
         pass
 
@@ -1147,6 +1147,24 @@ def readPerturbableSystem(top0, coords0, top1, coords1, property_map={}):
 
     # Update the molecule in the original system.
     system0.updateMolecules(mol)
+
+    # Remove "space" and "time" shared properties since this causes incorrect
+    # behaviour when extracting molecules and recombining them to make other
+    # systems.
+    try:
+        # Space.
+        prop = property_map.get("space", "space")
+        space = system0._sire_object.property(prop)
+        system0._sire_object.removeSharedProperty(prop)
+        system0._sire_object.setProperty(prop, space)
+
+        # Time.
+        prop = property_map.get("time", "time")
+        time = system0._sire_object.property(prop)
+        system0._sire_object.removeSharedProperty(prop)
+        system0._sire_object.setProperty(prop, time)
+    except:
+        pass
 
     return system0
 

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -37,7 +37,6 @@ from ..._Utils import _try_import, _have_imported
 
 import os as _os
 
-_parmed = _try_import("parmed")
 import queue as _queue
 import subprocess as _subprocess
 
@@ -188,10 +187,6 @@ class OpenForceField(_protocol.Protocol):
             is_smiles = True
         else:
             is_smiles = False
-
-        # The following is adapted from the Open Force Field examples, where an
-        # OpenFF system is converted to AMBER format files using ParmEd:
-        # https://github.com/openforcefield/openff-toolkit/blob/master/examples/using_smirnoff_in_amber_or_gromacs/convert_to_amber_gromacs.ipynb
 
         if is_smiles:
             # Convert SMILES string to an OpenFF molecule.
@@ -353,7 +348,7 @@ class OpenForceField(_protocol.Protocol):
             if par_mol.nMolecules() == 1:
                 par_mol = par_mol.getMolecules()[0]
         except Exception as e:
-            msg = "Failed to read molecule from: 'parmed.prmtop', 'parmed.inpcrd'"
+            msg = "Failed to read molecule from: 'interchange.prmtop', 'interchange.inpcrd'"
             if _isVerbose():
                 msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e

--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -46,6 +46,7 @@ from .. import _amber_home, _isVerbose
 from .._Config import Amber as _AmberConfig
 from .._Exceptions import IncompatibleError as _IncompatibleError
 from .._Exceptions import MissingSoftwareError as _MissingSoftwareError
+from ..Protocol._free_energy_mixin import _FreeEnergyMixin
 from ..Protocol._position_restraint_mixin import _PositionRestraintMixin
 from .._SireWrappers import System as _System
 from ..Types._type import Type as _Type
@@ -126,7 +127,7 @@ class Amber(_process.Process):
         )
 
         # Catch unsupported protocols.
-        if isinstance(protocol, _Protocol.FreeEnergy):
+        if isinstance(protocol, _FreeEnergyMixin):
             raise _IncompatibleError(
                 "Unsupported protocol: '%s'" % self._protocol.__class__.__name__
             )

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -52,6 +52,7 @@ from .. import _gmx_exe, _gmx_version
 from .. import _isVerbose
 from .._Config import Gromacs as _GromacsConfig
 from .._Exceptions import MissingSoftwareError as _MissingSoftwareError
+from ..Protocol._free_energy_mixin import _FreeEnergyMixin
 from ..Protocol._position_restraint_mixin import _PositionRestraintMixin
 from .._SireWrappers import System as _System
 from ..Types._type import Type as _Type
@@ -232,7 +233,7 @@ class Gromacs(_process.Process):
         # Create a copy of the system.
         system = self._system.copy()
 
-        if isinstance(self._protocol, _Protocol.FreeEnergy):
+        if isinstance(self._protocol, _FreeEnergyMixin):
             # Check that the system contains a perturbable molecule.
             if self._system.nPerturbableMolecules() == 0:
                 raise ValueError(

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -2545,10 +2545,15 @@ class Gromacs(_process.Process):
                 space_prop in old_system._sire_object.propertyKeys()
                 and space_prop in new_system._sire_object.propertyKeys()
             ):
-                box = new_system._sire_object.property("space")
-                old_system._sire_object.setProperty(
-                    self._property_map.get("space", "space"), box
-                )
+                # Get the original space.
+                box = old_system._sire_object.property("space")
+
+                # Only update the box if the space is periodic.
+                if box.isPeriodic():
+                    box = new_system._sire_object.property("space")
+                    old_system._sire_object.setProperty(
+                        self._property_map.get("space", "space"), box
+                    )
 
             # If this is a vacuum simulation, then translate the centre of mass
             # of the system back to the origin.
@@ -2656,11 +2661,16 @@ class Gromacs(_process.Process):
                     space_prop in old_system._sire_object.propertyKeys()
                     and space_prop in new_system._sire_object.propertyKeys()
                 ):
-                    box = new_system._sire_object.property("space")
+                    # Get the original space.
+                    box = old_system._sire_object.property("space")
+
+                    # Only update the box if the space is periodic.
                     if box.isPeriodic():
-                        old_system._sire_object.setProperty(
-                            self._property_map.get("space", "space"), box
-                        )
+                        box = new_system._sire_object.property("space")
+                        if box.isPeriodic():
+                            old_system._sire_object.setProperty(
+                                self._property_map.get("space", "space"), box
+                            )
 
                 # If this is a vacuum simulation, then translate the centre of mass
                 # of the system back to the origin.

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -566,7 +566,7 @@ def readMolecules(
         prop = property_map.get("time", "time")
         time = system.property(prop)
         system.removeSharedProperty(prop)
-        system.setProperties(prop, time)
+        system.setProperty(prop, time)
     except:
         pass
 
@@ -1147,6 +1147,24 @@ def readPerturbableSystem(top0, coords0, top1, coords1, property_map={}):
 
     # Update the molecule in the original system.
     system0.updateMolecules(mol)
+
+    # Remove "space" and "time" shared properties since this causes incorrect
+    # behaviour when extracting molecules and recombining them to make other
+    # systems.
+    try:
+        # Space.
+        prop = property_map.get("space", "space")
+        space = system0._sire_object.property(prop)
+        system0._sire_object.removeSharedProperty(prop)
+        system0._sire_object.setProperty(prop, space)
+
+        # Time.
+        prop = property_map.get("time", "time")
+        time = system0._sire_object.property(prop)
+        system0._sire_object.removeSharedProperty(prop)
+        system0._sire_object.setPropery(prop, time)
+    except:
+        pass
 
     return system0
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -37,7 +37,6 @@ from ..._Utils import _try_import, _have_imported
 
 import os as _os
 
-_parmed = _try_import("parmed")
 import queue as _queue
 import subprocess as _subprocess
 
@@ -188,10 +187,6 @@ class OpenForceField(_protocol.Protocol):
             is_smiles = True
         else:
             is_smiles = False
-
-        # The following is adapted from the Open Force Field examples, where an
-        # OpenFF system is converted to AMBER format files using ParmEd:
-        # https://github.com/openforcefield/openff-toolkit/blob/master/examples/using_smirnoff_in_amber_or_gromacs/convert_to_amber_gromacs.ipynb
 
         if is_smiles:
             # Convert SMILES string to an OpenFF molecule.
@@ -353,7 +348,7 @@ class OpenForceField(_protocol.Protocol):
             if par_mol.nMolecules() == 1:
                 par_mol = par_mol.getMolecules()[0]
         except Exception as e:
-            msg = "Failed to read molecule from: 'parmed.prmtop', 'parmed.inpcrd'"
+            msg = "Failed to read molecule from: 'interchange.prmtop', 'interchange.inpcrd'"
             if _isVerbose():
                 msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2638,10 +2638,15 @@ class Gromacs(_process.Process):
                 space_prop in old_system._sire_object.propertyKeys()
                 and space_prop in new_system._sire_object.propertyKeys()
             ):
-                box = new_system._sire_object.property("space")
-                old_system._sire_object.setProperty(
-                    self._property_map.get("space", "space"), box
-                )
+                # Get the original space.
+                box = old_system._sire_object.property("space")
+
+                # Only update the box if the space is periodic.
+                if box.isPeriodic():
+                    box = new_system._sire_object.property("space")
+                    old_system._sire_object.setProperty(
+                        self._property_map.get("space", "space"), box
+                    )
 
             # If this is a vacuum simulation, then translate the centre of mass
             # of the system back to the origin.
@@ -2749,11 +2754,16 @@ class Gromacs(_process.Process):
                     space_prop in old_system._sire_object.propertyKeys()
                     and space_prop in new_system._sire_object.propertyKeys()
                 ):
-                    box = new_system._sire_object.property("space")
+                    # Get the original space.
+                    box = old_system._sire_object.property("space")
+
+                    # Only update the box if the space is periodic.
                     if box.isPeriodic():
-                        old_system._sire_object.setProperty(
-                            self._property_map.get("space", "space"), box
-                        )
+                        box = new_system._sire_object.property("space")
+                        if box.isPeriodic():
+                            old_system._sire_object.setProperty(
+                                self._property_map.get("space", "space"), box
+                            )
 
                 # If this is a vacuum simulation, then translate the centre of mass
                 # of the system back to the origin.


### PR DESCRIPTION
This PR...

closes #241
    This removes shared properties when loading a perturbable system from file. This is needed to avoid issues when combining molecules together to form new systems. I've also added some extra logic into the GROMACS process code to check for a periodic system when updating the space property. For vacuum simulations we use a "fake" infinite box (as recommended by GROMACS) and I don't want to copy this property back if the original system contained an infinite cartesian space, which is now the default in Sire. Note that there was a typo in the existing code for `readMolecules`, which didn't cause any issues in practice since the property isn't used internally.

closes #242
    This updates the error message to use the correct file names and removes the now redundant `parmed` import.

closes #243
    This exposes the `FreeEnergyMixin` protocols, allowing GROMACS to run any existing protocol and intermediate lambda values, not just the end states. (This will be also be exposed for AMBER when ready.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods