### PR TITLE
Fix issue #270

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -792,7 +792,11 @@ class Molecule(_SireWrapper):
             if len(matches) < num_atoms0:
                 # Atom names or order might have changed. Try to match by coordinates.
                 matcher = _SireMol.AtomCoordMatcher()
-                matches = matcher.match(mol0, mol1)
+
+                try:
+                    matches = matcher.match(mol0, mol1)
+                except:
+                    matches = []
 
                 # We need to rename the atoms.
                 is_renamed = True
@@ -1003,7 +1007,11 @@ class Molecule(_SireWrapper):
                 matcher = _SireMol.AtomCoordMatcher()
 
                 # Get the matches for this molecule and append to the list.
-                match = matcher.match(mol0, mol)
+                try:
+                    match = matcher.match(mol0, mol)
+                except:
+                    match = []
+
                 matches.append(match)
                 num_matches += len(match)
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1888,6 +1888,7 @@ class System(_SireWrapper):
                     string = (
                         "(not water) and (resname "
                         + ",".join(_prot_res)
+                        + ","
                         + ",".join(_nucl_res)
                         + ") and (atomname N,CA,C,O,P,/C5'/,/C3'/,/O3'/,/O5'/)"
                     )
@@ -1943,6 +1944,7 @@ class System(_SireWrapper):
                             string = (
                                 "(not water) and (resname "
                                 + ",".join(_prot_res)
+                                + ","
                                 + ",".join(_nucl_res)
                                 + ") and (atomname N,CA,C,O,P,/C5'/,/C3'/,/O3'/,/O5'/)"
                             )

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_utils.py
@@ -22,8 +22,8 @@
 Utilities.
 """
 
-# A set of protein residues. Taken from MDAnalysis.
-_prot_res = {
+# A list of protein residues. Taken from MDAnalysis.
+_prot_res = [
     # CHARMM top_all27_prot_lipid.rtf
     "ALA",
     "ARG",
@@ -135,10 +135,10 @@ _prot_res = {
     "CMET",
     "CME",
     "ASF",
-}
+]
 
-# A set of nucleic acid residues. Taken from MDAnalysis.
-_nucl_res = {
+# A list of nucleic acid residues. Taken from MDAnalysis.
+_nucl_res = [
     "ADE",
     "URA",
     "CYT",
@@ -173,7 +173,7 @@ _nucl_res = {
     "RU3",
     "RG3",
     "RC3",
-}
+]
 
 # A list of ion elements.
 _ions = [

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -748,7 +748,11 @@ class Molecule(_SireWrapper):
             if len(matches) < num_atoms0:
                 # Atom names or order might have changed. Try to match by coordinates.
                 matcher = _SireMol.AtomCoordMatcher()
-                matches = matcher.match(mol0, mol1)
+
+                try:
+                    matches = matcher.match(mol0, mol1)
+                except:
+                    matches = []
 
                 # We need to rename the atoms.
                 is_renamed = True
@@ -959,7 +963,11 @@ class Molecule(_SireWrapper):
                 matcher = _SireMol.AtomCoordMatcher()
 
                 # Get the matches for this molecule and append to the list.
-                match = matcher.match(mol0, mol)
+                try:
+                    match = matcher.match(mol0, mol)
+                except:
+                    match = []
+
                 matches.append(match)
                 num_matches += len(match)
 

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1809,6 +1809,7 @@ class System(_SireWrapper):
                     string = (
                         "(not water) and (resname "
                         + ",".join(_prot_res)
+                        + ","
                         + ",".join(_nucl_res)
                         + ") and (atomname N,CA,C,O,P,/C5'/,/C3'/,/O3'/,/O5'/)"
                     )
@@ -1864,6 +1865,7 @@ class System(_SireWrapper):
                             string = (
                                 "(not water) and (resname "
                                 + ",".join(_prot_res)
+                                + ","
                                 + ",".join(_nucl_res)
                                 + ") and (atomname N,CA,C,O,P,/C5'/,/C3'/,/O3'/,/O5'/)"
                             )

--- a/python/BioSimSpace/_SireWrappers/_utils.py
+++ b/python/BioSimSpace/_SireWrappers/_utils.py
@@ -22,8 +22,8 @@
 Utilities.
 """
 
-# A set of protein residues. Taken from MDAnalysis.
-_prot_res = {
+# A list of protein residues. Taken from MDAnalysis.
+_prot_res = [
     # CHARMM top_all27_prot_lipid.rtf
     "ALA",
     "ARG",
@@ -135,10 +135,10 @@ _prot_res = {
     "CMET",
     "CME",
     "ASF",
-}
+]
 
-# A set of nucleic acid residues. Taken from MDAnalysis.
-_nucl_res = {
+# A list of nucleic acid residues. Taken from MDAnalysis.
+_nucl_res = [
     "ADE",
     "URA",
     "CYT",
@@ -173,7 +173,7 @@ _nucl_res = {
     "RU3",
     "RG3",
     "RC3",
-}
+]
 
 # A list of ion elements.
 _ions = [


### PR DESCRIPTION
This PR closes #270 by using a list rather than a set to store the names of protein and nucleic acid residues. This makes the search string for backbone atoms reproducible, hence the tests now repeatedly pass. I'm still not sure why this issue has only cropped up recently, since `_prot_res` has been a set since the code was first added.

```python
In [1]: x = {"1", "2", "3"}

In [2]: ",".join(x)
Out[2]: '2,3,1'

In [3]: x = ["1", "2", "3"]

In [4]: ",".join(x)
Out[4]: '1,2,3'
```

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods