### PR TITLE
Improve error mesage when attempting to extract all dummy selection.

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -1807,7 +1807,11 @@ class Molecule(_SireWrapper):
         try:
             search_result = mol.search(query, property_map)
         except:
-            search_result = []
+            msg = "All atoms in the selection are dummies. Unable to extract."
+            if _isVerbose():
+                raise _IncompatibleError(msg) from e
+            else:
+                raise _IncompatibleError(msg) from None
 
         # If there are no dummies, then simply return this molecule.
         if len(search_result) == mol.nAtoms():

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1739,7 +1739,11 @@ class Molecule(_SireWrapper):
         try:
             search_result = mol.search(query, property_map)
         except:
-            search_result = []
+            msg = "All atoms in the selection are dummies. Unable to extract."
+            if _isVerbose():
+                raise _IncompatibleError(msg) from e
+            else:
+                raise _IncompatibleError(msg) from None
 
         # If there are no dummies, then simply return this molecule.
         if len(search_result) == mol.nAtoms():


### PR DESCRIPTION
This PR closes #250 by catching a failing search for non dummy atoms in the molecule prior to extraction. Previously this was converted to an empty list, which failed at the point we attempted to extract the empty selection from the molecule.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods