### PR TITLE
Make handling of base units more robust

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
@@ -24,6 +24,8 @@
 
 __all__ = ["_base_units", "_base_dimensions", "_sire_units_locals"]
 
+import sys as _sys
+
 from ._angle import *
 from ._area import *
 from ._charge import *
@@ -34,12 +36,12 @@ from ._temperature import *
 from ._time import *
 from ._volume import *
 
-import sys as _sys
-
 _namespace = _sys.modules[__name__]
 
 # Create the list of base unit types.
-_base_units = [getattr(_namespace, var) for var in dir() if var[0] != "_"]
+_base_units = [
+    getattr(_namespace, var) for var in dir() if var[0] != "_" and isinstance(var, type)
+]
 
 _base_dimensions = {}
 for unit in _base_units:

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
@@ -38,10 +38,9 @@ from ._volume import *
 
 _namespace = _sys.modules[__name__]
 
-# Create the list of base unit types.
-_base_units = [
-    getattr(_namespace, var) for var in dir() if var[0] != "_" and isinstance(var, type)
-]
+_base_units = [getattr(_namespace, var) for var in dir() if var[0] != "_"]
+# Filter out modules
+_base_units = [unit for unit in _base_units if isinstance(unit, type)]
 
 _base_dimensions = {}
 for unit in _base_units:

--- a/python/BioSimSpace/Types/_base_units.py
+++ b/python/BioSimSpace/Types/_base_units.py
@@ -24,6 +24,8 @@
 
 __all__ = ["_base_units", "_base_dimensions", "_sire_units_locals"]
 
+import sys as _sys
+
 from ._angle import *
 from ._area import *
 from ._charge import *
@@ -34,12 +36,12 @@ from ._temperature import *
 from ._time import *
 from ._volume import *
 
-import sys as _sys
-
 _namespace = _sys.modules[__name__]
 
 # Create the list of base unit types.
-_base_units = [getattr(_namespace, var) for var in dir() if var[0] != "_"]
+_base_units = [
+    getattr(_namespace, var) for var in dir() if var[0] != "_" and isinstance(var, type)
+]
 
 _base_dimensions = {}
 for unit in _base_units:

--- a/python/BioSimSpace/Types/_base_units.py
+++ b/python/BioSimSpace/Types/_base_units.py
@@ -39,9 +39,9 @@ from ._volume import *
 _namespace = _sys.modules[__name__]
 
 # Create the list of base unit types.
-_base_units = [
-    getattr(_namespace, var) for var in dir() if var[0] != "_" and isinstance(var, type)
-]
+_base_units = [getattr(_namespace, var) for var in dir() if var[0] != "_"]
+# Filter out modules
+_base_units = [unit for unit in _base_units if isinstance(unit, type)]
 
 _base_dimensions = {}
 for unit in _base_units:


### PR DESCRIPTION
This ensures that only classes, and not modules, end up in the _base_units list. I am trying to integrate BSS-based code with [Maize](https://github.com/MolecularAI/maize/tree/public), and (during testing only) the _base_units_list would end up containing modules rather than just classes. Maize does a lot of messing around with the environment (it failed [here](https://github.com/MolecularAI/maize/blob/490ea9481e2afbb2336a683474cfe393c69f4b25/maize/core/node.py#L518)).

Also, Maize looks like a really neat solution for running BSS nodes/ workflows, with options to submit through slurm etc. I'm planning to convert some BSS nodes to Maize nodes and implement some workflows over the next few weeks.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges, @chryswoods
