### PR TITLE
Fix issues #258 and #259

### DIFF
--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -1995,8 +1995,10 @@ class Gromacs(_process.Process):
             # Create a copy of the system.
             system = self._system.copy()
 
-            # Convert to the lambda = 0 state if this is a perturbable system.
-            system = self._checkPerturbable(system)
+            # Convert to the lambda = 0 state if this is a perturbable system and this
+            # isn't a free energy protocol.
+            if not isinstance(self._protocol, _FreeEnergyMixin):
+                system = self._checkPerturbable(system)
 
             # Convert the water model topology so that it matches the GROMACS naming convention.
             system._set_water_topology("GROMACS")

--- a/python/BioSimSpace/Protocol/_position_restraint_mixin.py
+++ b/python/BioSimSpace/Protocol/_position_restraint_mixin.py
@@ -214,7 +214,7 @@ class _PositionRestraintMixin:
                 )
 
             # Validate the dimensions.
-            if force_constant.dimensions() != (0, 0, 0, 1, -1, 0, -2):
+            if force_constant.dimensions() != (1, 0, -2, 0, 0, -1, 0):
                 raise ValueError(
                     "'force_constant' has invalid dimensions! "
                     f"Expected dimensions are 'M Q-1 T-2', found '{force_constant.unit()}'"

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
@@ -290,13 +290,13 @@ class Restraint:
                             "'BioSimSpace.Types.Length'"
                         )
                 if not single_restraint_dict["kr"].dimensions() == (
-                    0,
-                    0,
-                    0,
                     1,
-                    -1,
                     0,
                     -2,
+                    0,
+                    0,
+                    -1,
+                    0,
                 ):
                     raise ValueError(
                         "distance_restraint_dict['kr'] must be of type "

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
@@ -174,7 +174,7 @@ class Restraint:
             for key in ["kthetaA", "kthetaB", "kphiA", "kphiB", "kphiC"]:
                 if restraint_dict["force_constants"][key] != 0:
                     dim = restraint_dict["force_constants"][key].dimensions()
-                    if dim != (-2, 0, 2, 1, -1, 0, -2):
+                    if dim != (1, 2, -2, 0, 0, -1, -2):
                         raise ValueError(
                             f"restraint_dict['force_constants']['{key}'] must be of type "
                             f"'BioSimSpace.Types.Energy'/'BioSimSpace.Types.Angle^2'"
@@ -202,7 +202,7 @@ class Restraint:
             # Test if the force constant of the bond r1-l1 is the correct unit
             # Such as kcal/mol/angstrom^2
             dim = restraint_dict["force_constants"]["kr"].dimensions()
-            if dim != (0, 0, 0, 1, -1, 0, -2):
+            if dim != (1, 0, -2, 0, 0, -1, 0):
                 raise ValueError(
                     "restraint_dict['force_constants']['kr'] must be of type "
                     "'BioSimSpace.Types.Energy'/'BioSimSpace.Types.Length^2'"

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -641,7 +641,7 @@ class RestraintSearch:
 
         if force_constant:
             dim = force_constant.dimensions()
-            if dim != (0, 0, 0, 1, -1, 0, -2):
+            if dim != (1, 0, -2, 0, 0, -1, 0):
                 raise ValueError(
                     "force_constant must be of type "
                     "'BioSimSpace.Types.Energy'/'BioSimSpace.Types.Length^2'"

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2099,8 +2099,10 @@ class Gromacs(_process.Process):
             # Create a copy of the system.
             system = self._system.copy()
 
-            # Convert to the lambda = 0 state if this is a perturbable system.
-            system = self._checkPerturbable(system)
+            # Convert to the lambda = 0 state if this is a perturbable system and this
+            # isn't a free energy protocol.
+            if not isinstance(self._protocol, _Protocol._FreeEnergyMixin):
+                system = self._checkPerturbable(system)
 
             # Convert the water model topology so that it matches the GROMACS naming convention.
             system._set_water_topology("GROMACS")

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -293,9 +293,9 @@ class ConfigFactory:
                                     ]
                                 restraint_mask = "@" + ",".join(restraint_atom_names)
                             elif restraint == "heavy":
-                                restraint_mask = "!:WAT & !@H="
+                                restraint_mask = "!:WAT & !@%NA,CL & !@H="
                             elif restraint == "all":
-                                restraint_mask = "!:WAT"
+                                restraint_mask = "!:WAT & !@%NA,CL"
 
                         # We can't do anything about a custom restraint, since we don't
                         # know anything about the atoms.

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_position_restraint.py
@@ -185,7 +185,7 @@ class _PositionRestraintMixin:
                 )
 
             # Validate the dimensions.
-            if force_constant.dimensions() != (0, 0, 0, 1, -1, 0, -2):
+            if force_constant.dimensions() != (1, 0, -2, 0, 0, -1, 0):
                 raise ValueError(
                     "'force_constant' has invalid dimensions! "
                     f"Expected dimensions are 'M Q-1 T-2', found '{force_constant.unit()}'"

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_angle.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_angle.py
@@ -187,7 +187,8 @@ class Angle(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -209,13 +210,13 @@ class Angle(_Type):
         unit = unit.replace("AD", "")
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_angle.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_angle.py
@@ -52,9 +52,8 @@ class Angle(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "RADIAN"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (1, 0, 0, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_area.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_area.py
@@ -329,7 +329,8 @@ class Area(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit is supported."""
 
         # Strip whitespace and convert to upper case.
@@ -359,13 +360,13 @@ class Area(_Type):
             unit = unit[0:index] + unit[index + 1 :] + "2"
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_area.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_area.py
@@ -72,9 +72,8 @@ class Area(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ANGSTROM2"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 2, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_charge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_charge.py
@@ -58,9 +58,8 @@ class Charge(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ELECTRON CHARGE"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 1, 0, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_charge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_charge.py
@@ -181,7 +181,8 @@ class Charge(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -212,11 +213,11 @@ class Charge(_Type):
         unit = unit.replace("COUL", "C")
 
         # Check that the unit is supported.
-        if unit in self._abbreviations:
-            return self._abbreviations[unit]
+        if unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_energy.py
@@ -68,9 +68,8 @@ class Energy(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "KILO CALORIES PER MOL"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 2, 1, -1, 0, -2)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_energy.py
@@ -212,7 +212,8 @@ class Energy(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -234,11 +235,11 @@ class Energy(_Type):
         unit = unit.replace("JOULES", "J")
 
         # Check that the unit is supported.
-        if unit in self._abbreviations:
-            return self._abbreviations[unit]
+        if unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -440,49 +440,39 @@ class GeneralUnit(_Type):
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
 
-        is_inverse = False
-        offset = 0
+        import math
+        import decimal
 
-        if isinstance(other, float):
-            if other > 1:
-                if not other.is_integer():
-                    raise ValueError("float exponent must be integer valued.")
-            else:
-                is_inverse = True
-                other = 1 / other
-                if not other.is_integer():
-                    raise ValueError(
-                        "Divisor in fractional exponent must be integer valued."
-                    )
-                other = int(other)
+        # Convert to a decimal representation.
+        d = decimal.Decimal(f"{other:.2f}")
+        numerator, denominator = d.as_integer_ratio()
 
-        if other == 0:
+        if numerator == 0:
             return GeneralUnit(self._sire_unit / self._sire_unit)
 
-        # Get the current unit dimemsions.
-        dims = self._sire_unit.dimensions()
+        # Get the existing unit dimensions.
+        dims = self.dimensions()
 
-        # Check that the exponent is a factor of all the unit dimensions.
-        if is_inverse:
-            for dim in dims:
-                if dim % other != 0:
-                    raise ValueError(
-                        "The divisor of the exponent must be a factor of all the unit dimensions."
-                    )
+        # First raise to the power of the numerator.
+        new_dims = [int(dim * numerator) for dim in dims]
 
-        if is_inverse:
-            new_dims = [int(dim / other) for dim in dims]
-        else:
-            new_dims = [int(dim * other) for dim in dims]
+        # Compute the new value.
+        value = self.value() ** other
 
-        if is_inverse:
-            value = self.value() ** (1 / other)
-        else:
-            value = self.value() ** other
+        if denominator != 1:
+            # Now check that the denominator is a factor of all the unit dimensions, within
+            # the accuracy of the decimal representation.
+            for dim in new_dims:
+                if dim % denominator != 0:
+                    small = min(dim, denominator)
+                    big = max(dim, denominator)
+                    if small / big < 0.99:
+                        raise ValueError(
+                            "The exponent must be a factor of all the unit dimensions."
+                        )
 
-        # Invert the value.
-        if other < 0 and not is_inverse:
-            value = 1 / value
+            # Divide the dimensions by the denominator.
+            new_dims = [math.ceil(dim / denominator) for dim in new_dims]
 
         # Return a new GeneralUnit object.
         return GeneralUnit(_GeneralUnit(value, new_dims))

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -261,11 +261,21 @@ class GeneralUnit(_Type):
             temp = self._from_string(other)
             return self + temp
 
+        # Addition of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
+
         else:
             raise TypeError(
                 "unsupported operand type(s) for +: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __radd__(self, other):
+        """Addition operator."""
+
+        # Addition is commutative: a+b = b+a
+        return self.__add__(other)
 
     def __sub__(self, other):
         """Subtraction operator."""
@@ -275,16 +285,26 @@ class GeneralUnit(_Type):
             temp = self._sire_unit - other._to_sire_unit()
             return GeneralUnit(temp)
 
-        # Addition of a string.
+        # Subtraction of a string.
         elif isinstance(other, str):
             temp = self._from_string(other)
             return self - temp
+
+        # Subtraction of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
 
         else:
             raise TypeError(
                 "unsupported operand type(s) for -: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __rsub__(self, other):
+        """Subtraction operator."""
+
+        # Subtraction is not commutative: a-b != b-a
+        return -self.__sub__(other)
 
     def __mul__(self, other):
         """Multiplication operator."""

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -38,16 +38,16 @@ class GeneralUnit(_Type):
     """A general unit type."""
 
     _dimension_chars = [
-        "A",  # Angle
-        "C",  # Charge
-        "L",  # Length
         "M",  # Mass
-        "Q",  # Quantity
+        "L",  # Length
+        "T",  # Time
+        "C",  # Charge
         "t",  # Temperature
-        "T",  # Tme
+        "Q",  # Quantity
+        "A",  # Angle
     ]
 
-    def __new__(cls, *args):
+    def __new__(cls, *args, no_cast=False):
         """
         Constructor.
 
@@ -65,6 +65,9 @@ class GeneralUnit(_Type):
 
         string : str
             A string representation of the unit type.
+
+        no_cast: bool
+            Whether to disable casting to a specific type.
         """
 
         # This operator may be called when unpickling an object. Catch empty
@@ -96,7 +99,7 @@ class GeneralUnit(_Type):
             if isinstance(_args[0], _GeneralUnit):
                 general_unit = _args[0]
 
-            # The user has passed a string representation of the temperature.
+            # The user has passed a string representation of the type.
             elif isinstance(_args[0], str):
                 # Extract the string.
                 string = _args[0]
@@ -128,15 +131,7 @@ class GeneralUnit(_Type):
         general_unit = value * general_unit
 
         # Store the dimension mask.
-        dimensions = (
-            general_unit.ANGLE(),
-            general_unit.CHARGE(),
-            general_unit.LENGTH(),
-            general_unit.MASS(),
-            general_unit.QUANTITY(),
-            general_unit.TEMPERATURE(),
-            general_unit.TIME(),
-        )
+        dimensions = tuple(general_unit.dimensions())
 
         # This is a dimensionless quantity, return the value as a float.
         if all(x == 0 for x in dimensions):
@@ -144,13 +139,13 @@ class GeneralUnit(_Type):
 
         # Check to see if the dimensions correspond to a supported type.
         # If so, return an object of that type.
-        if dimensions in _base_dimensions:
+        if not no_cast and dimensions in _base_dimensions:
             return _base_dimensions[dimensions](general_unit)
         # Otherwise, call __init__()
         else:
             return super(GeneralUnit, cls).__new__(cls)
 
-    def __init__(self, *args):
+    def __init__(self, *args, no_cast=False):
         """
         Constructor.
 
@@ -168,6 +163,9 @@ class GeneralUnit(_Type):
 
         string : str
             A string representation of the unit type.
+
+        no_cast: bool
+            Whether to disable casting to a specific type.
         """
 
         value = 1
@@ -194,7 +192,7 @@ class GeneralUnit(_Type):
             if isinstance(_args[0], _GeneralUnit):
                 general_unit = _args[0]
 
-            # The user has passed a string representation of the temperature.
+            # The user has passed a string representation of the type.
             elif isinstance(_args[0], str):
                 # Extract the string.
                 string = _args[0]
@@ -222,15 +220,7 @@ class GeneralUnit(_Type):
         self._value = self._sire_unit.value()
 
         # Store the dimension mask.
-        self._dimensions = (
-            general_unit.ANGLE(),
-            general_unit.CHARGE(),
-            general_unit.LENGTH(),
-            general_unit.MASS(),
-            general_unit.QUANTITY(),
-            general_unit.TEMPERATURE(),
-            general_unit.TIME(),
-        )
+        self._dimensions = tuple(general_unit.dimensions())
 
         # Create the unit string.
         self._unit = ""
@@ -312,16 +302,8 @@ class GeneralUnit(_Type):
             # Multipy the Sire unit objects.
             temp = self._sire_unit * other._to_sire_unit()
 
-            # Create the dimension mask.
-            dimensions = (
-                temp.ANGLE(),
-                temp.CHARGE(),
-                temp.LENGTH(),
-                temp.MASS(),
-                temp.QUANTITY(),
-                temp.TEMPERATURE(),
-                temp.TIME(),
-            )
+            # Get the dimension mask.
+            dimensions = temp.dimensions()
 
             # Return as an existing type if the dimensions match.
             try:
@@ -432,24 +414,58 @@ class GeneralUnit(_Type):
     def __pow__(self, other):
         """Power operator."""
 
-        if type(other) is not int:
+        if not isinstance(other, (int, float)):
             raise TypeError(
                 "unsupported operand type(s) for ^: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
 
+        is_inverse = False
+        offset = 0
+
+        if isinstance(other, float):
+            if other > 1:
+                if not other.is_integer():
+                    raise ValueError("float exponent must be integer valued.")
+            else:
+                is_inverse = True
+                other = 1 / other
+                if not other.is_integer():
+                    raise ValueError(
+                        "Divisor in fractional exponent must be integer valued."
+                    )
+                other = int(other)
+
         if other == 0:
             return GeneralUnit(self._sire_unit / self._sire_unit)
 
-        # Multiply the Sire GeneralUnit 'other' times.
-        temp = self._sire_unit
-        for x in range(0, abs(other) - 1):
-            temp = temp * self._sire_unit
+        # Get the current unit dimemsions.
+        dims = self._sire_unit.dimensions()
 
-        if other > 0:
-            return GeneralUnit(temp)
+        # Check that the exponent is a factor of all the unit dimensions.
+        if is_inverse:
+            for dim in dims:
+                if dim % other != 0:
+                    raise ValueError(
+                        "The divisor of the exponent must be a factor of all the unit dimensions."
+                    )
+
+        if is_inverse:
+            new_dims = [int(dim / other) for dim in dims]
         else:
-            return GeneralUnit(1 / temp)
+            new_dims = [int(dim * other) for dim in dims]
+
+        if is_inverse:
+            value = self.value() ** (1 / other)
+        else:
+            value = self.value() ** other
+
+        # Invert the value.
+        if other < 0 and not is_inverse:
+            value = 1 / value
+
+        # Return a new GeneralUnit object.
+        return GeneralUnit(_GeneralUnit(value, new_dims))
 
     def __lt__(self, other):
         """Less than operator."""
@@ -606,29 +622,17 @@ class GeneralUnit(_Type):
         """
         return self._dimensions
 
-    def angle(self):
+    def mass(self):
         """
-        Return the power of this general unit in the 'angle' dimension.
+        Return the power of this general unit in the 'mass' dimension.
 
         Returns
         -------
 
-        angle : int
-            The power of the general unit in the 'angle' dimension.
+        mass : int
+            The power of the general unit in the 'mass' dimension.
         """
         return self._dimensions[0]
-
-    def charge(self):
-        """
-        Return the power of this general unit in the 'charge' dimension.
-
-        Returns
-        -------
-
-        charge : int
-            The power of the general unit in the 'charge' dimension.
-        """
-        return self._dimensions[1]
 
     def length(self):
         """
@@ -640,31 +644,31 @@ class GeneralUnit(_Type):
         length : int
             The power of the general unit in the 'length' dimension.
         """
+        return self._dimensions[1]
+
+    def time(self):
+        """
+        Return the power of this general unit in the 'time' dimension.
+
+        Returns
+        -------
+
+        time : int
+            The power of the general unit in the 'time' dimension.
+        """
         return self._dimensions[2]
 
-    def mass(self):
+    def charge(self):
         """
-        Return the power of this general unit in the 'mass' dimension.
+        Return the power of this general unit in the 'charge' dimension.
 
         Returns
         -------
 
-        mass : int
-            The power of the general unit in the 'mass' dimension.
+        charge : int
+            The power of the general unit in the 'charge' dimension.
         """
         return self._dimensions[3]
-
-    def quantity(self):
-        """
-        Return the power of this general unit in the 'quantity' dimension.
-
-        Returns
-        -------
-
-        quantity : int
-            The power of the general unit in the 'quantity' dimension.
-        """
-        return self._dimensions[4]
 
     def temperature(self):
         """
@@ -676,17 +680,29 @@ class GeneralUnit(_Type):
         temperature : int
             The power of the general unit in the 'temperature' dimension.
         """
-        return self._dimensions[5]
+        return self._dimensions[4]
 
-    def time(self):
+    def quantity(self):
         """
-        Return the power of this general unit in the 'time' dimension.
+        Return the power of this general unit in the 'quantity' dimension.
 
         Returns
         -------
 
-        time : int
-            The power of the general unit in the 'time' dimension.
+        quantity : int
+            The power of the general unit in the 'quantity' dimension.
+        """
+        return self._dimensions[5]
+
+    def angle(self):
+        """
+        Return the power of this general unit in the 'angle' dimension.
+
+        Returns
+        -------
+
+        angle : int
+            The power of the general unit in the 'angle' dimension.
         """
         return self._dimensions[6]
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_length.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_length.py
@@ -338,7 +338,8 @@ class Length(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -352,13 +353,13 @@ class Length(_Type):
             unit = "ANGS" + unit[3:]
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_length.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_length.py
@@ -87,9 +87,8 @@ class Length(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ANGSTROM"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 1, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """
@@ -194,29 +193,6 @@ class Length(_Type):
 
         # Multiplication is commutative: a*b = b*a
         return self.__mul__(other)
-
-    def __pow__(self, other):
-        """Power operator."""
-
-        if not isinstance(other, int):
-            raise ValueError("We can only raise to the power of integer values.")
-
-        # No change.
-        if other == 1:
-            return self
-
-        # Area.
-        if other == 2:
-            mag = self.angstroms().value() ** 2
-            return _Area(mag, "A2")
-
-        # Volume.
-        if other == 3:
-            mag = self.angstroms().value() ** 3
-            return _Volume(mag, "A3")
-
-        else:
-            return super().__pow__(other)
 
     def meters(self):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_pressure.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_pressure.py
@@ -176,7 +176,8 @@ class Pressure(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -195,11 +196,11 @@ class Pressure(_Type):
         unit = unit.replace("S", "")
 
         # Check that the unit is supported.
-        if unit in self._abbreviations:
-            return self._abbreviations[unit]
+        if unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_pressure.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_pressure.py
@@ -55,9 +55,8 @@ class Pressure(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ATMOSPHERE"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, -1, 1, 0, 0, -2)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_temperature.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_temperature.py
@@ -391,7 +391,8 @@ class Temperature(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -404,16 +405,16 @@ class Temperature(_Type):
         unit = unit.replace("DEG", "")
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         elif len(unit) == 0:
             raise ValueError(f"Unit is not given. You must supply the unit.")
         else:
             raise ValueError(
                 "Unsupported unit '%s'. Supported units are: '%s'"
-                % (unit, list(self._supported_units.keys()))
+                % (unit, list(cls._supported_units.keys()))
             )
 
     def _to_sire_unit(self):

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_temperature.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_temperature.py
@@ -60,9 +60,8 @@ class Temperature(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "KELVIN"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 0, 0, 0, 1, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """
@@ -409,9 +408,12 @@ class Temperature(_Type):
             return unit
         elif unit in self._abbreviations:
             return self._abbreviations[unit]
+        elif len(unit) == 0:
+            raise ValueError(f"Unit is not given. You must supply the unit.")
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Unsupported unit '%s'. Supported units are: '%s'"
+                % (unit, list(self._supported_units.keys()))
             )
 
     def _to_sire_unit(self):
@@ -441,13 +443,13 @@ class Temperature(_Type):
         if isinstance(sire_unit, _SireUnits.GeneralUnit):
             # Create a mask for the dimensions of the object.
             dimensions = (
-                sire_unit.ANGLE(),
-                sire_unit.CHARGE(),
-                sire_unit.LENGTH(),
                 sire_unit.MASS(),
-                sire_unit.QUANTITY(),
-                sire_unit.TEMPERATURE(),
+                sire_unit.LENGTH(),
                 sire_unit.TIME(),
+                sire_unit.CHARGE(),
+                sire_unit.TEMPERATURE(),
+                sire_unit.QUANTITY(),
+                sire_unit.ANGLE(),
             )
 
             # Make sure the dimensions match.
@@ -470,7 +472,7 @@ class Temperature(_Type):
         else:
             raise TypeError(
                 "'sire_unit' must be of type 'sire.units.GeneralUnit', "
-                "'Sire.Units.Celsius', or 'sire.units.Fahrenheit'"
+                "'sire.units.Celsius', or 'sire.units.Fahrenheit'"
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_time.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_time.py
@@ -96,9 +96,8 @@ class Time(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "NANOSECOND"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 0, 0, 0, 0, 1)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_time.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_time.py
@@ -336,24 +336,25 @@ class Time(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
         unit = unit.replace(" ", "").upper()
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit[:-1] in self._supported_units:
+        elif unit[:-1] in cls._supported_units:
             return unit[:-1]
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
-        elif unit[:-1] in self._abbreviations:
-            return self._abbreviations[unit[:-1]]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
+        elif unit[:-1] in cls._abbreviations:
+            return cls._abbreviations[unit[:-1]]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
@@ -168,11 +168,21 @@ class Type:
             temp = self._from_string(other)
             return self + temp
 
+        # Addition of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
+
         else:
             raise TypeError(
                 "unsupported operand type(s) for +: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __radd__(self, other):
+        """Addition operator."""
+
+        # Addition is commutative: a+b = b+a
+        return self.__add__(other)
 
     def __sub__(self, other):
         """Subtraction operator."""
@@ -185,21 +195,31 @@ class Type:
             # Return a new object of the same type with the original unit.
             return self._to_default_unit(val)._convert_to(self._unit)
 
-        # Addition of a different type with the same dimensions.
+        # Subtraction of a different type with the same dimensions.
         elif isinstance(other, Type) and self._dimensions == other.dimensions:
             # Negate other and add.
             return -other + self
 
-        # Addition of a string.
+        # Subtraction of a string.
         elif isinstance(other, str):
             temp = self._from_string(other)
             return self - temp
+
+        # Subtraction of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
 
         else:
             raise TypeError(
                 "unsupported operand type(s) for -: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __rsub__(self, other):
+        """Subtraction operator."""
+
+        # Subtraction is not commutative: a-b != b-a
+        return -self.__sub__(other)
 
     def __mul__(self, other):
         """Multiplication operator."""

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
@@ -103,7 +103,7 @@ class Type:
                 self._value = temp._value
                 self._unit = temp._unit
 
-            # The user has passed a string representation of the temperature.
+            # The user has passed a string representation of the type.
             elif isinstance(args[0], str):
                 # Convert the string to an object of this type.
                 obj = self._from_string(args[0])
@@ -244,19 +244,9 @@ class Type:
     def __pow__(self, other):
         """Power operator."""
 
-        if not isinstance(other, int):
-            raise ValueError("We can only raise to the power of integer values.")
-
         from ._general_unit import GeneralUnit as _GeneralUnit
 
-        default_unit = self._to_default_unit()
-        mag = default_unit.value() ** other
-        unit = default_unit.unit().lower()
-        pow_to_mul = "*".join(abs(other) * [unit])
-        if other > 0:
-            return _GeneralUnit(f"{mag}*{pow_to_mul}")
-        else:
-            return _GeneralUnit(f"{mag}/({pow_to_mul})")
+        return _GeneralUnit(self._to_sire_unit(), no_cast=True) ** other
 
     def __truediv__(self, other):
         """Division operator."""
@@ -486,49 +476,10 @@ class Type:
         containing the power in each dimension.
 
         Returns : (int, int, int, int, int, int)
-            The power in each dimension: 'angle', 'charge', 'length',
-            'mass', 'quantity', 'temperature', and 'time'.
+            The power in each dimension: 'mass', 'length', 'temperature',
+            'charge', 'time', 'quantity', and 'angle'.
         """
         return cls._dimensions
-
-    @classmethod
-    def angle(cls):
-        """
-        Return the power in the 'angle' dimension.
-
-        Returns
-        -------
-
-        angle : int
-            The power in the 'angle' dimension.
-        """
-        return cls._dimensions[0]
-
-    @classmethod
-    def charge(cls):
-        """
-        Return the power in the 'charge' dimension.
-
-        Returns
-        -------
-
-        charge : int
-            The power in the 'charge' dimension.
-        """
-        return cls._dimensions[1]
-
-    @classmethod
-    def length(cls):
-        """
-        Return the power in the 'length' dimension.
-
-        Returns
-        -------
-
-        length : int
-            The power in the 'length' dimension.
-        """
-        return cls._dimensions[2]
 
     @classmethod
     def mass(cls):
@@ -541,20 +492,46 @@ class Type:
         mass : int
             The power in the 'mass' dimension.
         """
-        return cls._dimensions[3]
+        return cls._dimensions[0]
 
     @classmethod
-    def quantity(cls):
+    def length(cls):
         """
-        Return the power in the 'quantity' dimension.
+        Return the power in the 'length' dimension.
 
         Returns
         -------
 
-        quantity : int
-            The power in the 'quantity' dimension.
+        length : int
+            The power in the 'length' dimension.
         """
-        return cls._dimensions[4]
+        return cls._dimensions[1]
+
+    @classmethod
+    def time(cls):
+        """
+        Return the power in the 'time' dimension.
+
+        Returns
+        -------
+
+        time : int
+            The power the 'time' dimension.
+        """
+        return cls._dimensions[2]
+
+    @classmethod
+    def charge(cls):
+        """
+        Return the power in the 'charge' dimension.
+
+        Returns
+        -------
+
+        charge : int
+            The power in the 'charge' dimension.
+        """
+        return cls._dimensions[3]
 
     @classmethod
     def temperature(cls):
@@ -567,18 +544,31 @@ class Type:
         temperature : int
             The power in the 'temperature' dimension.
         """
-        return cls._dimensions[5]
+        return cls._dimensions[4]
 
     @classmethod
-    def time(cls):
+    def quantity(cls):
         """
-        Return the power in the 'time' dimension.
+        Return the power in the 'quantity' dimension.
 
         Returns
         -------
 
-        time : int
-            The power the 'time' dimension.
+        quantity : int
+            The power in the 'quantity' dimension.
+        """
+        return cls._dimensions[5]
+
+    @classmethod
+    def angle(cls):
+        """
+        Return the power in the 'angle' dimension.
+
+        Returns
+        -------
+
+        angle : int
+            The power in the 'angle' dimension.
         """
         return cls._dimensions[6]
 
@@ -662,15 +652,7 @@ class Type:
             raise TypeError("'sire_unit' must be of type 'sire.units.GeneralUnit'")
 
         # Create a mask for the dimensions of the object.
-        dimensions = (
-            sire_unit.ANGLE(),
-            sire_unit.CHARGE(),
-            sire_unit.LENGTH(),
-            sire_unit.MASS(),
-            sire_unit.QUANTITY(),
-            sire_unit.TEMPERATURE(),
-            sire_unit.TIME(),
-        )
+        dimensions = tuple(sire_unit.dimensions())
 
         # Make sure that this isn't zero.
         if hasattr(sire_unit, "is_zero"):

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_volume.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_volume.py
@@ -286,7 +286,8 @@ class Volume(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -316,13 +317,13 @@ class Volume(_Type):
             unit = unit[0:index] + unit[index + 1 :] + "3"
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_volume.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_volume.py
@@ -72,9 +72,8 @@ class Volume(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ANGSTROM3"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 3, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_angle.py
+++ b/python/BioSimSpace/Types/_angle.py
@@ -187,7 +187,8 @@ class Angle(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -209,13 +210,13 @@ class Angle(_Type):
         unit = unit.replace("AD", "")
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_angle.py
+++ b/python/BioSimSpace/Types/_angle.py
@@ -52,9 +52,8 @@ class Angle(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "RADIAN"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (1, 0, 0, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_area.py
+++ b/python/BioSimSpace/Types/_area.py
@@ -329,7 +329,8 @@ class Area(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit is supported."""
 
         # Strip whitespace and convert to upper case.
@@ -359,13 +360,13 @@ class Area(_Type):
             unit = unit[0:index] + unit[index + 1 :] + "2"
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_area.py
+++ b/python/BioSimSpace/Types/_area.py
@@ -72,9 +72,8 @@ class Area(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ANGSTROM2"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 2, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_charge.py
+++ b/python/BioSimSpace/Types/_charge.py
@@ -58,9 +58,8 @@ class Charge(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ELECTRON CHARGE"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 1, 0, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_charge.py
+++ b/python/BioSimSpace/Types/_charge.py
@@ -181,7 +181,8 @@ class Charge(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -212,11 +213,11 @@ class Charge(_Type):
         unit = unit.replace("COUL", "C")
 
         # Check that the unit is supported.
-        if unit in self._abbreviations:
-            return self._abbreviations[unit]
+        if unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_energy.py
+++ b/python/BioSimSpace/Types/_energy.py
@@ -68,9 +68,8 @@ class Energy(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "KILO CALORIES PER MOL"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 2, 1, -1, 0, -2)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_energy.py
+++ b/python/BioSimSpace/Types/_energy.py
@@ -212,7 +212,8 @@ class Energy(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -234,11 +235,11 @@ class Energy(_Type):
         unit = unit.replace("JOULES", "J")
 
         # Check that the unit is supported.
-        if unit in self._abbreviations:
-            return self._abbreviations[unit]
+        if unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -441,7 +441,6 @@ class GeneralUnit(_Type):
             )
 
         is_inverse = False
-        offset = 0
 
         if isinstance(other, float):
             if other > 1:

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -261,11 +261,21 @@ class GeneralUnit(_Type):
             temp = self._from_string(other)
             return self + temp
 
+        # Addition of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
+
         else:
             raise TypeError(
                 "unsupported operand type(s) for +: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __radd__(self, other):
+        """Addition operator."""
+
+        # Addition is commutative: a+b = b+a
+        return self.__add__(other)
 
     def __sub__(self, other):
         """Subtraction operator."""
@@ -275,16 +285,26 @@ class GeneralUnit(_Type):
             temp = self._sire_unit - other._to_sire_unit()
             return GeneralUnit(temp)
 
-        # Addition of a string.
+        # Subtraction of a string.
         elif isinstance(other, str):
             temp = self._from_string(other)
             return self - temp
+
+        # Subtraction of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
 
         else:
             raise TypeError(
                 "unsupported operand type(s) for -: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __rsub__(self, other):
+        """Subtraction operator."""
+
+        # Subtraction is not commutative: a-b != b-a
+        return -self.__sub__(other)
 
     def __mul__(self, other):
         """Multiplication operator."""

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -38,16 +38,16 @@ class GeneralUnit(_Type):
     """A general unit type."""
 
     _dimension_chars = [
-        "A",  # Angle
-        "C",  # Charge
-        "L",  # Length
         "M",  # Mass
-        "Q",  # Quantity
+        "L",  # Length
+        "T",  # Time
+        "C",  # Charge
         "t",  # Temperature
-        "T",  # Tme
+        "Q",  # Quantity
+        "A",  # Angle
     ]
 
-    def __new__(cls, *args):
+    def __new__(cls, *args, no_cast=False):
         """
         Constructor.
 
@@ -65,6 +65,9 @@ class GeneralUnit(_Type):
 
         string : str
             A string representation of the unit type.
+
+        no_cast: bool
+            Whether to disable casting to a specific type.
         """
 
         # This operator may be called when unpickling an object. Catch empty
@@ -96,7 +99,7 @@ class GeneralUnit(_Type):
             if isinstance(_args[0], _GeneralUnit):
                 general_unit = _args[0]
 
-            # The user has passed a string representation of the temperature.
+            # The user has passed a string representation of the type.
             elif isinstance(_args[0], str):
                 # Extract the string.
                 string = _args[0]
@@ -128,15 +131,7 @@ class GeneralUnit(_Type):
         general_unit = value * general_unit
 
         # Store the dimension mask.
-        dimensions = (
-            general_unit.ANGLE(),
-            general_unit.CHARGE(),
-            general_unit.LENGTH(),
-            general_unit.MASS(),
-            general_unit.QUANTITY(),
-            general_unit.TEMPERATURE(),
-            general_unit.TIME(),
-        )
+        dimensions = tuple(general_unit.dimensions())
 
         # This is a dimensionless quantity, return the value as a float.
         if all(x == 0 for x in dimensions):
@@ -144,13 +139,13 @@ class GeneralUnit(_Type):
 
         # Check to see if the dimensions correspond to a supported type.
         # If so, return an object of that type.
-        if dimensions in _base_dimensions:
+        if not no_cast and dimensions in _base_dimensions:
             return _base_dimensions[dimensions](general_unit)
         # Otherwise, call __init__()
         else:
             return super(GeneralUnit, cls).__new__(cls)
 
-    def __init__(self, *args):
+    def __init__(self, *args, no_cast=False):
         """
         Constructor.
 
@@ -168,6 +163,9 @@ class GeneralUnit(_Type):
 
         string : str
             A string representation of the unit type.
+
+        no_cast: bool
+            Whether to disable casting to a specific type.
         """
 
         value = 1
@@ -194,7 +192,7 @@ class GeneralUnit(_Type):
             if isinstance(_args[0], _GeneralUnit):
                 general_unit = _args[0]
 
-            # The user has passed a string representation of the temperature.
+            # The user has passed a string representation of the type.
             elif isinstance(_args[0], str):
                 # Extract the string.
                 string = _args[0]
@@ -222,15 +220,7 @@ class GeneralUnit(_Type):
         self._value = self._sire_unit.value()
 
         # Store the dimension mask.
-        self._dimensions = (
-            general_unit.ANGLE(),
-            general_unit.CHARGE(),
-            general_unit.LENGTH(),
-            general_unit.MASS(),
-            general_unit.QUANTITY(),
-            general_unit.TEMPERATURE(),
-            general_unit.TIME(),
-        )
+        self._dimensions = tuple(general_unit.dimensions())
 
         # Create the unit string.
         self._unit = ""
@@ -312,16 +302,8 @@ class GeneralUnit(_Type):
             # Multipy the Sire unit objects.
             temp = self._sire_unit * other._to_sire_unit()
 
-            # Create the dimension mask.
-            dimensions = (
-                temp.ANGLE(),
-                temp.CHARGE(),
-                temp.LENGTH(),
-                temp.MASS(),
-                temp.QUANTITY(),
-                temp.TEMPERATURE(),
-                temp.TIME(),
-            )
+            # Get the dimension mask.
+            dimensions = temp.dimensions()
 
             # Return as an existing type if the dimensions match.
             try:
@@ -432,24 +414,58 @@ class GeneralUnit(_Type):
     def __pow__(self, other):
         """Power operator."""
 
-        if type(other) is not int:
+        if not isinstance(other, (int, float)):
             raise TypeError(
                 "unsupported operand type(s) for ^: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
 
+        is_inverse = False
+        offset = 0
+
+        if isinstance(other, float):
+            if other > 1:
+                if not other.is_integer():
+                    raise ValueError("float exponent must be integer valued.")
+            else:
+                is_inverse = True
+                other = 1 / other
+                if not other.is_integer():
+                    raise ValueError(
+                        "Divisor in fractional exponent must be integer valued."
+                    )
+                other = int(other)
+
         if other == 0:
             return GeneralUnit(self._sire_unit / self._sire_unit)
 
-        # Multiply the Sire GeneralUnit 'other' times.
-        temp = self._sire_unit
-        for x in range(0, abs(other) - 1):
-            temp = temp * self._sire_unit
+        # Get the current unit dimemsions.
+        dims = self._sire_unit.dimensions()
 
-        if other > 0:
-            return GeneralUnit(temp)
+        # Check that the exponent is a factor of all the unit dimensions.
+        if is_inverse:
+            for dim in dims:
+                if dim % other != 0:
+                    raise ValueError(
+                        "The divisor of the exponent must be a factor of all the unit dimensions."
+                    )
+
+        if is_inverse:
+            new_dims = [int(dim / other) for dim in dims]
         else:
-            return GeneralUnit(1 / temp)
+            new_dims = [int(dim * other) for dim in dims]
+
+        if is_inverse:
+            value = self.value() ** (1 / other)
+        else:
+            value = self.value() ** other
+
+        # Invert the value.
+        if other < 0 and not is_inverse:
+            value = 1 / value
+
+        # Return a new GeneralUnit object.
+        return GeneralUnit(_GeneralUnit(value, new_dims))
 
     def __lt__(self, other):
         """Less than operator."""
@@ -606,29 +622,17 @@ class GeneralUnit(_Type):
         """
         return self._dimensions
 
-    def angle(self):
+    def mass(self):
         """
-        Return the power of this general unit in the 'angle' dimension.
+        Return the power of this general unit in the 'mass' dimension.
 
         Returns
         -------
 
-        angle : int
-            The power of the general unit in the 'angle' dimension.
+        mass : int
+            The power of the general unit in the 'mass' dimension.
         """
         return self._dimensions[0]
-
-    def charge(self):
-        """
-        Return the power of this general unit in the 'charge' dimension.
-
-        Returns
-        -------
-
-        charge : int
-            The power of the general unit in the 'charge' dimension.
-        """
-        return self._dimensions[1]
 
     def length(self):
         """
@@ -640,31 +644,31 @@ class GeneralUnit(_Type):
         length : int
             The power of the general unit in the 'length' dimension.
         """
+        return self._dimensions[1]
+
+    def time(self):
+        """
+        Return the power of this general unit in the 'time' dimension.
+
+        Returns
+        -------
+
+        time : int
+            The power of the general unit in the 'time' dimension.
+        """
         return self._dimensions[2]
 
-    def mass(self):
+    def charge(self):
         """
-        Return the power of this general unit in the 'mass' dimension.
+        Return the power of this general unit in the 'charge' dimension.
 
         Returns
         -------
 
-        mass : int
-            The power of the general unit in the 'mass' dimension.
+        charge : int
+            The power of the general unit in the 'charge' dimension.
         """
         return self._dimensions[3]
-
-    def quantity(self):
-        """
-        Return the power of this general unit in the 'quantity' dimension.
-
-        Returns
-        -------
-
-        quantity : int
-            The power of the general unit in the 'quantity' dimension.
-        """
-        return self._dimensions[4]
 
     def temperature(self):
         """
@@ -676,17 +680,29 @@ class GeneralUnit(_Type):
         temperature : int
             The power of the general unit in the 'temperature' dimension.
         """
-        return self._dimensions[5]
+        return self._dimensions[4]
 
-    def time(self):
+    def quantity(self):
         """
-        Return the power of this general unit in the 'time' dimension.
+        Return the power of this general unit in the 'quantity' dimension.
 
         Returns
         -------
 
-        time : int
-            The power of the general unit in the 'time' dimension.
+        quantity : int
+            The power of the general unit in the 'quantity' dimension.
+        """
+        return self._dimensions[5]
+
+    def angle(self):
+        """
+        Return the power of this general unit in the 'angle' dimension.
+
+        Returns
+        -------
+
+        angle : int
+            The power of the general unit in the 'angle' dimension.
         """
         return self._dimensions[6]
 

--- a/python/BioSimSpace/Types/_length.py
+++ b/python/BioSimSpace/Types/_length.py
@@ -338,7 +338,8 @@ class Length(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -352,13 +353,13 @@ class Length(_Type):
             unit = "ANGS" + unit[3:]
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_length.py
+++ b/python/BioSimSpace/Types/_length.py
@@ -87,9 +87,8 @@ class Length(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ANGSTROM"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 1, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """
@@ -194,29 +193,6 @@ class Length(_Type):
 
         # Multiplication is commutative: a*b = b*a
         return self.__mul__(other)
-
-    def __pow__(self, other):
-        """Power operator."""
-
-        if not isinstance(other, int):
-            raise ValueError("We can only raise to the power of integer values.")
-
-        # No change.
-        if other == 1:
-            return self
-
-        # Area.
-        if other == 2:
-            mag = self.angstroms().value() ** 2
-            return _Area(mag, "A2")
-
-        # Volume.
-        if other == 3:
-            mag = self.angstroms().value() ** 3
-            return _Volume(mag, "A3")
-
-        else:
-            return super().__pow__(other)
 
     def meters(self):
         """

--- a/python/BioSimSpace/Types/_pressure.py
+++ b/python/BioSimSpace/Types/_pressure.py
@@ -176,7 +176,8 @@ class Pressure(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -195,11 +196,11 @@ class Pressure(_Type):
         unit = unit.replace("S", "")
 
         # Check that the unit is supported.
-        if unit in self._abbreviations:
-            return self._abbreviations[unit]
+        if unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_pressure.py
+++ b/python/BioSimSpace/Types/_pressure.py
@@ -55,9 +55,8 @@ class Pressure(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ATMOSPHERE"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, -1, 1, 0, 0, -2)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_temperature.py
+++ b/python/BioSimSpace/Types/_temperature.py
@@ -391,7 +391,8 @@ class Temperature(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -404,16 +405,16 @@ class Temperature(_Type):
         unit = unit.replace("DEG", "")
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         elif len(unit) == 0:
             raise ValueError(f"Unit is not given. You must supply the unit.")
         else:
             raise ValueError(
                 "Unsupported unit '%s'. Supported units are: '%s'"
-                % (unit, list(self._supported_units.keys()))
+                % (unit, list(cls._supported_units.keys()))
             )
 
     def _to_sire_unit(self):

--- a/python/BioSimSpace/Types/_temperature.py
+++ b/python/BioSimSpace/Types/_temperature.py
@@ -60,9 +60,8 @@ class Temperature(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "KELVIN"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 0, 0, 0, 1, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """
@@ -444,13 +443,13 @@ class Temperature(_Type):
         if isinstance(sire_unit, _SireUnits.GeneralUnit):
             # Create a mask for the dimensions of the object.
             dimensions = (
-                sire_unit.ANGLE(),
-                sire_unit.CHARGE(),
-                sire_unit.LENGTH(),
                 sire_unit.MASS(),
-                sire_unit.QUANTITY(),
-                sire_unit.TEMPERATURE(),
+                sire_unit.LENGTH(),
                 sire_unit.TIME(),
+                sire_unit.CHARGE(),
+                sire_unit.TEMPERATURE(),
+                sire_unit.QUANTITY(),
+                sire_unit.ANGLE(),
             )
 
             # Make sure the dimensions match.

--- a/python/BioSimSpace/Types/_time.py
+++ b/python/BioSimSpace/Types/_time.py
@@ -96,9 +96,8 @@ class Time(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "NANOSECOND"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 0, 0, 0, 0, 1)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/Types/_time.py
+++ b/python/BioSimSpace/Types/_time.py
@@ -336,24 +336,25 @@ class Time(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
         unit = unit.replace(" ", "").upper()
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit[:-1] in self._supported_units:
+        elif unit[:-1] in cls._supported_units:
             return unit[:-1]
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
-        elif unit[:-1] in self._abbreviations:
-            return self._abbreviations[unit[:-1]]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
+        elif unit[:-1] in cls._abbreviations:
+            return cls._abbreviations[unit[:-1]]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_type.py
+++ b/python/BioSimSpace/Types/_type.py
@@ -168,11 +168,21 @@ class Type:
             temp = self._from_string(other)
             return self + temp
 
+        # Addition of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
+
         else:
             raise TypeError(
                 "unsupported operand type(s) for +: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __radd__(self, other):
+        """Addition operator."""
+
+        # Addition is commutative: a+b = b+a
+        return self.__add__(other)
 
     def __sub__(self, other):
         """Subtraction operator."""
@@ -185,21 +195,31 @@ class Type:
             # Return a new object of the same type with the original unit.
             return self._to_default_unit(val)._convert_to(self._unit)
 
-        # Addition of a different type with the same dimensions.
+        # Subtraction of a different type with the same dimensions.
         elif isinstance(other, Type) and self._dimensions == other.dimensions:
             # Negate other and add.
             return -other + self
 
-        # Addition of a string.
+        # Subtraction of a string.
         elif isinstance(other, str):
             temp = self._from_string(other)
             return self - temp
+
+        # Subtraction of a zero-valued integer or float.
+        elif isinstance(other, (int, float)) and other == 0:
+            return self
 
         else:
             raise TypeError(
                 "unsupported operand type(s) for -: '%s' and '%s'"
                 % (self.__class__.__qualname__, other.__class__.__qualname__)
             )
+
+    def __rsub__(self, other):
+        """Subtraction operator."""
+
+        # Subtraction is not commutative: a-b != b-a
+        return -self.__sub__(other)
 
     def __mul__(self, other):
         """Multiplication operator."""

--- a/python/BioSimSpace/Types/_type.py
+++ b/python/BioSimSpace/Types/_type.py
@@ -103,7 +103,7 @@ class Type:
                 self._value = temp._value
                 self._unit = temp._unit
 
-            # The user has passed a string representation of the temperature.
+            # The user has passed a string representation of the type.
             elif isinstance(args[0], str):
                 # Convert the string to an object of this type.
                 obj = self._from_string(args[0])
@@ -244,19 +244,9 @@ class Type:
     def __pow__(self, other):
         """Power operator."""
 
-        if not isinstance(other, int):
-            raise ValueError("We can only raise to the power of integer values.")
-
         from ._general_unit import GeneralUnit as _GeneralUnit
 
-        default_unit = self._to_default_unit()
-        mag = default_unit.value() ** other
-        unit = default_unit.unit().lower()
-        pow_to_mul = "*".join(abs(other) * [unit])
-        if other > 0:
-            return _GeneralUnit(f"{mag}*{pow_to_mul}")
-        else:
-            return _GeneralUnit(f"{mag}/({pow_to_mul})")
+        return _GeneralUnit(self._to_sire_unit(), no_cast=True) ** other
 
     def __truediv__(self, other):
         """Division operator."""
@@ -486,49 +476,10 @@ class Type:
         containing the power in each dimension.
 
         Returns : (int, int, int, int, int, int)
-            The power in each dimension: 'angle', 'charge', 'length',
-            'mass', 'quantity', 'temperature', and 'time'.
+            The power in each dimension: 'mass', 'length', 'temperature',
+            'charge', 'time', 'quantity', and 'angle'.
         """
         return cls._dimensions
-
-    @classmethod
-    def angle(cls):
-        """
-        Return the power in the 'angle' dimension.
-
-        Returns
-        -------
-
-        angle : int
-            The power in the 'angle' dimension.
-        """
-        return cls._dimensions[0]
-
-    @classmethod
-    def charge(cls):
-        """
-        Return the power in the 'charge' dimension.
-
-        Returns
-        -------
-
-        charge : int
-            The power in the 'charge' dimension.
-        """
-        return cls._dimensions[1]
-
-    @classmethod
-    def length(cls):
-        """
-        Return the power in the 'length' dimension.
-
-        Returns
-        -------
-
-        length : int
-            The power in the 'length' dimension.
-        """
-        return cls._dimensions[2]
 
     @classmethod
     def mass(cls):
@@ -541,20 +492,46 @@ class Type:
         mass : int
             The power in the 'mass' dimension.
         """
-        return cls._dimensions[3]
+        return cls._dimensions[0]
 
     @classmethod
-    def quantity(cls):
+    def length(cls):
         """
-        Return the power in the 'quantity' dimension.
+        Return the power in the 'length' dimension.
 
         Returns
         -------
 
-        quantity : int
-            The power in the 'quantity' dimension.
+        length : int
+            The power in the 'length' dimension.
         """
-        return cls._dimensions[4]
+        return cls._dimensions[1]
+
+    @classmethod
+    def time(cls):
+        """
+        Return the power in the 'time' dimension.
+
+        Returns
+        -------
+
+        time : int
+            The power the 'time' dimension.
+        """
+        return cls._dimensions[2]
+
+    @classmethod
+    def charge(cls):
+        """
+        Return the power in the 'charge' dimension.
+
+        Returns
+        -------
+
+        charge : int
+            The power in the 'charge' dimension.
+        """
+        return cls._dimensions[3]
 
     @classmethod
     def temperature(cls):
@@ -567,18 +544,31 @@ class Type:
         temperature : int
             The power in the 'temperature' dimension.
         """
-        return cls._dimensions[5]
+        return cls._dimensions[4]
 
     @classmethod
-    def time(cls):
+    def quantity(cls):
         """
-        Return the power in the 'time' dimension.
+        Return the power in the 'quantity' dimension.
 
         Returns
         -------
 
-        time : int
-            The power the 'time' dimension.
+        quantity : int
+            The power in the 'quantity' dimension.
+        """
+        return cls._dimensions[5]
+
+    @classmethod
+    def angle(cls):
+        """
+        Return the power in the 'angle' dimension.
+
+        Returns
+        -------
+
+        angle : int
+            The power in the 'angle' dimension.
         """
         return cls._dimensions[6]
 
@@ -662,15 +652,7 @@ class Type:
             raise TypeError("'sire_unit' must be of type 'sire.units.GeneralUnit'")
 
         # Create a mask for the dimensions of the object.
-        dimensions = (
-            sire_unit.ANGLE(),
-            sire_unit.CHARGE(),
-            sire_unit.LENGTH(),
-            sire_unit.MASS(),
-            sire_unit.QUANTITY(),
-            sire_unit.TEMPERATURE(),
-            sire_unit.TIME(),
-        )
+        dimensions = tuple(sire_unit.dimensions())
 
         # Make sure that this isn't zero.
         if hasattr(sire_unit, "is_zero"):

--- a/python/BioSimSpace/Types/_volume.py
+++ b/python/BioSimSpace/Types/_volume.py
@@ -286,7 +286,8 @@ class Volume(_Type):
                 "Supported units are: '%s'" % list(self._supported_units.keys())
             )
 
-    def _validate_unit(self, unit):
+    @classmethod
+    def _validate_unit(cls, unit):
         """Validate that the unit are supported."""
 
         # Strip whitespace and convert to upper case.
@@ -316,13 +317,13 @@ class Volume(_Type):
             unit = unit[0:index] + unit[index + 1 :] + "3"
 
         # Check that the unit is supported.
-        if unit in self._supported_units:
+        if unit in cls._supported_units:
             return unit
-        elif unit in self._abbreviations:
-            return self._abbreviations[unit]
+        elif unit in cls._abbreviations:
+            return cls._abbreviations[unit]
         else:
             raise ValueError(
-                "Supported units are: '%s'" % list(self._supported_units.keys())
+                "Supported units are: '%s'" % list(cls._supported_units.keys())
             )
 
     @staticmethod

--- a/python/BioSimSpace/Types/_volume.py
+++ b/python/BioSimSpace/Types/_volume.py
@@ -72,9 +72,8 @@ class Volume(_Type):
     # Null type unit for avoiding issue printing configargparse help.
     _default_unit = "ANGSTROM3"
 
-    # The dimension mask:
-    #     Angle, Charge, Length, Mass, Quantity, Temperature, Time
-    _dimensions = (0, 0, 3, 0, 0, 0, 0)
+    # The dimension mask.
+    _dimensions = tuple(list(_supported_units.values())[0].dimensions())
 
     def __init__(self, *args):
         """

--- a/python/BioSimSpace/_Config/_amber.py
+++ b/python/BioSimSpace/_Config/_amber.py
@@ -224,9 +224,9 @@ class Amber(_Config):
                                     ]
                                 restraint_mask = "@" + ",".join(restraint_atom_names)
                             elif restraint == "heavy":
-                                restraint_mask = "!:WAT & !@H="
+                                restraint_mask = "!:WAT & !@%NA,CL & !@H="
                             elif restraint == "all":
-                                restraint_mask = "!:WAT"
+                                restraint_mask = "!:WAT & !@%NA,CL"
 
                         # We can't do anything about a custom restraint, since we don't
                         # know anything about the atoms.

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -31,6 +31,7 @@ test:
     - pytest-black  # [linux and x86_64 and py==311]
     - ambertools    # [linux and x86_64]
     - gromacs       # [linux and x86_64]
+    - requests
   imports:
     - BioSimSpace
   source_files:

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint_search.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint_search.py
@@ -291,7 +291,15 @@ class TestBSS_analysis:
         assert restr_dict["permanent_distance_restraint"][
             "r0"
         ].value() == pytest.approx(8.9019, abs=1e-4)
-        assert restr_dict["permanent_distance_restraint"]["kr"].unit() == "M Q-1 T-2"
+        assert restr_dict["permanent_distance_restraint"]["kr"].dimensions() == (
+            1,
+            0,
+            -2,
+            0,
+            0,
+            -1,
+            0,
+        )
         assert restr_dict["permanent_distance_restraint"]["kr"].value() == 40.0
         assert restr_dict["permanent_distance_restraint"]["r_fb"].unit() == "ANGSTROM"
         assert restr_dict["permanent_distance_restraint"][

--- a/tests/Sandpit/Exscientia/Types/test_general_unit.py
+++ b/tests/Sandpit/Exscientia/Types/test_general_unit.py
@@ -3,15 +3,26 @@ import pytest
 import BioSimSpace.Sandpit.Exscientia.Types as Types
 import BioSimSpace.Sandpit.Exscientia.Units as Units
 
+import sire as sr
+
 
 @pytest.mark.parametrize(
     "string, dimensions",
     [
-        ("kilo Cal oriEs per Mole / angstrom **2", (0, 0, 0, 1, -1, 0, -2)),
-        ("k Cal_per  _mOl / nm^2", (0, 0, 0, 1, -1, 0, -2)),
-        ("kj p  eR  moles / pico METERs2", (0, 0, 0, 1, -1, 0, -2)),
-        ("coul oMbs / secs * ATm os phereS", (0, 1, -1, 1, 0, 0, -3)),
-        ("pm**3 * rads * de grEE", (2, 0, 3, 0, 0, 0, 0)),
+        (
+            "kilo Cal oriEs per Mole / angstrom **2",
+            tuple(sr.u("kcal_per_mol / angstrom**2").dimensions()),
+        ),
+        ("k Cal_per  _mOl / nm^2", tuple(sr.u("kcal_per_mol / nm**2").dimensions())),
+        (
+            "kj p  eR  moles / pico METERs2",
+            tuple(sr.u("kJ_per_mol / pm**2").dimensions()),
+        ),
+        (
+            "coul oMbs / secs * ATm os phereS",
+            tuple(sr.u("coulombs / second / atm").dimensions()),
+        ),
+        ("pm**3 * rads * de grEE", tuple(sr.u("pm**3 * rad * degree").dimensions())),
     ],
 )
 def test_supported_units(string, dimensions):
@@ -138,6 +149,61 @@ def test_neg_pow(unit_type):
     # Each dimension entry should be the inverse of the old value.
     for d0, d1 in zip(old_dimensions, new_dimensions):
         assert d1 == -d0
+
+
+def test_frac_pow():
+    """Test that unit-based types can be raised to fractional powers."""
+
+    # Create a base unit type.
+    unit_type = 2 * Units.Length.angstrom
+
+    # Store the original value and dimensions.
+    value = unit_type.value()
+    dimensions = unit_type.dimensions()
+
+    # Square the type.
+    unit_type = unit_type**2
+
+    # Assert that we can't take the cube root.
+    with pytest.raises(ValueError):
+        unit_type = unit_type ** (1 / 3)
+
+    # Now take the square root.
+    unit_type = unit_type ** (1 / 2)
+
+    # The value should be the same.
+    assert unit_type.value() == value
+
+    # The dimensions should be the same.
+    assert unit_type.dimensions() == dimensions
+
+    # Cube the type.
+    unit_type = unit_type**3
+
+    # Assert that we can't take the square root.
+    with pytest.raises(ValueError):
+        unit_type = unit_type ** (1 / 2)
+
+    # Now take the cube root.
+    unit_type = unit_type ** (1 / 3)
+
+    # The value should be the same.
+    assert unit_type.value() == value
+
+    # The dimensions should be the same.
+    assert unit_type.dimensions() == dimensions
+
+    # Square the type again.
+    unit_type = unit_type**2
+
+    # Now take the negative square root.
+    unit_type = unit_type ** (-1 / 2)
+
+    # The value should be inverted.
+    assert unit_type.value() == 1 / value
+
+    # The dimensions should be negated.
+    assert unit_type.dimensions() == tuple(-d for d in dimensions)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR...

1) closes #258 by excluding the standard free ions (Na and Cl) to the AMBER position restraint mask. This logic is triggered when the manual restraint mask exceeds the mask character limit, so we need to fall back on the assumption of _standard_ AMBER atom naming. This will work in the case of a BioSImSpace workflow, e.g. where solvation is performed with BioSimSpace, but not for arbitrary input. (The restraint is unreliable then anyway.)

2) closes #259 by adding support for fractional exponents in the `BioSimSpace.Types._GeneralUnit.__pow__` operator. I've also re-orded the dimension mask used internally for consistency with sire, which will make it easier to create `GeneralUnit` types from these masks. (I hadn't used this before.) These update is largely covered by the existing tests but I've added a further test specific to fractional exponents to cover a range of cases, including error handling.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods