### PR TITLE
Fix issues #240 and #246

### DIFF
--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
@@ -592,7 +592,7 @@ class Funnel(_CollectiveVariable):
         volume = _Volume(_math.pi * result, "nanometers cubed")
 
         # Estimate the average area of the restraint (in Angstrom squared).
-        area = (volume / proj_max).angstroms2()
+        area = (volume / (proj_max - proj_min)).angstroms2()
 
         # Compute the correction. (1/1660 A-3 is the standard concentration.)
         correction = _Energy(_math.log((area / 1660).value()), "kt")

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -329,8 +329,8 @@ class OpenForceField(_protocol.Protocol):
 
         # Export AMBER format files.
         try:
-            interchange.to_prmtop(prefix + "interchange.prmtop")
-            interchange.to_inpcrd(prefix + "interchange.inpcrd")
+            interchange.to_prmtop(prefix + "interchange.prm7")
+            interchange.to_inpcrd(prefix + "interchange.rst7")
         except Exception as e:
             msg = "Unable to write Interchange object to AMBER format!"
             if _isVerbose():
@@ -342,13 +342,13 @@ class OpenForceField(_protocol.Protocol):
         # Load the parameterised molecule. (This could be a system of molecules.)
         try:
             par_mol = _IO.readMolecules(
-                [prefix + "interchange.prmtop", prefix + "interchange.inpcrd"]
+                [prefix + "interchange.prm7", prefix + "interchange.rst7"]
             )
             # Extract single molecules.
             if par_mol.nMolecules() == 1:
                 par_mol = par_mol.getMolecules()[0]
         except Exception as e:
-            msg = "Failed to read molecule from: 'interchange.prmtop', 'interchange.inpcrd'"
+            msg = "Failed to read molecule from: 'interchange.prm7', 'interchange.rst7'"
             if _isVerbose():
                 msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
@@ -592,7 +592,7 @@ class Funnel(_CollectiveVariable):
         volume = _Volume(_math.pi * result, "nanometers cubed")
 
         # Estimate the average area of the restraint (in Angstrom squared).
-        area = (volume / proj_max).angstroms2()
+        area = (volume / (proj_max - proj_min)).angstroms2()
 
         # Compute the correction. (1/1660 A-3 is the standard concentration.)
         correction = _Energy(_math.log((area / 1660).value()), "kt")

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -329,8 +329,8 @@ class OpenForceField(_protocol.Protocol):
 
         # Export AMBER format files.
         try:
-            interchange.to_prmtop(prefix + "interchange.prmtop")
-            interchange.to_inpcrd(prefix + "interchange.inpcrd")
+            interchange.to_prmtop(prefix + "interchange.prm7")
+            interchange.to_inpcrd(prefix + "interchange.rst7")
         except Exception as e:
             msg = "Unable to write Interchange object to AMBER format!"
             if _isVerbose():
@@ -342,13 +342,13 @@ class OpenForceField(_protocol.Protocol):
         # Load the parameterised molecule. (This could be a system of molecules.)
         try:
             par_mol = _IO.readMolecules(
-                [prefix + "interchange.prmtop", prefix + "interchange.inpcrd"]
+                [prefix + "interchange.prm7", prefix + "interchange.rst7"]
             )
             # Extract single molecules.
             if par_mol.nMolecules() == 1:
                 par_mol = par_mol.getMolecules()[0]
         except Exception as e:
-            msg = "Failed to read molecule from: 'interchange.prmtop', 'interchange.inpcrd'"
+            msg = "Failed to read molecule from: 'interchange.prm7', 'interchange.rst7'"
             if _isVerbose():
                 msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -80,13 +80,16 @@ class Molecule(_SireWrapper):
         if isinstance(molecule, _SireMol._Mol.Molecule):
             super().__init__(molecule)
             if self._sire_object.hasProperty("is_perturbable"):
-                self._convertFromMergedMolecule()
+                # Flag that the molecule is perturbable.
+                self._is_perturbable = True
+
+                # Extract the end states.
                 if molecule.hasProperty("molecule0"):
-                    self._molecule = Molecule(molecule.property("molecule0"))
+                    self._molecule0 = Molecule(molecule.property("molecule0"))
                 else:
                     self._molecule0, _ = self._extractMolecule()
                 if molecule.hasProperty("molecule1"):
-                    self._molecule = Molecule(molecule.property("molecule1"))
+                    self._molecule1 = Molecule(molecule.property("molecule1"))
                 else:
                     self._molecule1, _ = self._extractMolecule(is_lambda1=True)
 
@@ -1564,25 +1567,6 @@ class Molecule(_SireWrapper):
                     property_map[prop[:-1]] = prop
 
         return property_map
-
-    def _convertFromMergedMolecule(self):
-        """Convert from a merged molecule."""
-
-        # Extract the components of the merged molecule.
-        try:
-            mol0 = self._sire_object.property("molecule0")
-            mol1 = self._sire_object.property("molecule1")
-        except:
-            raise _IncompatibleError(
-                "The merged molecule doesn't have the required properties!"
-            )
-
-        # Store the components.
-        self._molecule0 = Molecule(mol0)
-        self._molecule1 = Molecule(mol1)
-
-        # Flag that the molecule is perturbable.
-        self._is_perturbable = True
 
     def _fixCharge(self, property_map={}):
         """

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -80,13 +80,16 @@ class Molecule(_SireWrapper):
         if isinstance(molecule, _SireMol._Mol.Molecule):
             super().__init__(molecule)
             if self._sire_object.hasProperty("is_perturbable"):
-                self._convertFromMergedMolecule()
+                # Flag that the molecule is perturbable.
+                self._is_perturbable = True
+
+                # Extract the end states.
                 if molecule.hasProperty("molecule0"):
-                    self._molecule = Molecule(molecule.property("molecule0"))
+                    self._molecule0 = Molecule(molecule.property("molecule0"))
                 else:
                     self._molecule0, _ = self._extractMolecule()
                 if molecule.hasProperty("molecule1"):
-                    self._molecule = Molecule(molecule.property("molecule1"))
+                    self._molecule1 = Molecule(molecule.property("molecule1"))
                 else:
                     self._molecule1, _ = self._extractMolecule(is_lambda1=True)
 
@@ -1520,25 +1523,6 @@ class Molecule(_SireWrapper):
                     property_map[prop[:-1]] = prop
 
         return property_map
-
-    def _convertFromMergedMolecule(self):
-        """Convert from a merged molecule."""
-
-        # Extract the components of the merged molecule.
-        try:
-            mol0 = self._sire_object.property("molecule0")
-            mol1 = self._sire_object.property("molecule1")
-        except:
-            raise _IncompatibleError(
-                "The merged molecule doesn't have the required properties!"
-            )
-
-        # Store the components.
-        self._molecule0 = Molecule(mol0)
-        self._molecule1 = Molecule(mol1)
-
-        # Flag that the molecule is perturbable.
-        self._is_perturbable = True
 
     def _fixCharge(self, property_map={}):
         """


### PR DESCRIPTION
This PR...

closes #240 by using the default Sire extensions for the interchange prmtop and inpcrd files. In particular, this ensures that the coordinate file isn't accidentally detected as an SDF file.

closes #246 by fixing the range of the funnel axis used in the calculation of the correction term.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
