### PR TITLE
Avoid setting all end-state properties when decoupling

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_decouple.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_decouple.py
@@ -76,7 +76,7 @@ def decouple(
             if not isinstance(value, bool):
                 raise ValueError(f"{value} in {name} must be bool.")
 
-    # Change names of charge and LJ tuples to avoid clashes with properties
+    # Change names of charge and LJ tuples to avoid clashes with properties.
     charge_tuple = charge
     LJ_tuple = LJ
 
@@ -86,7 +86,7 @@ def decouple(
     # Invert the user property mappings.
     inv_property_map = {v: k for k, v in property_map.items()}
 
-    # Create a copy of this molecule and Sire object to check properties
+    # Create a copy of this molecule and Sire object to check properties.
     mol = _Molecule(molecule)
     mol_sire = mol._sire_object
 
@@ -97,7 +97,7 @@ def decouple(
     element = inv_property_map.get("element", "element")
     ambertype = inv_property_map.get("ambertype", "ambertype")
 
-    # Check for missing information
+    # Check for missing information.
     if not mol_sire.hasProperty(ff):
         raise _IncompatibleError("Cannot determine 'forcefield' of 'molecule'!")
     if not mol_sire.hasProperty(LJ):
@@ -107,7 +107,7 @@ def decouple(
     if not mol_sire.hasProperty(element):
         raise _IncompatibleError("Cannot determine elements in molecule")
 
-    # Check for ambertype property (optional)
+    # Check for ambertype property (optional).
     has_ambertype = True
     if not mol_sire.hasProperty(ambertype):
         has_ambertype = False
@@ -115,10 +115,10 @@ def decouple(
     if not isinstance(intramol, bool):
         raise TypeError("'intramol' must be of type 'bool'")
 
-    # Edit the molecule
+    # Edit the molecule.
     mol_edit = mol_sire.edit()
 
-    # Create dictionary to store charge and LJ tuples
+    # Create dictionary to store charge and LJ tuples.
     mol_edit.setProperty(
         "decouple", {"charge": charge_tuple, "LJ": LJ_tuple, "intramol": intramol}
     )
@@ -126,34 +126,12 @@ def decouple(
     # Set the "forcefield0" property.
     mol_edit.setProperty("forcefield0", molecule._sire_object.property(ff))
 
-    # Set starting properties based on fully-interacting molecule
+    # Set starting properties based on fully-interacting molecule.
     mol_edit.setProperty("charge0", molecule._sire_object.property(charge))
     mol_edit.setProperty("LJ0", molecule._sire_object.property(LJ))
     mol_edit.setProperty("element0", molecule._sire_object.property(element))
     if has_ambertype:
         mol_edit.setProperty("ambertype0", molecule._sire_object.property(ambertype))
-
-    # Set final charges and LJ terms to 0, elements to "X" and (if required) ambertypes to du
-    for atom in mol_sire.atoms():
-        mol_edit = (
-            mol_edit.atom(atom.index())
-            .setProperty("charge1", 0 * _SireUnits.e_charge)
-            .molecule()
-        )
-        mol_edit = (
-            mol_edit.atom(atom.index())
-            .setProperty("LJ1", _SireMM.LJParameter())
-            .molecule()
-        )
-        mol_edit = (
-            mol_edit.atom(atom.index())
-            .setProperty("element1", _SireMol.Element(0))
-            .molecule()
-        )
-        if has_ambertype:
-            mol_edit = (
-                mol_edit.atom(atom.index()).setProperty("ambertype1", "du").molecule()
-            )
 
     mol_edit.setProperty("annihilated", _SireBase.wrap(intramol))
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -26,9 +26,9 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["Somd"]
 
-from .._Utils import _try_import
-
 import os as _os
+
+from .._Utils import _try_import
 
 _pygtail = _try_import("pygtail")
 import glob as _glob
@@ -38,24 +38,21 @@ import sys as _sys
 import timeit as _timeit
 import warnings as _warnings
 
-from sire.legacy import Base as _SireBase
 from sire.legacy import CAS as _SireCAS
 from sire.legacy import IO as _SireIO
 from sire.legacy import MM as _SireMM
+from sire.legacy import Base as _SireBase
 from sire.legacy import Mol as _SireMol
 from sire.legacy import Units as _SireUnits
-
-from .. import _isVerbose
-from .._Exceptions import IncompatibleError as _IncompatibleError
-from .._Exceptions import MissingSoftwareError as _MissingSoftwareError
-from .._SireWrappers import Molecule as _Molecule
-from .._SireWrappers import System as _System
 
 from .. import IO as _IO
 from .. import Protocol as _Protocol
 from .. import Trajectory as _Trajectory
-from .. import _Utils
-
+from .. import _isVerbose, _Utils
+from .._Exceptions import IncompatibleError as _IncompatibleError
+from .._Exceptions import MissingSoftwareError as _MissingSoftwareError
+from .._SireWrappers import Molecule as _Molecule
+from .._SireWrappers import System as _System
 from . import _process
 
 
@@ -1034,7 +1031,6 @@ def _to_pert_file(
     # If the molecule is decoupled (for an ABFE calculation), then we need to
     # set the end-state properties of the molecule.
     if molecule.isDecoupled():
-
         # Invert the user property mappings.
         inv_property_map = {v: k for k, v in property_map.items()}
 

--- a/tests/Sandpit/Exscientia/Align/test_decouple.py
+++ b/tests/Sandpit/Exscientia/Align/test_decouple.py
@@ -81,8 +81,11 @@ def test_topology(mol, tmp_path):
 
 
 def test_end_types(mol):
-    """Check that the correct properties have been set at either
-    end of the perturbation."""
+    """
+    Check that the correct properties have been set for the 0
+    end of the perturbation. Note that for SOMD, the 1 end state
+    properties are set in Process.Somd._to_pert_file.
+    """
 
     decoupled_mol = decouple(mol)
     assert decoupled_mol._sire_object.property("charge0") == mol._sire_object.property(
@@ -95,8 +98,3 @@ def test_end_types(mol):
     assert decoupled_mol._sire_object.property(
         "ambertype0"
     ) == mol._sire_object.property("ambertype")
-    for atom in decoupled_mol._sire_object.atoms():
-        assert atom.property("charge1") == 0 * _SireUnits.e_charge
-        assert atom.property("LJ1") == _SireMM.LJParameter()
-        assert atom.property("element1") == _SireMol.Element(0)
-        assert atom.property("ambertype1") == "du"


### PR DESCRIPTION
This closes https://github.com/OpenBioSim/biosimspace/issues/252. BSS.Align.decouple() no longer sets LJ1, element1, or ambertype1, rather this is done by the _to_pert_file method of Process.Somd. The related tests of "decouple" have been removed, and direct tests on the SOMD pert files have been added.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges, @xiki-tempula 

