### PR TITLE
Only convert to end state if this isn't a FreeEnergy protocol.

### DIFF
--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -1995,8 +1995,10 @@ class Gromacs(_process.Process):
             # Create a copy of the system.
             system = self._system.copy()
 
-            # Convert to the lambda = 0 state if this is a perturbable system.
-            system = self._checkPerturbable(system)
+            # Convert to the lambda = 0 state if this is a perturbable system and this
+            # isn't a free energy protocol.
+            if not isinstance(self._protocol, _FreeEnergyMixin):
+                system = self._checkPerturbable(system)
 
             # Convert the water model topology so that it matches the GROMACS naming convention.
             system._set_water_topology("GROMACS")

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2099,8 +2099,10 @@ class Gromacs(_process.Process):
             # Create a copy of the system.
             system = self._system.copy()
 
-            # Convert to the lambda = 0 state if this is a perturbable system.
-            system = self._checkPerturbable(system)
+            # Convert to the lambda = 0 state if this is a perturbable system and this
+            # isn't a free energy protocol.
+            if not isinstance(self._protocol, _Protocol._FreeEnergyMixin):
+                system = self._checkPerturbable(system)
 
             # Convert the water model topology so that it matches the GROMACS naming convention.
             system._set_water_topology("GROMACS")


### PR DESCRIPTION
This PR closes #256 by checking for a `FreeEnergy` protocol before extracting an end state prior to writing the modified topology file when position restraints are used.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods 
