### PR TITLE
Add support for openff-nagl for generation of partial charges

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -36,7 +36,7 @@ jobs:
       SIRE_DONT_PHONEHOME: 1
       SIRE_SILENT_PHONEHOME: 1
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -49,7 +49,7 @@ jobs:
         run: git clone -b devel https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa boltons anaconda-client packaging=21 pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -49,7 +49,7 @@ jobs:
         run: git clone -b devel https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa boltons anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa=0.16 anaconda-client packaging=21 pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -49,7 +49,7 @@ jobs:
         run: git clone -b devel https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa=0.16 anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa anaconda-client packaging pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
       SIRE_DONT_PHONEHOME: 1
       SIRE_SILENT_PHONEHOME: 1
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         run: git clone -b main https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa=0.16 anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa anaconda-client packaging pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         run: git clone -b main https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa boltons anaconda-client packaging=21 pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         run: git clone -b main https://github.com/openbiosim/biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa boltons anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa=0.16 anaconda-client packaging=21 pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
       SIRE_SILENT_PHONEHOME: 1
       REPO: "${{ github.event.pull_request.head.repo.full_name || github.repository }}"
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }} biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa=0.16 anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa anaconda-client packaging pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }} biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa boltons anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa=0.16 anaconda-client packaging=21 pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/${{ env.REPO }} biosimspace
 #
       - name: Setup Conda
-        run: mamba install -y -c conda-forge boa anaconda-client packaging=21 pip-requirements-parser
+        run: mamba install -y -c conda-forge boa boltons anaconda-client packaging=21 pip-requirements-parser
 #
       - name: Update Conda recipe
         run: python ${{ github.workspace }}/biosimspace/actions/update_recipe.py

--- a/python/BioSimSpace/IO/__init__.py
+++ b/python/BioSimSpace/IO/__init__.py
@@ -28,6 +28,9 @@ Functions
 .. autosummary::
     :toctree: generated/
 
+    clearCache
+    disableCache
+    enableCache
     fileFormats
     formatInfo
     readMolecules
@@ -38,3 +41,4 @@ Functions
 """
 
 from ._io import *
+from ._file_cache import *

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -24,7 +24,7 @@
 __author__ = "Lester Hedges"
 __email__ = "lester.hedges@gmail.com"
 
-__all__ = ["check_cache", "update_cache"]
+__all__ = ["clearCache", "disableCache", "enableCache"]
 
 import collections as _collections
 import hashlib as _hashlib
@@ -80,8 +80,43 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
 # to the same format, allowing us to re-use the existing file.
 _cache = _FixedSizeOrderedDict()
 
+# Whether to use the cache.
+_use_cache = True
 
-def check_cache(
+
+def clearCache():
+    """
+    Clear the file cache.
+    """
+    global _cache
+    _cache = _FixedSizeOrderedDict()
+
+
+def disableCache():
+    """
+    Disable the file cache.
+    """
+    global _use_cache
+    _use_cache = False
+
+
+def enableCache():
+    """
+    Enable the file cache.
+    """
+    global _use_cache
+    _use_cache = True
+
+
+def _cache_active():
+    """
+    Internal helper function to check whether the cache is active.
+    """
+    global _use_cache
+    return _use_cache
+
+
+def _check_cache(
     system,
     format,
     filebase,
@@ -157,6 +192,8 @@ def check_cache(
     if not isinstance(skip_water, bool):
         raise TypeError("'skip_water' must be of type 'bool'.")
 
+    global _cache
+
     # Create the key.
     key = (
         system._sire_object.uid().toString(),
@@ -221,7 +258,7 @@ def check_cache(
         return ext
 
 
-def update_cache(
+def _update_cache(
     system,
     format,
     path,
@@ -283,6 +320,8 @@ def update_cache(
 
     if not isinstance(skip_water, bool):
         raise TypeError("'skip_water' must be of type 'bool'.")
+
+    global _cache
 
     # Convert to an absolute path.
     path = _os.path.abspath(path)

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -450,7 +450,10 @@ def readMolecules(
     # Glob all files to catch wildcards.
     new_files = []
     for file in files:
-        new_files += _glob(file)
+        if not file.startswith(("http", "www")):
+            new_files += _glob(file)
+        else:
+            new_files.append(file)
     files = new_files
 
     # Validate the molecule unwrapping flag.

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -431,9 +431,9 @@ def readMolecules(
         )
         _has_gmx_warned = True
 
+    # Convert a single string to a list.
     if isinstance(files, str):
-        if not files.startswith(("http", "www")):
-            files = [files]
+        files = [files]
 
     # Check that all arguments are of type 'str'.
     if isinstance(files, (list, tuple)):

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -76,12 +76,10 @@ _openff = _try_import("openff")
 if _have_imported(_openff):
     from openff.interchange import Interchange as _Interchange
     from openff.toolkit.topology import Molecule as _OpenFFMolecule
-    from openff.toolkit.topology import Topology as _OpenFFTopology
     from openff.toolkit.typing.engines.smirnoff import ForceField as _Forcefield
 else:
     _Interchange = _openff
     _OpenFFMolecule = _openff
-    _OpenFFTopology = _openff
     _Forcefield = _openff
 
 # Reset stderr.

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -73,6 +73,9 @@ else:
 
 _openff = _try_import("openff")
 
+# Initialise the NAGL support flag.
+_has_nagl = False
+
 if _have_imported(_openff):
     from openff.interchange import Interchange as _Interchange
     from openff.toolkit.topology import Molecule as _OpenFFMolecule

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -463,6 +463,7 @@ def _parameterise_openff(
     forcefield,
     molecule,
     ensure_compatible=True,
+    use_nagl=True,
     work_dir=None,
     property_map={},
     **kwargs,
@@ -488,6 +489,11 @@ def _parameterise_openff(
         raised if this isn't the case, e.g. if atoms have been added. When True,
         the parameterised molecule will preserve the topology of the original
         molecule, e.g. the original atom and residue names will be kept.
+
+    use_nagl : bool
+        Whether to use NAGL to compute AM1-BCC charges. If False, the default
+        is to use AmberTools via antechamber and sqm. (This option is only
+        used if NAGL is available.)
 
     work_dir : str
         The working directory for the process.
@@ -583,12 +589,21 @@ def _parameterise_openff(
         if forcefield not in _forcefields_lower:
             raise ValueError("Supported force fields are: %s" % openForceFields())
 
+    if not isinstance(ensure_compatible, bool):
+        raise TypeError("'ensure_compatible' must be of type 'bool'.")
+
+    if not isinstance(use_nagl, bool):
+        raise TypeError("'use_nagl' must be of type 'bool'.")
+
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'")
 
     # Create a default protocol.
     protocol = _Protocol.OpenForceField(
-        forcefield, ensure_compatible=ensure_compatible, property_map=property_map
+        forcefield,
+        ensure_compatible=ensure_compatible,
+        use_nagl=use_nagl,
+        property_map=property_map,
     )
 
     # Run the parameterisation protocol in the background and return
@@ -1079,7 +1094,9 @@ def _make_amber_protein_function(name):
 # it conforms to sensible function naming standards, i.e. "-" and "."
 # characters replaced by underscores.
 def _make_openff_function(name):
-    def _function(molecule, ensure_compatible=True, work_dir=None, property_map={}):
+    def _function(
+        molecule, ensure_compatible=True, use_nagl=True, work_dir=None, property_map={}
+    ):
         """
         Parameterise a molecule using the named force field from the
         Open Force Field initiative.
@@ -1100,6 +1117,11 @@ def _make_openff_function(name):
             molecule will preserve the topology of the original molecule, e.g.
             the original atom and residue names will be kept.
 
+        use_nagl : bool
+            Whether to use NAGL to compute AM1-BCC charges. If False, the default
+            is to use AmberTools via antechamber and sqm. (This option is only
+            used if NAGL is available.)
+
         work_dir : str
             The working directory for the process.
 
@@ -1118,6 +1140,7 @@ def _make_openff_function(name):
             name,
             molecule,
             ensure_compatible=ensure_compatible,
+            use_nagl=use_nagl,
             work_dir=work_dir,
             property_map=property_map,
         )

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/__init__.py
@@ -28,6 +28,9 @@ Functions
 .. autosummary::
     :toctree: generated/
 
+    clearCache
+    disableCache
+    enableCache
     fileFormats
     formatInfo
     readMolecules
@@ -37,6 +40,5 @@ Functions
     savePerturbableSystem
 """
 
-from glob import glob
-
 from ._io import *
+from ._file_cache import *

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -24,7 +24,7 @@
 __author__ = "Lester Hedges"
 __email__ = "lester.hedges@gmail.com"
 
-__all__ = ["check_cache", "update_cache"]
+__all__ = ["clearCache", "disableCache", "enableCache"]
 
 import collections as _collections
 import hashlib as _hashlib
@@ -80,8 +80,43 @@ class _FixedSizeOrderedDict(_collections.OrderedDict):
 # to the same format, allowing us to re-use the existing file.
 _cache = _FixedSizeOrderedDict()
 
+# Whether to use the cache.
+_use_cache = True
 
-def check_cache(
+
+def clearCache():
+    """
+    Clear the file cache.
+    """
+    global _cache
+    _cache = _FixedSizeOrderedDict()
+
+
+def disableCache():
+    """
+    Disable the file cache.
+    """
+    global _use_cache
+    _use_cache = False
+
+
+def enableCache():
+    """
+    Enable the file cache.
+    """
+    global _use_cache
+    _use_cache = True
+
+
+def _cache_active():
+    """
+    Internal helper function to check whether the cache is active.
+    """
+    global _use_cache
+    return _use_cache
+
+
+def _check_cache(
     system,
     format,
     filebase,
@@ -157,6 +192,8 @@ def check_cache(
     if not isinstance(skip_water, bool):
         raise TypeError("'skip_water' must be of type 'bool'.")
 
+    global _cache
+
     # Create the key.
     key = (
         system._sire_object.uid().toString(),
@@ -221,7 +258,7 @@ def check_cache(
         return ext
 
 
-def update_cache(
+def _update_cache(
     system,
     format,
     path,
@@ -283,6 +320,8 @@ def update_cache(
 
     if not isinstance(skip_water, bool):
         raise TypeError("'skip_water' must be of type 'bool'.")
+
+    global _cache
 
     # Convert to an absolute path.
     path = _os.path.abspath(path)

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -450,7 +450,10 @@ def readMolecules(
     # Glob all files to catch wildcards.
     new_files = []
     for file in files:
-        new_files += _glob(file)
+        if not file.startswith(("http", "www")):
+            new_files += _glob(file)
+        else:
+            new_files.append(file)
     files = new_files
 
     # Validate the molecule unwrapping flag.

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -431,9 +431,9 @@ def readMolecules(
         )
         _has_gmx_warned = True
 
+    # Convert a single string to a list.
     if isinstance(files, str):
-        if not files.startswith(("http", "www")):
-            files = [files]
+        files = [files]
 
     # Check that all arguments are of type 'str'.
     if isinstance(files, (list, tuple)):

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -66,8 +66,9 @@ from .._SireWrappers import Molecules as _Molecules
 from .._SireWrappers import System as _System
 from .. import _Utils
 
-from ._file_cache import check_cache as _check_cache
-from ._file_cache import update_cache as _update_cache
+from ._file_cache import _check_cache
+from ._file_cache import _update_cache
+from ._file_cache import _cache_active
 
 
 # Context manager for capturing stdout.
@@ -430,11 +431,8 @@ def readMolecules(
         )
         _has_gmx_warned = True
 
-    # Glob string to catch wildcards and convert to list.
     if isinstance(files, str):
         if not files.startswith(("http", "www")):
-            files = _glob(files)
-        else:
             files = [files]
 
     # Check that all arguments are of type 'str'.
@@ -448,6 +446,12 @@ def readMolecules(
             files = list(files)
     else:
         raise TypeError("'files' must be of type 'str', or a list of 'str' types.")
+
+    # Glob all files to catch wildcards.
+    new_files = []
+    for file in files:
+        new_files += _glob(file)
+    files = new_files
 
     # Validate the molecule unwrapping flag.
     if not isinstance(make_whole, bool):
@@ -741,14 +745,17 @@ def saveMolecules(
     # Save the system using each file format.
     for format in formats:
         # Copy an existing file if it exists in the cache.
-        ext = _check_cache(
-            system,
-            format,
-            filebase,
-            match_water=match_water,
-            property_map=property_map,
-            **kwargs,
-        )
+        if _cache_active():
+            ext = _check_cache(
+                system,
+                format,
+                filebase,
+                match_water=match_water,
+                property_map=property_map,
+                **kwargs,
+            )
+        else:
+            ext = None
         if ext:
             files.append(_os.path.abspath(filebase + ext))
             continue
@@ -835,7 +842,10 @@ def saveMolecules(
             files += file
 
             # If this is a new file, then add it to the cache.
-            _update_cache(system, format, file[0], match_water=match_water, **kwargs)
+            if _cache_active():
+                _update_cache(
+                    system, format, file[0], match_water=match_water, **kwargs
+                )
 
         except Exception as e:
             msg = "Failed to save system to format: '%s'" % format
@@ -1162,7 +1172,7 @@ def readPerturbableSystem(top0, coords0, top1, coords1, property_map={}):
         prop = property_map.get("time", "time")
         time = system0._sire_object.property(prop)
         system0._sire_object.removeSharedProperty(prop)
-        system0._sire_object.setPropery(prop, time)
+        system0._sire_object.setProperty(prop, time)
     except:
         pass
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -76,12 +76,10 @@ _openff = _try_import("openff")
 if _have_imported(_openff):
     from openff.interchange import Interchange as _Interchange
     from openff.toolkit.topology import Molecule as _OpenFFMolecule
-    from openff.toolkit.topology import Topology as _OpenFFTopology
     from openff.toolkit.typing.engines.smirnoff import ForceField as _Forcefield
 else:
     _Interchange = _openff
     _OpenFFMolecule = _openff
-    _OpenFFTopology = _openff
     _Forcefield = _openff
 
 # Reset stderr.

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -73,6 +73,9 @@ else:
 
 _openff = _try_import("openff")
 
+# Initialise the NAGL support flag.
+_has_nagl = False
+
 if _have_imported(_openff):
     from openff.interchange import Interchange as _Interchange
     from openff.toolkit.topology import Molecule as _OpenFFMolecule

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -463,6 +463,7 @@ def _parameterise_openff(
     forcefield,
     molecule,
     ensure_compatible=True,
+    use_nagl=True,
     work_dir=None,
     property_map={},
     **kwargs,
@@ -488,6 +489,11 @@ def _parameterise_openff(
         raised if this isn't the case, e.g. if atoms have been added. When True,
         the parameterised molecule will preserve the topology of the original
         molecule, e.g. the original atom and residue names will be kept.
+
+    use_nagl : bool
+        Whether to use NAGL to compute AM1-BCC charges. If False, the default
+        is to use AmberTools via antechamber and sqm. (This option is only
+        used if NAGL is available.)
 
     work_dir : str
         The working directory for the process.
@@ -583,12 +589,21 @@ def _parameterise_openff(
         if forcefield not in _forcefields_lower:
             raise ValueError("Supported force fields are: %s" % openForceFields())
 
+    if not isinstance(ensure_compatible, bool):
+        raise TypeError("'ensure_compatible' must be of type 'bool'.")
+
+    if not isinstance(use_nagl, bool):
+        raise TypeError("'use_nagl' must be of type 'bool'.")
+
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'")
 
     # Create a default protocol.
     protocol = _Protocol.OpenForceField(
-        forcefield, ensure_compatible=ensure_compatible, property_map=property_map
+        forcefield,
+        ensure_compatible=ensure_compatible,
+        use_nagl=use_nagl,
+        property_map=property_map,
     )
 
     # Run the parameterisation protocol in the background and return
@@ -1079,7 +1094,9 @@ def _make_amber_protein_function(name):
 # it conforms to sensible function naming standards, i.e. "-" and "."
 # characters replaced by underscores.
 def _make_openff_function(name):
-    def _function(molecule, ensure_compatible=True, work_dir=None, property_map={}):
+    def _function(
+        molecule, ensure_compatible=True, use_nagl=True, work_dir=None, property_map={}
+    ):
         """
         Parameterise a molecule using the named force field from the
         Open Force Field initiative.
@@ -1100,6 +1117,11 @@ def _make_openff_function(name):
             molecule will preserve the topology of the original molecule, e.g.
             the original atom and residue names will be kept.
 
+        use_nagl : bool
+            Whether to use NAGL to compute AM1-BCC charges. If False, the default
+            is to use AmberTools via antechamber and sqm. (This option is only
+            used if NAGL is available.)
+
         work_dir : str
             The working directory for the process.
 
@@ -1118,6 +1140,7 @@ def _make_openff_function(name):
             name,
             molecule,
             ensure_compatible=ensure_compatible,
+            use_nagl=use_nagl,
             work_dir=work_dir,
             property_map=property_map,
         )

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
@@ -24,6 +24,8 @@
 
 __all__ = ["_base_units", "_base_dimensions", "_sire_units_locals"]
 
+import sys as _sys
+
 from ._angle import *
 from ._area import *
 from ._charge import *
@@ -33,13 +35,17 @@ from ._pressure import *
 from ._temperature import *
 from ._time import *
 from ._volume import *
-
-import sys as _sys
+from ._type import Type as _Type
 
 _namespace = _sys.modules[__name__]
 
 # Create the list of base unit types.
 _base_units = [getattr(_namespace, var) for var in dir() if var[0] != "_"]
+# Filter out any non-Type objects. (This can happen when BioSimSpace is
+# wrapped by other tools, e.g. Maize.)
+_base_units = [
+    unit for unit in _base_units if isinstance(unit, type) and unit.__base__ == _Type
+]
 
 _base_dimensions = {}
 for unit in _base_units:

--- a/python/BioSimSpace/Types/_base_units.py
+++ b/python/BioSimSpace/Types/_base_units.py
@@ -24,6 +24,8 @@
 
 __all__ = ["_base_units", "_base_dimensions", "_sire_units_locals"]
 
+import sys as _sys
+
 from ._angle import *
 from ._area import *
 from ._charge import *
@@ -33,13 +35,17 @@ from ._pressure import *
 from ._temperature import *
 from ._time import *
 from ._volume import *
-
-import sys as _sys
+from ._type import Type as _Type
 
 _namespace = _sys.modules[__name__]
 
 # Create the list of base unit types.
 _base_units = [getattr(_namespace, var) for var in dir() if var[0] != "_"]
+# Filter out any non-Type objects. (This can happen when BioSimSpace is
+# wrapped by other tools, e.g. Maize.)
+_base_units = [
+    unit for unit in _base_units if isinstance(unit, type) and unit.__base__ == _Type
+]
 
 _base_dimensions = {}
 for unit in _base_units:

--- a/tests/IO/test_file_cache.py
+++ b/tests/IO/test_file_cache.py
@@ -15,7 +15,7 @@ def test_file_cache():
     """
 
     # Clear the file cache.
-    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
+    BSS.IO.clearCache()
 
     # Load the molecular system.
     s = BSS.IO.readMolecules(["tests/input/ala.crd", "tests/input/ala.top"])
@@ -82,6 +82,21 @@ def test_file_cache():
     # Make sure the number of atoms in the cache was decremented.
     assert BSS.IO._file_cache._cache._num_atoms == total_atoms - num_atoms
 
+    # Clear the file cache.
+    BSS.IO.clearCache()
+
+    # The cache should now be empty.
+    assert len(BSS.IO._file_cache._cache) == 0
+
+    # Disable the cache.
+    BSS.IO.disableCache()
+
+    # Write to PDB and GroTop format. The PDB from the cache should not be reused.
+    BSS.IO.saveMolecules(f"{tmp_path}/tmp5", s, ["pdb", "grotop"])
+
+    # The cache should still be empty.
+    assert len(BSS.IO._file_cache._cache) == 0
+
 
 @pytest.mark.skipif(
     has_amber is False or has_openff is False,
@@ -93,8 +108,11 @@ def test_file_cache_mol_nums():
     contain different MolNUms.
     """
 
+    # Enable the cache.
+    BSS.IO.enableCache()
+
     # Clear the file cache.
-    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
+    BSS.IO.clearCache()
 
     # Create an initial system.
     system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()

--- a/tests/Sandpit/Exscientia/IO/test_file_cache.py
+++ b/tests/Sandpit/Exscientia/IO/test_file_cache.py
@@ -16,7 +16,7 @@ def test_file_cache():
     """
 
     # Clear the file cache.
-    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
+    BSS.IO.clearCache()
 
     # Load the molecular system.
     s = BSS.IO.readMolecules([f"{root_fp}/input/ala.crd", f"{root_fp}/input/ala.top"])
@@ -83,6 +83,21 @@ def test_file_cache():
     # Make sure the number of atoms in the cache was decremented.
     assert BSS.IO._file_cache._cache._num_atoms == total_atoms - num_atoms
 
+    # Clear the file cache.
+    BSS.IO.clearCache()
+
+    # The cache should now be empty.
+    assert len(BSS.IO._file_cache._cache) == 0
+
+    # Disable the cache.
+    BSS.IO.disableCache()
+
+    # Write to PDB and GroTop format. The PDB from the cache should not be reused.
+    BSS.IO.saveMolecules(f"{tmp_path}/tmp5", s, ["pdb", "grotop"])
+
+    # The cache should still be empty.
+    assert len(BSS.IO._file_cache._cache) == 0
+
 
 @pytest.mark.skipif(
     has_amber is False or has_openff is False,
@@ -94,8 +109,11 @@ def test_file_cache_mol_nums():
     contain different MolNUms.
     """
 
+    # Enable the cache.
+    BSS.IO.enableCache()
+
     # Clear the file cache.
-    BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
+    BSS.IO.clearCache()
 
     # Create an initial system.
     system = BSS.Parameters.openff_unconstrained_2_0_0("CO").getMolecule().toSystem()


### PR DESCRIPTION
This PR adds support for using `openff-nagl` to generate partial charges during parameterisation. Rather than adding `openff-nagl` as a hard dependency, I decided to check for availability at runtime and selectively use it if available. The user can choose to disable NAGL when calling an OpenFF parameterisation function using `use_nagl=False`, in which case it will use AmberTools. To activate the feature, a user should only need to install `openff-nagl-base` and `openff-nagl-models` on top of the base BioSimSpace environment. Thankfully these are pinned against specific versions of `openff-toolkit`, so we should always be able to resolve a compatible environment. (The full `openff-nagl` package pulls in over 2GB of dependencies, so it is desirable to exclude it if it's not absolutely necessary.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods