### PR TITLE
Use Langevin integrator for free-energy simulations

### DIFF
--- a/python/BioSimSpace/_Config/_gromacs.py
+++ b/python/BioSimSpace/_Config/_gromacs.py
@@ -207,10 +207,14 @@ class Gromacs(_Config):
 
         # Temperature control.
         if not isinstance(self._protocol, _Protocol.Minimisation):
-            # Leap-frog molecular dynamics.
-            protocol_dict["integrator"] = "md"
-            # Temperature coupling using velocity rescaling with a stochastic term.
-            protocol_dict["tcoupl"] = "v-rescale"
+            if isinstance(self._protocol, _FreeEnergyMixin):
+                # Langevin dynamics.
+                protocol_dict["integrator"] = "sd"
+            else:
+                # Leap-frog molecular dynamics.
+                protocol_dict["integrator"] = "md"
+                # Temperature coupling using velocity rescaling with a stochastic term.
+                protocol_dict["tcoupl"] = "v-rescale"
             # A single temperature group for the entire system.
             protocol_dict["tc-grps"] = "system"
             # Thermostat coupling frequency (ps).


### PR DESCRIPTION
I was just going through the recent Exscientia PRs and saw [this](https://github.com/Exscientia/biosimspace/pull/37/files), so thought I'd port it to the main code base, since my config is based on theirs. Perhaps there should be an easier mechanism for this sort of thing. I can obviously compare at the point of synchronisation, but it's obviously a lot of work if there are many changes.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods