### PR TITLE
Final fixes for the 2024.1.0 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,35 +63,35 @@ Conda package
 The easiest way to install BioSimSpace is using our `conda channel <https://anaconda.org/openbiosim/repo>`__.
 BioSimSpace is built using dependencies from `conda-forge <https://conda-forge.org/>`__,
 so please ensure that the channel takes strict priority. We recommend using
-`Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`__.
+`Miniforge <https://github.com/conda-forge/miniforge>`__.
 
 To create a new environment:
 
 .. code-block:: bash
 
-    mamba create -n openbiosim -c conda-forge -c openbiosim biosimspace
-    mamba activate openbiosim
+    conda create -n openbiosim -c conda-forge -c openbiosim biosimspace
+    conda activate openbiosim
 
 To install the latest development version you can use:
 
 .. code-block:: bash
 
-    mamba create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace
-    mamba activate openbiosim-dev
+    conda create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace
+    conda activate openbiosim-dev
 
 When updating the development version it is generally advised to update `Sire <https://github.com/openbiosim/sire>`_
 at the same time:
 
 .. code-block:: bash
 
-    mamba update -c conda-forge -c openbiosim/label/dev biosimspace sire
+    conda update -c conda-forge -c openbiosim/label/dev biosimspace sire
 
 Unless you add the required channels to your Conda configuration, then you'll
 need to add them when updating, e.g., for the development package:
 
 .. code-block:: bash
 
-    mamba update -c conda-forge -c openbiosim/label/dev biosimspace
+    conda update -c conda-forge -c openbiosim/label/dev biosimspace
 
 Installing from source
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -146,8 +146,8 @@ latest development code into that.
 
 .. code-block:: bash
 
-   mamba create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace --only-deps
-   mamba activate openbiosim-dev
+   conda create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace --only-deps
+   conda activate openbiosim-dev
    git clone https://github.com/openbiosim/biosimspace
    cd biosimspace/python
    BSS_SKIP_DEPENDENCIES=1 python setup.py develop

--- a/doc/source/contributing/packaging.rst
+++ b/doc/source/contributing/packaging.rst
@@ -4,12 +4,11 @@
 Development process
 ===================
 
-:mod:`BioSimSpace` uses a ``main``, ``devel`` and ``future`` development process,
+:mod:`BioSimSpace` uses a ``main`` and ``devel`` development process,
 using feature branches for all code development.
 
 * ``main`` - this always contains the latest official release.
 * ``devel`` - this always contains the latest development release, which will become the next official release.
-* ``future`` - this contains pull requests that have been accepted, but which are targetted for a future release (i.e. not the next official release)
 
 Code should be developed on a fork or in a feature branch called ``feature_{feature}``.
 When your feature is ready, please submit a pull request against ``devel``. This
@@ -27,29 +26,8 @@ tests, examples and/or tutorial instructions.
   the tutorials or writing a detailed description for the website.
 
 Assuming the CI completes successfully, then one of the release team will
-conduct a code review. The outcome of the review will be one of the following;
-
-1. This feature is ready, and should be part of the next official release. The pull request
-   will be accepted into ``devel``. This will trigger our CI/CD process, building the new dev
-   package and uploading it to `anaconda.org <https://anaconda.org/openbiosim/biosimspace>`__
-   for everyone to use.
-
-2. This feature is good, but it is not yet ready to be part of the next offical release. This
-   could be because the feature is part of a series, and all of the series need to be finished
-   before release. Or because we are in a feature freeze period. Or because you want more time
-   for people to explore and play with the feature before it is officially released (and would
-   then need to be supported, and backwards compatibility maintained). If this is the case (or
-   it is your request) then the pull request will be redirected into the ``future`` branch.
-   Once it (and features that depend on it) are ready, you can then issue a pull request for
-   all of the features at once into ``devel``. It will be noted that each of the individual
-   parts have already been code reviewed, so the process to accept the combination
-   into ``devel`` should be more straightforward.
-
-3. This feature is good, but more work is needed before it can be accepted. This could be
-   because some of the unit tests haven't passed, or the latest version of ``devel`` hasn't
-   been merged. Or there may be changes that are requested that would make the code easier
-   to maintain or to preserve backwards compatibility. If this is the case, then we
-   will engage in conversation with you and will work together to rectify any issues.
+conduct a code review, with the code being merged into ``devel`` if it is
+approved.
 
 Bug fixes or issue fixes are developed on fix branches, called ``fix_{number}`` (again in
 either the main repository or forks). If no `issue thread <https://github.com/OpenBioSim/biosimspace/issues>`__

--- a/doc/source/contributing/roadmap.rst
+++ b/doc/source/contributing/roadmap.rst
@@ -76,8 +76,6 @@ You can keep up with what we are working on in several ways;
 * Keep an eye on the various ``feature_X`` branches as they appear in the repository. Feel free to initiate
   a conversation on GitHub with the developer who is working on that branch if you want to learn more, or
   want to make suggestions or offer a helping hand.
-* Clone and build your own copy of the ``future`` branch. This is the bleeding edge, and things may change and break.
-  But it is the earliest way to use the future version of :mod:`BioSimSpace`.
 
 Wishlists / suggestions
 =======================

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -46,27 +46,25 @@ The easiest way to install :mod:`BioSimSpace` is in a new
 `conda environment <https://anaconda.org>`__.
 
 You can use any conda environment or installation. We recommend using
-`mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`__,
-as this is pre-configured to use `conda-forge <https://conda-forge.org>`__,
-and bundles `mamba <https://mamba.readthedocs.io/en/latest/>`__, which
-is a fast drop-in replacement for `conda <https://conda.io>`__.
+`Miniforge <https://github.com/conda-forge/miniforge>`__,
+as this is pre-configured to use `conda-forge <https://conda-forge.org>`__.
 
-.. _Install_Mambaforge:
-Either... Install a new copy of ``mambaforge``
+.. _Install_Miniforge:
+Either... Install a new copy of ``Miniforge``
 ----------------------------------------------
 
 To install a new copy of
-`mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`__,
-first download a ``Mambaforge`` from
-`this page <https://github.com/conda-forge/miniforge#mambaforge>`__ that
+`Miniforge <https://github.com/conda-forge/miniforge>`__,
+first download a ``Miniforge`` from
+`this page <https://github.com/conda-forge/miniforge>`__ that
 matches your operating system and processor.
 
-Install ``Mambaforge`` following the
+Install ``Miniforge`` following the
 `instructions here <https://github.com/conda-forge/miniforge#install>`__.
 
-Once installed, you should be able to run the ``mamba`` command to
-install other packages (e.g. ``mamba -h`` will print out help on
-how to use the ``mamba`` command).
+Once installed, you should be able to run the ``conda`` command to
+install other packages (e.g. ``conda -h`` will print out help on
+how to use the ``conda`` command).
 
 Or... Use an existing anaconda/miniconda install
 ------------------------------------------------
@@ -80,21 +78,7 @@ the full path to your anaconda or miniconda installation.
 
 You should now be able to run the ``conda`` command to install other
 packages (e.g. ``conda -h`` will print out help on how to use the
-``conda`` command). We highly recommend that you use ``mamba`` as a
-drop-in replacement for ``conda``, so first install ``mamba``.
-
-.. code-block:: bash
-
-   $ conda install -c conda-forge mamba
-
-This should install mamba. If this fails, then your anaconda or miniconda
-environment is likely quite full, or else it is outdated. We recommend
-going back and following `the instructions <_Install_Mambaforge>`
-to install a new copy of ``mambaforge``.
-
-If this works, then you should now be able to run the ``mamba`` command
-to install other packages (e.g. ``mamba -h`` will print out help
-on how to use the ``mamba`` command).
+``conda`` command).
 
 And then... Install BioSimSpace into a new environment
 ------------------------------------------------------
@@ -107,7 +91,7 @@ by creating a Python 3.9 environment that we will call ``openbiosim``.
 
 .. code-block:: bash
 
-   $ mamba create -n openbiosim "python<3.10"
+   $ conda create -n openbiosim "python<3.10"
 
 .. note::
 
@@ -118,27 +102,27 @@ We can now install :mod:`BioSimSpace` into that environment by typing
 
 .. code-block:: bash
 
-   $ mamba install -n openbiosim -c openbiosim biosimspace
+   $ conda install -n openbiosim -c openbiosim biosimspace
 
 .. note::
 
-   The option ``-n openbiosim`` tells ``mamba`` to install :mod:`BioSimSpace`
+   The option ``-n openbiosim`` tells ``conda`` to install :mod:`BioSimSpace`
    into the ``openbiosim`` environment. The option ``-c openbiosim``
-   tells ``mamba`` to install :mod:`BioSimSpace` from the ``openbiosim``
+   tells ``conda`` to install :mod:`BioSimSpace` from the ``openbiosim``
    conda channel.
 
 If you want the latest development release, then install by typing
 
 .. code-block:: bash
 
-   $ mamba install -n openbiosim -c "openbiosim/label/dev" biosimspace
+   $ conda install -n openbiosim -c "openbiosim/label/dev" biosimspace
 
 To install the latest development version you can use:
 
 .. code-block:: bash
 
-    mamba create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace
-    mamba activate openbiosim-dev
+    conda create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace
+    conda activate openbiosim-dev
 
 To run :mod:`BioSimSpace`, you must now activate the ``openbiosim`` environment.
 You can do this by typing
@@ -268,8 +252,8 @@ latest development code into that.
 
 .. code-block:: bash
 
-   mamba create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace --only-deps
-   mamba activate openbiosim-dev
+   conda create -n openbiosim-dev -c conda-forge -c openbiosim/label/dev biosimspace --only-deps
+   conda activate openbiosim-dev
    git clone https://github.com/openbiosim/biosimspace
    cd biosimspace/python
    BSS_SKIP_DEPENDENCIES=1 python setup.py develop

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -406,7 +406,7 @@ class Relative:
                     )
 
             # Write to the zip file.
-            with _zipfile.ZipFile(cwd + f"/{zipname}", "w") as zip:
+            with _zipfile.Zipfile(_os.join(cwd, zipname), "w") as zip:
                 for file in files:
                     zip.write(file)
 
@@ -2074,15 +2074,15 @@ class Relative:
                     process._system = first_process._system.copy()
                     process._protocol = self._protocol
                     process._work_dir = new_dir
-                    process._std_out_file = new_dir + "/somd.out"
-                    process._std_err_file = new_dir + "/somd.err"
-                    process._rst_file = new_dir + "/somd.rst7"
-                    process._top_file = new_dir + "/somd.prm7"
-                    process._traj_file = new_dir + "/traj000000001.dcd"
-                    process._restart_file = new_dir + "/latest.rst"
-                    process._config_file = new_dir + "/somd.cfg"
-                    process._pert_file = new_dir + "/somd.pert"
-                    process._gradients_file = new_dir + "/gradients.dat"
+                    process._std_out_file = _os.path.join(new_dir, "somd.out")
+                    process._std_err_file = _os.path.join(new_dir, "somd.err")
+                    process._rst_file = _os.path.join(new_dir, "somd.rst7")
+                    process._top_file = _os.path.join(new_dir, "somd.prm7")
+                    process._traj_file = _os.path.join(new_dir, "traj000000001.dcd")
+                    process._restart_file = _os.path.join(new_dir, "latest.rst")
+                    process._config_file = _os.path.join(new_dir, "somd.cfg")
+                    process._pert_file = _os.path.join(new_dir, "somd.pert")
+                    process._gradients_file = _os.path.join(new_dir, "gradients.dat")
                     process._input_files = [
                         process._config_file,
                         process._rst_file,
@@ -2106,10 +2106,10 @@ class Relative:
                     for line in new_config:
                         f.write(line)
 
-                mdp = new_dir + "/gromacs.mdp"
-                gro = new_dir + "/gromacs.gro"
-                top = new_dir + "/gromacs.top"
-                tpr = new_dir + "/gromacs.tpr"
+                mdp = _os.path.join(new_dir, "gromacs.mdp")
+                gro = _os.path.join(new_dir, "gromacs.gro")
+                top = _os.path.join(new_dir, "gromacs.top")
+                tpr = _os.path.join(new_dir, "gromacs.tpr")
 
                 # Use grompp to generate the portable binary run input file.
                 _Process.Gromacs._generate_binary_run_file(
@@ -2129,14 +2129,14 @@ class Relative:
                     process._system = first_process._system.copy()
                     process._protocol = self._protocol
                     process._work_dir = new_dir
-                    process._std_out_file = new_dir + "/gromacs.out"
-                    process._std_err_file = new_dir + "/gromacs.err"
-                    process._gro_file = new_dir + "/gromacs.gro"
-                    process._top_file = new_dir + "/gromacs.top"
-                    process._ref_file = new_dir + "/gromacs_ref.gro"
-                    process._traj_file = new_dir + "/gromacs.trr"
-                    process._config_file = new_dir + "/gromacs.mdp"
-                    process._tpr_file = new_dir + "/gromacs.tpr"
+                    process._std_out_file = _os.path.join(new_dir, "gromacs.out")
+                    process._std_err_file = _os.path.join(new_dir, "gromacs.err")
+                    process._gro_file = _os.path.join(new_dir, "gromacs.gro")
+                    process._top_file = _os.path.join(new_dir, "gromacs.top")
+                    process._ref_file = _os.path.join(new_dir, "gromacs_ref.gro")
+                    process._traj_file = _os.path.join(new_dir, "gromacs.trr")
+                    process._config_file = _os.path.join(new_dir, "gromacs.mdp")
+                    process._tpr_file = _os.path.join(new_dir, "gromacs.tpr")
                     process._input_files = [
                         process._config_file,
                         process._gro_file,
@@ -2165,14 +2165,14 @@ class Relative:
                     process._system = first_process._system.copy()
                     process._protocol = self._protocol
                     process._work_dir = new_dir
-                    process._std_out_file = new_dir + "/amber.out"
-                    process._std_err_file = new_dir + "/amber.err"
-                    process._rst_file = new_dir + "/amber.rst7"
-                    process._top_file = new_dir + "/amber.prm7"
-                    process._ref_file = new_dir + "/amber_ref.rst7"
-                    process._traj_file = new_dir + "/amber.nc"
-                    process._config_file = new_dir + "/amber.cfg"
-                    process._nrg_file = new_dir + "/amber.nrg"
+                    process._std_out_file = _os.path.join(new_dir, "amber.out")
+                    process._std_err_file = _os.path.join(new_dir, "amber.err")
+                    process._rst_file = _os.path.join(new_dir, "amber.rst7")
+                    process._top_file = _os.path.join(new_dir, "amber.prm7")
+                    process._ref_file = _os.path.join(new_dir, "amber_ref.rst7")
+                    process._traj_file = _os.path.join(new_dir, "amber.nc")
+                    process._config_file = _os.path.join(new_dir, "amber.cfg")
+                    process._nrg_file = _os.path.join(new_dir, "amber.nrg")
                     process._input_files = [
                         process._config_file,
                         process._rst_file,

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -552,7 +552,7 @@ class AmberProtein(_protocol.Protocol):
         ) and _os.path.isfile(_os.path.join(str(work_dir), "leap.crd")):
             # Check the output of tLEaP for missing atoms.
             if self._ensure_compatible:
-                if _has_missing_atoms(_os.path.join(str(work_dir), "leap.top")):
+                if _has_missing_atoms(_os.path.join(str(work_dir), "leap.out")):
                     raise _ParameterisationError(
                         "tLEaP added missing atoms. The topology is now "
                         "inconsistent with the original molecule. Please "

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -384,8 +384,8 @@ class OpenForceField(_protocol.Protocol):
 
         # Export AMBER format files.
         try:
-            interchange.to_prmtop(_os.path.join(str(work_dir), "interchange.prmtop"))
-            interchange.to_inpcrd(_os.path.join(str(work_dir), "interchange.inpcrd"))
+            interchange.to_prmtop(_os.path.join(str(work_dir), "interchange.prm7"))
+            interchange.to_inpcrd(_os.path.join(str(work_dir), "interchange.rst7"))
         except Exception as e:
             msg = "Unable to write Interchange object to AMBER format!"
             if _isVerbose():
@@ -398,8 +398,8 @@ class OpenForceField(_protocol.Protocol):
         try:
             par_mol = _IO.readMolecules(
                 [
-                    _os.path.join(str(work_dir), "interchange.prmtop"),
-                    _os.path.join(str(work_dir), "interchange.inpcrd"),
+                    _os.path.join(str(work_dir), "interchange.prm7"),
+                    _os.path.join(str(work_dir), "interchange.rst7"),
                 ],
             )
             # Extract single molecules.

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -214,9 +214,6 @@ class OpenForceField(_protocol.Protocol):
         if work_dir is None:
             work_dir = _os.getcwd()
 
-        # Create the file prefix.
-        prefix = work_dir + "/"
-
         # Flag whether the molecule is a SMILES string.
         if isinstance(molecule, str):
             is_smiles = True
@@ -256,7 +253,7 @@ class OpenForceField(_protocol.Protocol):
                 # Write the molecule to SDF format.
                 try:
                     _IO.saveMolecules(
-                        prefix + "molecule",
+                        _os.path.join(str(work_dir), "molecule"),
                         molecule,
                         "sdf",
                         property_map=self._property_map,
@@ -275,7 +272,7 @@ class OpenForceField(_protocol.Protocol):
                 # Write the molecule to a PDB file.
                 try:
                     _IO.saveMolecules(
-                        prefix + "molecule",
+                        _os.path.join(str(work_dir), "molecule"),
                         molecule,
                         "pdb",
                         property_map=self._property_map,
@@ -291,7 +288,7 @@ class OpenForceField(_protocol.Protocol):
                 # Create an RDKit molecule from the PDB file.
                 try:
                     rdmol = _Chem.MolFromPDBFile(
-                        prefix + "molecule.pdb", removeHs=False
+                        _os.path.join(str(work_dir), "molecule.pdb"), removeHs=False
                     )
                 except Exception as e:
                     msg = "RDKit was unable to read the molecular PDB file!"
@@ -303,7 +300,9 @@ class OpenForceField(_protocol.Protocol):
 
                 # Use RDKit to write back to SDF format.
                 try:
-                    writer = _Chem.SDWriter(prefix + "molecule.sdf")
+                    writer = _Chem.SDWriter(
+                        _os.path.join(str(work_dir), "molecule.sdf")
+                    )
                     writer.write(rdmol)
                     writer.close()
                 except Exception as e:
@@ -317,7 +316,9 @@ class OpenForceField(_protocol.Protocol):
             # Create the Open Forcefield Molecule from the intermediate SDF file,
             # as recommended by @j-wags and @mattwthompson.
             try:
-                off_molecule = _OpenFFMolecule.from_file(prefix + "molecule.sdf")
+                off_molecule = _OpenFFMolecule.from_file(
+                    _os.path.join(str(work_dir), "molecule.sdf")
+                )
             except Exception as e:
                 msg = "Unable to create OpenFF Molecule!"
                 if _isVerbose():
@@ -383,8 +384,8 @@ class OpenForceField(_protocol.Protocol):
 
         # Export AMBER format files.
         try:
-            interchange.to_prmtop(prefix + "interchange.prm7")
-            interchange.to_inpcrd(prefix + "interchange.rst7")
+            interchange.to_prmtop(_os.path.join(str(work_dir), "interchange.prmtop"))
+            interchange.to_inpcrd(_os.path.join(str(work_dir), "interchange.inpcrd"))
         except Exception as e:
             msg = "Unable to write Interchange object to AMBER format!"
             if _isVerbose():
@@ -396,7 +397,10 @@ class OpenForceField(_protocol.Protocol):
         # Load the parameterised molecule. (This could be a system of molecules.)
         try:
             par_mol = _IO.readMolecules(
-                [prefix + "interchange.prm7", prefix + "interchange.rst7"]
+                [
+                    _os.path.join(str(work_dir), "interchange.prmtop"),
+                    _os.path.join(str(work_dir), "interchange.inpcrd"),
+                ],
             )
             # Extract single molecules.
             if par_mol.nMolecules() == 1:

--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -235,15 +235,15 @@ class Amber(_process.Process):
         self._is_header = False
 
         # The names of the input files.
-        self._rst_file = "%s/%s.rst7" % (self._work_dir, name)
-        self._top_file = "%s/%s.prm7" % (self._work_dir, name)
-        self._ref_file = "%s/%s_ref.rst7" % (self._work_dir, name)
+        self._rst_file = _os.path.join(str(self._work_dir), f"{name}.rst7")
+        self._top_file = _os.path.join(str(self._work_dir), f"{name}.prm7")
+        self._ref_file = _os.path.join(str(self._work_dir), f"{name}_ref.rst7")
 
         # The name of the trajectory file.
-        self._traj_file = "%s/%s.nc" % (self._work_dir, name)
+        self._traj_file = _os.path.join(str(self._work_dir), f"{name}.nc")
 
         # Set the path for the AMBER configuration file.
-        self._config_file = "%s/%s.cfg" % (self._work_dir, name)
+        self._config_file = _os.path.join(str(self._work_dir), f"{name}.cfg")
 
         # Create the list of input files.
         self._input_files = [self._config_file, self._rst_file, self._top_file]
@@ -400,7 +400,9 @@ class Amber(_process.Process):
             if auxiliary_files is not None:
                 for file in auxiliary_files:
                     file_name = _os.path.basename(file)
-                    _shutil.copyfile(file, self._work_dir + f"/{file_name}")
+                    _shutil.copyfile(
+                        file, _os.path.join(str(self._work_dir), file_name)
+                    )
             self._input_files.append(self._plumed_config_file)
 
             # Expose the PLUMED specific member functions.
@@ -534,7 +536,7 @@ class Amber(_process.Process):
             _warnings.warn("The process exited with an error!")
 
         # Create the name of the restart CRD file.
-        restart = "%s/%s.crd" % (self._work_dir, self._name)
+        restart = _os.path.join(str(self._work_dir), "%s.crd" % self._name)
 
         # Check that the file exists.
         if _os.path.isfile(restart):

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -208,18 +208,18 @@ class Gromacs(_process.Process):
         self._energy_file = "%s/%s.edr" % (self._work_dir, name)
 
         # The names of the input files.
-        self._gro_file = "%s/%s.gro" % (self._work_dir, name)
-        self._top_file = "%s/%s.top" % (self._work_dir, name)
-        self._ref_file = "%s/%s_ref.gro" % (self._work_dir, name)
+        self._gro_file = _os.path.join(str(self._work_dir), f"{name}.gro")
+        self._top_file = _os.path.join(str(self._work_dir), f"{name}.top")
+        self._ref_file = _os.path.join(str(self._work_dir), f"{name}_ref.gro")
 
         # The name of the trajectory file.
-        self._traj_file = "%s/%s.trr" % (self._work_dir, name)
+        self._traj_file = _os.path.join(str(self._work_dir), f"{name}.trr")
 
         # The name of the output coordinate file.
-        self._crd_file = "%s/%s_out.gro" % (self._work_dir, name)
+        self._crd_file = _os.path.join(str(self._work_dir), f"{name}_out.gro")
 
         # Set the path for the GROMACS configuration file.
-        self._config_file = "%s/%s.mdp" % (self._work_dir, name)
+        self._config_file = _os.path.join(str(self._work_dir), f"{name}.mdp")
 
         # Create the list of input files.
         self._input_files = [self._config_file, self._gro_file, self._top_file]
@@ -314,7 +314,7 @@ class Gromacs(_process.Process):
         )
 
         # Create the binary input file name.
-        self._tpr_file = "%s/%s.tpr" % (self._work_dir, self._name)
+        self._tpr_file = _os.path.join(str(self._work_dir), f"{self._name}.tpr")
         self._input_files.append(self._tpr_file)
 
         # Generate the GROMACS configuration file.
@@ -397,7 +397,9 @@ class Gromacs(_process.Process):
             if auxiliary_files is not None:
                 for file in auxiliary_files:
                     file_name = _os.path.basename(file)
-                    _shutil.copyfile(file, self._work_dir + f"/{file_name}")
+                    _shutil.copyfile(
+                        file, _os.path.join(str(self._work_dir), file_name)
+                    )
             self._input_files.append(self._plumed_config_file)
 
             # Expose the PLUMED specific member functions.
@@ -423,7 +425,9 @@ class Gromacs(_process.Process):
             if auxiliary_files is not None:
                 for file in auxiliary_files:
                     file_name = _os.path.basename(file)
-                    _shutil.copyfile(file, self._work_dir + f"/{file_name}")
+                    _shutil.copyfile(
+                        file, _os.path.join(str(self._work_dir), file_name)
+                    )
             self._input_files.append(self._plumed_config_file)
 
             # Expose the PLUMED specific member functions.
@@ -2122,7 +2126,9 @@ class Gromacs(_process.Process):
                     if len(restrained_atoms) > 0:
                         # Create the file names.
                         include_file = "posre_%04d.itp" % num_restraint
-                        restraint_file = "%s/%s" % (self._work_dir, include_file)
+                        restraint_file = _os.path.join(
+                            str(self._work_dir), include_file
+                        )
 
                         with open(restraint_file, "w") as file:
                             # Write the header.
@@ -2206,7 +2212,9 @@ class Gromacs(_process.Process):
                     if len(atom_idxs) > 0:
                         # Create the file names.
                         include_file = "posre_%04d.itp" % num_restraint
-                        restraint_file = "%s/%s" % (self._work_dir, include_file)
+                        restraint_file = _os.path.join(
+                            str(self._work_dir), include_file
+                        )
 
                         with open(restraint_file, "w") as file:
                             # Write the header.
@@ -2735,11 +2743,12 @@ class Gromacs(_process.Process):
                 return old_system
 
         except:
+            raise
             _warnings.warn(
                 "Failed to extract trajectory frame with trjconv. "
                 "Try running 'getSystem' again."
             )
-            frame = "%s/frame.gro" % self._work_dir
+            frame = _os.path.join(str(self._work_dir), "frame.gro")
             if _os.path.isfile(frame):
                 _os.remove(frame)
             return None
@@ -2759,7 +2768,7 @@ class Gromacs(_process.Process):
         # Check that the current trajectory file is found.
         if not _os.path.isfile(self._traj_file):
             # If not, first check for any trr extension.
-            traj_file = _glob.glob("%s/*.trr" % self._work_dir)
+            traj_file = _glob.glob(_os.path.join(str(self._work_dir), "*.trr"))
 
             # Store the number of trr files.
             num_trr = len(traj_file)
@@ -2769,7 +2778,7 @@ class Gromacs(_process.Process):
                 return traj_file[0]
             else:
                 # Now check for any xtc files.
-                traj_file = _glob.glob("%s/*.xtc" % self._work_dir)
+                traj_file = _glob.glob(_os.path.join(str(self._work_dir), "*.xtc"))
 
                 if len(traj_file) == 1:
                     return traj_file[0]

--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -148,17 +148,17 @@ class Namd(_process.Process):
         self._stdout_title = None
 
         # The names of the input files.
-        self._psf_file = "%s/%s.psf" % (self._work_dir, name)
-        self._top_file = "%s/%s.pdb" % (self._work_dir, name)
-        self._param_file = "%s/%s.params" % (self._work_dir, name)
+        self._psf_file = _os.path.join(str(self._work_dir), f"{name}.psf")
+        self._top_file = _os.path.join(str(self._work_dir), f"{name}.pdb")
+        self._param_file = _os.path.join(str(self._work_dir), f"{name}.params")
         self._velocity_file = None
         self._restraint_file = None
 
         # The name of the trajectory file.
-        self._traj_file = "%s/%s_out.dcd" % (self._work_dir, name)
+        self._traj_file = _os.path.join(str(self._work_dir), f"{name}_out.dcd")
 
         # Set the path for the NAMD configuration file.
-        self._config_file = "%s/%s.cfg" % (self._work_dir, name)
+        self._config_file = _os.path.join(str(self._work_dir), f"{name}.cfg")
 
         # Create the list of input files.
         self._input_files = [
@@ -443,9 +443,8 @@ class Namd(_process.Process):
                     p = _SireIO.PDB2(restrained._sire_object, {prop: "restrained"})
 
                     # File name for the restraint file.
-                    self._restraint_file = "%s/%s.restrained" % (
-                        self._work_dir,
-                        self._name,
+                    self._restraint_file = _os.path.join(
+                        str(self._work_dir), f"{self._name}.restrained"
                     )
 
                     # Write the PDB file.
@@ -733,13 +732,19 @@ class Namd(_process.Process):
         has_coor = False
 
         # First check for final configuration.
-        if _os.path.isfile("%s/%s_out.coor" % (self._work_dir, self._name)):
-            coor_file = "%s/%s_out.coor" % (self._work_dir, self._name)
+        if _os.path.isfile(
+            _os.path.join(str(self._work_dir), f"{self._name}_out.coor")
+        ):
+            coor_file = _os.path.join(str(self._work_dir), f"{self._name}_out.coor")
             has_coor = True
 
         # Otherwise check for a restart file.
-        elif _os.path.isfile("%s/%s_out.restart.coor" % (self._work_dir, self._name)):
-            coor_file = "%s/%s_out.restart.coor" % (self._work_dir, self._name)
+        elif _os.path.isfile(
+            _os.path.join(str(self._work_dir), f"{self._name}_out.restart.coor")
+        ):
+            coor_file = _os.path.join(
+                str(self._work_dir), f"{self._name}_out.restart.coor"
+            )
             has_coor = True
 
         # Try to find an XSC file.
@@ -747,13 +752,17 @@ class Namd(_process.Process):
         has_xsc = False
 
         # First check for final XSC file.
-        if _os.path.isfile("%s/%s_out.xsc" % (self._work_dir, self._name)):
-            xsc_file = "%s/%s_out.xsc" % (self._work_dir, self._name)
+        if _os.path.isfile(_os.path.join(str(self._work_dir), f"{self._name}_out.xsc")):
+            xsc_file = _os.path.join(str(self._work_dir), f"{self._name}_out.xsc")
             has_xsc = True
 
         # Otherwise check for a restart XSC file.
-        elif _os.path.isfile("%s/%s_out.restart.xsc" % (self._work_dir, self._name)):
-            xsc_file = "%s/%s_out.restart.xsc" % (self._work_dir, self._name)
+        elif _os.path.isfile(
+            _os.path.join(str(self._work_dir), f"{self._name}_out.restart.xsc")
+        ):
+            xsc_file = _os.path.join(
+                str(self._work_dir), f"{self._name}_out.restart.xsc"
+            )
             has_xsc = True
 
         # We found a coordinate file.

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -174,7 +174,7 @@ class OpenMM(_process.Process):
         self._stdout_dict = _process._MultiDict()
 
         # Store the name of the OpenMM log file.
-        self._log_file = "%s/%s.log" % (self._work_dir, name)
+        self._log_file = _os.path.join(str(self._work_dir), f"{name}.log")
 
         # Initialise the log file separator.
         self._record_separator = None
@@ -184,16 +184,16 @@ class OpenMM(_process.Process):
 
         # The names of the input files. We choose to use AMBER files since they
         # are self-contained, but could equally work with GROMACS files.
-        self._rst_file = "%s/%s.rst7" % (self._work_dir, name)
-        self._top_file = "%s/%s.prm7" % (self._work_dir, name)
-        self._ref_file = "%s/%s_ref.rst7" % (self._work_dir, name)
+        self._rst_file = _os.path.join(str(self._work_dir), f"{name}.rst7")
+        self._top_file = _os.path.join(str(self._work_dir), f"{name}.prm7")
+        self._ref_file = _os.path.join(str(self._work_dir), f"{name}_ref.rst7")
 
         # The name of the trajectory file.
-        self._traj_file = "%s/%s.dcd" % (self._work_dir, name)
+        self._traj_file = _os.path.join(str(self._work_dir), f"{name}.dcd")
 
         # Set the path for the OpenMM Python script. (We use the concept of a
         # config file for consistency with other Process classes.)
-        self._config_file = "%s/%s_script.py" % (self._work_dir, name)
+        self._config_file = _os.path.join(str(self._work_dir), f"{name}_script.py")
 
         # Create the list of input files.
         self._input_files = [self._config_file, self._rst_file, self._top_file]
@@ -772,7 +772,7 @@ class OpenMM(_process.Process):
             )
 
             # Copy the file into the working directory.
-            _shutil.copyfile(path, self._work_dir + f"/{aux_file}")
+            _shutil.copyfile(path, _os.path.join(str(self._work_dir), aux_file))
 
             # The following OpenMM native implementation of the funnel metadynamics protocol
             # is adapted from funnel_maker.py by Dominykas Lukauskis.
@@ -970,9 +970,13 @@ class OpenMM(_process.Process):
 
             # Get the number of steps to date.
             step = 0
-            if _os.path.isfile(f"{self._work_dir}/{self._name}.xml"):
-                if _os.path.isfile(f"{self._work_dir}/{self._name}.log"):
-                    with open(f"{self._work_dir}/{self._name}.log", "r") as f:
+            if _os.path.isfile(_os.path.join(str(self._work_dir), f"{self._name}.xml")):
+                if _os.path.isfile(
+                    _os.path.join(str(self._work_dir), f"{self._name}.log")
+                ):
+                    with open(
+                        _os.path.join(str(self._work_dir), f"{self._name}.log"), "r"
+                    ) as f:
                         lines = f.readlines()
                         last_line = lines[-1].split()
                         try:
@@ -2031,8 +2035,10 @@ class OpenMM(_process.Process):
         self.addToConfig("else:")
         self.addToConfig("    is_restart = False")
 
-        if _os.path.isfile(f"{self._work_dir}/{self._name}.xml"):
-            with open(f"{self._work_dir}/{self._name}.log", "r") as f:
+        if _os.path.isfile(_os.path.join(str(self._work_dir), f"{self._name}.xml")):
+            with open(
+                _os.path.join(str(self._work_dir), f"{self._name}.log"), "r"
+            ) as f:
                 lines = f.readlines()
                 last_line = lines[-1].split()
                 step = int(last_line[0])

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -117,8 +117,8 @@ class Plumed:
         self._work_dir = work_dir
 
         # Set the location of the HILLS and COLVAR files.
-        self._hills_file = "%s/HILLS" % self._work_dir
-        self._colvar_file = "%s/COLVAR" % self._work_dir
+        self._hills_file = _os.path.join(str(self._work_dir), "HILLS")
+        self._colvar_file = _os.path.join(str(self._work_dir), "COLVAR")
 
         # The number of collective variables and total number of components.
         self._num_colvar = 0
@@ -250,11 +250,11 @@ class Plumed:
 
         # Always remove pygtail offset files.
         try:
-            _os.remove("%s/COLVAR.offset" % self._work_dir)
+            _os.remove(_os.path.join(str(self._work_dir), "COLVAR.offset"))
         except:
             pass
         try:
-            _os.remove("%s/HILLS.offset" % self._work_dir)
+            _os.remove(_os.path.join(str(self._work_dir), "HILLS.offset"))
         except:
             pass
 
@@ -627,7 +627,9 @@ class Plumed:
                 colvar_string += " TYPE=%s" % colvar.getAlignmentType().upper()
 
                 # Write the reference PDB file.
-                with open("%s/reference.pdb" % self._work_dir, "w") as file:
+                with open(
+                    _os.path.join(str(self._work_dir), "reference.pdb"), "w"
+                ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")
 
@@ -870,7 +872,9 @@ class Plumed:
             metad_string += (
                 " GRID_WFILE=GRID GRID_WSTRIDE=%s" % protocol.getHillFrequency()
             )
-            if is_restart and _os.path.isfile(f"{self._work_dir}/GRID"):
+            if is_restart and _os.path.isfile(
+                _os.path.join(str(self._work_dir), "GRID")
+            ):
                 metad_string += " GRID_RFILE=GRID"
             metad_string += " CALC_RCT"
 
@@ -940,7 +944,7 @@ class Plumed:
 
         # Always remove pygtail offset files.
         try:
-            _os.remove("%s/COLVAR.offset" % self._work_dir)
+            _os.remove(_os.path.join(str(self._work_dir), "COLVAR.offset"))
         except:
             pass
 
@@ -1225,7 +1229,8 @@ class Plumed:
 
                 # Write the reference PDB file.
                 with open(
-                    "%s/reference_%i.pdb" % (self._work_dir, num_rmsd), "w"
+                    _os.path.join(str(self._work_dir), "reference_%i.pdb" % num_rmsd),
+                    "w",
                 ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")
@@ -1449,8 +1454,8 @@ class Plumed:
             raise ValueError("'kt' must have value > 0")
 
         # Delete any existing FES directotry and create a new one.
-        _shutil.rmtree(f"{self._work_dir}/fes", ignore_errors=True)
-        _os.makedirs(f"{self._work_dir}/fes")
+        _shutil.rmtree(_os.path.join(str(self._work_dir), "fes"), ignore_errors=True)
+        _os.makedirs(_os.path.join(str(self._work_dir), "fes"))
 
         # Create the command string.
         command = "%s sum_hills --hills ../HILLS --mintozero" % self._exe
@@ -1466,7 +1471,7 @@ class Plumed:
         free_energies = []
 
         # Move to the working directory.
-        with _Utils.cd(self._work_dir + "/fes"):
+        with _Utils.cd(_os.path.join(str(self._work_dir), "fes")):
             # Run the sum_hills command as a background process.
             proc = _subprocess.run(
                 _Utils.command_split(command),
@@ -1556,7 +1561,7 @@ class Plumed:
                 _os.remove(fes)
 
         # Remove the FES output directory.
-        _shutil.rmtree(f"{self._work_dir}/fes", ignore_errors=True)
+        _shutil.rmtree(_os.path.join(str(self._work_dir), "fes"), ignore_errors=True)
 
         return tuple(free_energies)
 

--- a/python/BioSimSpace/Process/_process.py
+++ b/python/BioSimSpace/Process/_process.py
@@ -281,11 +281,11 @@ class Process:
             self._work_dir = _Utils.WorkDir(work_dir)
 
         # Files for redirection of stdout and stderr.
-        self._stdout_file = "%s/%s.out" % (self._work_dir, name)
-        self._stderr_file = "%s/%s.err" % (self._work_dir, name)
+        self._stdout_file = _os.path.join(str(self._work_dir), f"{name}.out")
+        self._stderr_file = _os.path.join(str(self._work_dir), f"{name}.err")
 
         # Files for metadynamics simulation with PLUMED.
-        self._plumed_config_file = "%s/plumed.dat" % self._work_dir
+        self._plumed_config_file = _os.path.join(str(self._work_dir), "plumed.dat")
         self._plumed_config = None
 
         # Initialise the configuration file string list.
@@ -349,13 +349,13 @@ class Process:
         self._stderr = []
 
         # Clean up any existing offset files.
-        offset_files = _glob.glob("%s/*.offset" % self._work_dir)
+        offset_files = _glob.glob(_os.path.join(str(self._work_dir), "*.offset"))
 
         # Remove any HILLS or COLVAR files from the list. These will be dealt
         # with by the PLUMED interface.
         try:
-            offset_files.remove("%s/COLVAR.offset" % self._work_dir)
-            offset_files.remove("%s/HILLS.offset" % self._work_dir)
+            offset_files.remove(_os.path.join(str(self._work_dir), "COLVAR.offset"))
+            offset_files.remove(_os.path.join(str(self._work_dir), "HILLS.offset"))
         except:
             pass
 
@@ -1240,7 +1240,7 @@ class Process:
         zipname = "%s.zip" % name
 
         # Glob all of the output files.
-        output = _glob.glob("%s/*" % self._work_dir)
+        output = _glob.glob(_os.path.join(str(self._work_dir), "*"))
 
         with _zipfile.ZipFile(zipname, "w") as zip:
             # Loop over all of the file outputs.

--- a/python/BioSimSpace/Process/_process_runner.py
+++ b/python/BioSimSpace/Process/_process_runner.py
@@ -843,7 +843,9 @@ class ProcessRunner:
         # Loop over each process.
         for process in processes:
             # Create the new working directory name.
-            new_dir = "%s/%s" % (self._work_dir, _os.path.basename(process._work_dir))
+            new_dir = _os.path.join(
+                self._work_dir, _os.path.basename(process._work_dir)
+            )
 
             # Create a new process object using the nested directory.
             if process._package_name == "SOMD":

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -227,23 +227,23 @@ class Somd(_process.Process):
                 raise IOError("SOMD executable doesn't exist: '%s'" % exe)
 
         # The names of the input files.
-        self._rst_file = "%s/%s.rst7" % (self._work_dir, name)
-        self._top_file = "%s/%s.prm7" % (self._work_dir, name)
+        self._rst_file = _os.path.join(str(self._work_dir), f"{name}.rst7")
+        self._top_file = _os.path.join(str(self._work_dir), f"{name}.prm7")
 
         # The name of the trajectory file.
-        self._traj_file = "%s/traj000000001.dcd" % self._work_dir
+        self._traj_file = _os.path.join(str(self._work_dir), "traj000000001.dcd")
 
         # The name of the restart file.
-        self._restart_file = "%s/latest.pdb" % self._work_dir
+        self._restart_file = _os.path.join(str(self._work_dir), "latest.pdb")
 
         # Set the path for the SOMD configuration file.
-        self._config_file = "%s/%s.cfg" % (self._work_dir, name)
+        self._config_file = _os.path.join(str(self._work_dir), f"{name}.cfg")
 
         # Set the path for the perturbation file.
-        self._pert_file = "%s/%s.pert" % (self._work_dir, name)
+        self._pert_file = _os.path.join(str(self._work_dir), f"{name}.pert")
 
         # Set the path for the gradient file and create the gradient list.
-        self._gradient_file = "%s/gradients.dat" % self._work_dir
+        self._gradient_file = _os.path.join(str(self._work_dir), "gradients.dat")
         self._gradients = []
 
         # Create the list of input files.
@@ -871,26 +871,26 @@ class Somd(_process.Process):
 
         # Delete any restart and trajectory files in the working directory.
 
-        file = "%s/sim_restart.s3" % self._work_dir
+        file = _os.path.join(str(self._work_dir), "sim_restart.s3")
         if _os.path.isfile(file):
             _os.remove(file)
 
-        file = "%s/SYSTEM.s3" % self._work_dir
+        file = _os.path.join(str(self._work_dir), "SYSTEM.s3")
         if _os.path.isfile(file):
             _os.remove(file)
 
-        files = _glob.glob("%s/traj*.dcd" % self._work_dir)
+        files = _glob.glob(_os.path.join(str(self._work_dir), "traj*.dcd"))
         for file in files:
             if _os.path.isfile(file):
                 _os.remove(file)
 
         # Additional files for free energy simulations.
         if isinstance(self._protocol, _Protocol.FreeEnergy):
-            file = "%s/gradients.dat" % self._work_dir
+            file = _os.path.join(str(self._work_dir), "gradients.dat")
             if _os.path.isfile(file):
                 _os.remove(file)
 
-            file = "%s/simfile.dat" % self._work_dir
+            file = _os.path.join(str(self._work_dir), "simfile.dat")
             if _os.path.isfile(file):
                 _os.remove(file)
 

--- a/python/BioSimSpace/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Protocol/_metadynamics.py
@@ -48,6 +48,7 @@ class Metadynamics(_Protocol):
         runtime=_Types.Time(1, "nanosecond"),
         temperature=_Types.Temperature(300, "kelvin"),
         pressure=_Types.Pressure(1, "atmosphere"),
+        thermostat_time_constant=_Types.Time(1, "picosecond"),
         hill_height=_Types.Energy(1, "kj per mol"),
         hill_frequency=1000,
         report_interval=1000,
@@ -75,6 +76,9 @@ class Metadynamics(_Protocol):
 
         pressure : :class:`Pressure <BioSimSpace.Types.Pressure>`
             The pressure. Pass pressure=None to use the NVT ensemble.
+
+        thermostat_time_constant : :class:`Time <BioSimSpace.Types.Time>`
+            Time constant for thermostat coupling.
 
         hill_height : :class:`Energy <BioSimSpace.Types.Energy>`
             The height of the Gaussian hills.
@@ -122,6 +126,9 @@ class Metadynamics(_Protocol):
             self.setPressure(pressure)
         else:
             self._pressure = None
+
+        # Set the thermostat time constant.
+        self.setThermostatTimeConstant(thermostat_time_constant)
 
         # Set the hill parameters: height, frequency.
         self.setHillHeight(hill_height)
@@ -382,6 +389,42 @@ class Metadynamics(_Protocol):
         else:
             raise TypeError(
                 "'pressure' must be of type 'str' or 'BioSimSpace.Types.Pressure'"
+            )
+
+    def getThermostatTimeConstant(self):
+        """
+        Return the time constant for the thermostat.
+
+        Returns
+        -------
+
+        runtime : :class:`Time <BioSimSpace.Types.Time>`
+            The time constant for the thermostat.
+        """
+        return self._thermostat_time_constant
+
+    def setThermostatTimeConstant(self, thermostat_time_constant):
+        """
+        Set the time constant for the thermostat.
+
+        Parameters
+        ----------
+
+        thermostat_time_constant : str, :class:`Time <BioSimSpace.Types.Time>`
+            The time constant for the thermostat.
+        """
+        if isinstance(thermostat_time_constant, str):
+            try:
+                self._thermostat_time_constant = _Types.Time(thermostat_time_constant)
+            except:
+                raise ValueError(
+                    "Unable to parse 'thermostat_time_constant' string."
+                ) from None
+        elif isinstance(thermostat_time_constant, _Types.Time):
+            self._thermostat_time_constant = thermostat_time_constant
+        else:
+            raise TypeError(
+                "'thermostat_time_constant' must be of type 'str' or 'BioSimSpace.Types.Time'"
             )
 
     def getHillHeight(self):

--- a/python/BioSimSpace/Protocol/_position_restraint_mixin.py
+++ b/python/BioSimSpace/Protocol/_position_restraint_mixin.py
@@ -110,13 +110,14 @@ class _PositionRestraintMixin:
         )
 
     def getRestraint(self):
-        """Return the type of restraint..
+        """
+        Return the type of restraint.
 
         Returns
         -------
 
         restraint : str, [int]
-            The type of restraint.
+            The type of restraint, either a keyword or a list of atom indices.
         """
         return self._restraint
 

--- a/python/BioSimSpace/Protocol/_protocol.py
+++ b/python/BioSimSpace/Protocol/_protocol.py
@@ -40,6 +40,23 @@ class Protocol:
         # Flag that the protocol hasn't been customised.
         self._is_customised = False
 
+    def getRestraint(self):
+        """
+        Return the type of restraint.
+
+        Returns
+        -------
+
+        restraint : str, [int]
+            The type of restraint, either a keyword or a list of atom indices.
+        """
+        from ._position_restraint_mixin import _PositionRestraintMixin
+
+        if isinstance(self, _PositionRestraintMixin):
+            return self._restraint
+        else:
+            return None
+
     def _setCustomised(self, is_customised):
         """
         Internal function to flag whether a protocol has been customised.

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -88,12 +88,20 @@ class System(_SireWrapper):
             sire_object = _SireSystem.System("BioSimSpace_System.")
             super().__init__(sire_object)
             self.addMolecules(_Molecule(system))
+            if "fileformat" in system.propertyKeys():
+                self._sire_object.setProperty(
+                    "fileformat", system.property("fileformat")
+                )
 
         # A BioSimSpace Molecule object.
         elif isinstance(system, _Molecule):
             sire_object = _SireSystem.System("BioSimSpace_System.")
             super().__init__(sire_object)
             self.addMolecules(system)
+            if "fileformat" in system._sire_object.propertyKeys():
+                self._sire_object.setProperty(
+                    "fileformat", system._sire_object.property("fileformat")
+                )
 
         # A BioSimSpace Molecules object.
         elif isinstance(system, _Molecules):

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -157,7 +157,7 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
     errors = []
     is_sire = False
     is_mdanalysis = False
-    pdb_file = work_dir + f"/{str(_uuid.uuid4())}.pdb"
+    pdb_file = _os.path.join(str(work_dir), f"{str(_uuid.uuid4())}.pdb")
     try:
         frame = _sire_load(
             [trajectory, topology],
@@ -169,7 +169,7 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
     except Exception as e:
         errors.append(f"Sire: {str(e)}")
         try:
-            frame_file = work_dir + f"/{str(_uuid.uuid4())}.rst7"
+            frame_file = _os.path.join(str(work_dir), f"{str(_uuid.uuid4())}.rst7")
             frame = _mdtraj.load_frame(trajectory, index, top=topology)
             frame.save(frame_file, force_overwrite=True)
             frame.save(pdb_file, force_overwrite=True)
@@ -178,7 +178,7 @@ def getFrame(trajectory, topology, index, system=None, property_map={}):
             errors.append(f"MDTraj: {str(e)}")
             # Try to load the frame with MDAnalysis.
             try:
-                frame_file = work_dir + f"/{str(_uuid.uuid4())}.gro"
+                frame_file = _os.path.join(str(work_dir), f"{str(_uuid.uuid4())}.gro")
                 universe = _mdanalysis.Universe(topology, trajectory)
                 universe.trajectory.trajectory[index]
                 with _warnings.catch_warnings():
@@ -615,7 +615,9 @@ class Trajectory:
             # If this is a PRM7 file, copy to PARM7.
             if extension == ".prm7":
                 # Set the path to the temporary topology file.
-                top_file = self._work_dir + f"/{str(_uuid.uuid4())}.parm7"
+                top_file = _os.path.join(
+                    str(self._work_dir), f"{str(_uuid.uuid4())}.parm7"
+                )
 
                 # Copy the topology to a file with the correct extension.
                 _shutil.copyfile(self._top_file, top_file)
@@ -761,16 +763,20 @@ class Trajectory:
 
             # Write the current frame to file.
 
-            pdb_file = self._work_dir + f"/{str(_uuid.uuid4())}.pdb"
+            pdb_file = _os.path.join(str(self._work_dir), f"{str(_uuid.uuid4())}.pdb")
 
             if self._backend == "SIRE":
                 frame = self._trajectory[x]
             elif self._backend == "MDTRAJ":
-                frame_file = self._work_dir + f"/{str(_uuid.uuid4())}.rst7"
+                frame_file = _os.path.join(
+                    str(self._work_dir), f"{str(_uuid.uuid4())}.rst7"
+                )
                 self._trajectory[x].save(frame_file, force_overwrite=True)
                 self._trajectory[x].save(pdb_file, force_overwrite=True)
             elif self._backend == "MDANALYSIS":
-                frame_file = self._work_dir + f"/{str(_uuid.uuid4())}.gro"
+                frame_file = _os.path.join(
+                    str(self._work_dir), f"{str(_uuid.uuid4())}.gro"
+                )
                 self._trajectory.trajectory[x]
                 with _warnings.catch_warnings():
                     _warnings.simplefilter("ignore")
@@ -1110,8 +1116,8 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
     formats = reference.fileFormat()
 
     # Write the frame coordinates/velocities to file.
-    coord_file = work_dir + f"/{str(_uuid.uuid4())}.coords"
-    top_file = work_dir + f"/{str(_uuid.uuid4())}.top"
+    coord_file = _os.path.join(str(work_dir), f"{str(_uuid.uuid4())}.coords")
+    top_file = _os.path.join(str(work_dir), f"{str(_uuid.uuid4())}.top")
     frame.writeToFile(coord_file)
 
     # Whether we've parsed as a PDB file.

--- a/python/BioSimSpace/_Config/_amber.py
+++ b/python/BioSimSpace/_Config/_amber.py
@@ -321,10 +321,7 @@ class Amber(_Config):
                     )
 
         # Temperature control.
-        if not isinstance(
-            self._protocol,
-            (_Protocol.Metadynamics, _Protocol.Steering, _Protocol.Minimisation),
-        ):
+        if not isinstance(self._protocol, _Protocol.Minimisation):
             # Langevin dynamics.
             protocol_dict["ntt"] = 3
             # Collision frequency (1 / ps).

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -88,12 +88,20 @@ class System(_SireWrapper):
             sire_object = _SireSystem.System("BioSimSpace_System.")
             super().__init__(sire_object)
             self.addMolecules(_Molecule(system))
+            if "fileformat" in system.propertyKeys():
+                self._sire_object.setProperty(
+                    "fileformat", system.property("fileformat")
+                )
 
         # A BioSimSpace Molecule object.
         elif isinstance(system, _Molecule):
             sire_object = _SireSystem.System("BioSimSpace_System.")
             super().__init__(sire_object)
             self.addMolecules(system)
+            if "fileformat" in system._sire_object.propertyKeys():
+                self._sire_object.setProperty(
+                    "fileformat", system._sire_object.property("fileformat")
+                )
 
         # A BioSimSpace Molecules object.
         elif isinstance(system, _Molecules):

--- a/tests/Convert/test_convert.py
+++ b/tests/Convert/test_convert.py
@@ -5,11 +5,6 @@ from sire.legacy import Mol as SireMol
 import pytest
 
 
-@pytest.fixture(scope="session")
-def system():
-    return BSS.IO.readMolecules(["tests/input/ala.crd", "tests/input/ala.top"])
-
-
 def test_system(system):
     """
     Check that system conversions work as expected.

--- a/tests/FreeEnergy/test_relative.py
+++ b/tests/FreeEnergy/test_relative.py
@@ -10,17 +10,6 @@ from tests.conftest import url, has_alchemlyb, has_gromacs
 
 
 @pytest.fixture(scope="module")
-def perturbable_system():
-    """Re-use the same perturbable system for each test."""
-    return BSS.IO.readPerturbableSystem(
-        f"{url}/perturbable_system0.prm7",
-        f"{url}/perturbable_system0.rst7",
-        f"{url}/perturbable_system1.prm7",
-        f"{url}/perturbable_system1.rst7",
-    )
-
-
-@pytest.fixture(scope="module")
 def fep_output():
     """Path to a temporary directory containing FEP output."""
 

--- a/tests/Metadynamics/test_metadynamics.py
+++ b/tests/Metadynamics/test_metadynamics.py
@@ -85,7 +85,7 @@ def test_steering(system):
 
 @pytest.mark.skipif(
     socket.gethostname() != "porridge",
-    reason="Local test requiring PLUMED patched GROMACS.",
+    reason="Local test requiring PLUMED.",
 )
 def test_funnel_metadynamics():
     # Load the protein-ligand system.

--- a/tests/Metadynamics/test_metadynamics.py
+++ b/tests/Metadynamics/test_metadynamics.py
@@ -1,0 +1,40 @@
+import pytest
+import socket
+
+import BioSimSpace as BSS
+
+
+@pytest.mark.skipif(
+    socket.gethostname() != "porridge",
+    reason="Local test requiring PLUMED patched GROMACS.",
+)
+def test_metadynamics(system):
+    # Search for the first molecule containing ALA.
+    molecule = system.search("resname ALA").molecules()[0]
+
+    # Store the torsion indices.
+    phi_idx = [4, 6, 8, 14]
+    psi_idx = [6, 8, 14, 16]
+
+    # Create the collective variables.
+    phi = BSS.Metadynamics.CollectiveVariable.Torsion(atoms=phi_idx)
+    psi = BSS.Metadynamics.CollectiveVariable.Torsion(atoms=psi_idx)
+
+    # Create the metadynamics protocol.
+    protocol = BSS.Protocol.Metadynamics(
+        collective_variable=[phi, psi], runtime=100 * BSS.Units.Time.picosecond
+    )
+
+    # Run the metadynamics simulation.
+    process = BSS.Metadynamics.run(molecule.toSystem(), protocol, gpu_support=True)
+
+    # Wait for the process to finish.
+    process.wait()
+
+    # Check if the process has finished successfully.
+    assert not process.isError()
+
+    free_nrg = process.getFreeEnergy(kt=BSS.Units.Energy.kt)
+
+    # Check if the free energy is not None.
+    assert free_nrg is not None

--- a/tests/Metadynamics/test_metadynamics.py
+++ b/tests/Metadynamics/test_metadynamics.py
@@ -38,3 +38,120 @@ def test_metadynamics(system):
 
     # Check if the free energy is not None.
     assert free_nrg is not None
+
+
+@pytest.mark.skipif(
+    socket.gethostname() != "porridge",
+    reason="Local test requiring PLUMED patched GROMACS.",
+)
+def test_steering(system):
+    # Find the indices of the atoms in the ALA residue.
+    rmsd_idx = [x.index() for x in system.search("resname ALA").atoms()]
+
+    # Create the collective variable.
+    cv = BSS.Metadynamics.CollectiveVariable.RMSD(system, system[0], rmsd_idx)
+
+    # Add some stages.
+    start = 0 * BSS.Units.Time.nanosecond
+    apply_force = 4 * BSS.Units.Time.picosecond
+    steer = 50 * BSS.Units.Time.picosecond
+    relax = 100 * BSS.Units.Time.picosecond
+
+    # Create some restraints.
+    nm = BSS.Units.Length.nanometer
+    restraint_1 = BSS.Metadynamics.Restraint(cv.getInitialValue(), 0)
+    restraint_2 = BSS.Metadynamics.Restraint(cv.getInitialValue(), 3500)
+    restraint_3 = BSS.Metadynamics.Restraint(0 * nm, 3500)
+    restraint_4 = BSS.Metadynamics.Restraint(0 * nm, 0)
+
+    # Create the steering protocol.
+    protocol = BSS.Protocol.Steering(
+        cv,
+        [start, apply_force, steer, relax],
+        [restraint_1, restraint_2, restraint_3, restraint_4],
+        runtime=100 * BSS.Units.Time.picosecond,
+    )
+
+    # Create the steering process.
+    process = BSS.Process.Gromacs(system, protocol, extra_args={"-ntmpi": 1})
+
+    # Start the process and wait for it to finish.
+    process.start()
+    process.wait()
+
+    # Check if the process has finished successfully.
+    assert not process.isError()
+
+
+def test_funnel_metadynamics():
+    # Load the protein-ligand system.
+    system = BSS.IO.readMolecules(
+        BSS.IO.expand(BSS.tutorialUrl(), ["funnel_system.rst7", "funnel_system.prm7"])
+    )
+
+    # Get the p0 and p1 points for defining the funnel.
+    p0, p1 = BSS.Metadynamics.CollectiveVariable.makeFunnel(system)
+
+    # Expected p0 and p1 points.
+    expected_p0 = [1017, 1031, 1050, 1186, 1205, 1219, 1238, 2585, 2607, 2623]
+    expected_p1 = [
+        519,
+        534,
+        553,
+        572,
+        583,
+        597,
+        608,
+        619,
+        631,
+        641,
+        1238,
+        1254,
+        1280,
+        1287,
+        1306,
+        1313,
+        1454,
+        1473,
+        1480,
+        1863,
+        1879,
+        1886,
+        1906,
+        2081,
+        2116,
+        2564,
+        2571,
+        2585,
+        2607,
+    ]
+
+    # Make sure the p0 and p1 points are as expected.
+    assert p0 == expected_p0
+    assert p1 == expected_p1
+
+    # Set the upper bound for the funnel collective variable.
+    upper_bound = BSS.Metadynamics.Bound(value=3.5 * BSS.Units.Length.nanometer)
+
+    # Create the funnel collective variable.
+    cv = BSS.Metadynamics.CollectiveVariable.Funnel(p0, p1, upper_bound=upper_bound)
+
+    # Create the metadynamics protocol.
+    protocol = BSS.Protocol.Metadynamics(
+        cv,
+        runtime=1 * BSS.Units.Time.picosecond,
+        hill_height=1.5 * BSS.Units.Energy.kj_per_mol,
+        hill_frequency=500,
+        restart_interval=1000,
+        bias_factor=10,
+    )
+
+    # Create the metadynamics process.
+    process = BSS.Process.OpenMM(system, protocol)
+
+    # Start the process and wait for it to finish.
+    process.start()
+    process.wait()
+
+    # Check if the process has finished successfully.
+    assert not process.isError()

--- a/tests/Metadynamics/test_metadynamics.py
+++ b/tests/Metadynamics/test_metadynamics.py
@@ -83,6 +83,10 @@ def test_steering(system):
     assert not process.isError()
 
 
+@pytest.mark.skipif(
+    socket.gethostname() != "porridge",
+    reason="Local test requiring PLUMED patched GROMACS.",
+)
 def test_funnel_metadynamics():
     # Load the protein-ligand system.
     system = BSS.IO.readMolecules(

--- a/tests/Process/test_amber.py
+++ b/tests/Process/test_amber.py
@@ -14,12 +14,6 @@ restraints = BSS.Protocol._position_restraint_mixin._PositionRestraintMixin.rest
 
 
 @pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
-@pytest.fixture(scope="session")
 def rna_system():
     """An RNA system for re-use."""
     return BSS.IO.readMolecules(
@@ -32,28 +26,6 @@ def large_protein_system():
     """A large protein system for re-use."""
     return BSS.IO.readMolecules(
         BSS.IO.expand(BSS.tutorialUrl(), ["complex_vac0.prm7", "complex_vac0.rst7"])
-    )
-
-
-@pytest.fixture(scope="module")
-def perturbable_system():
-    """Re-use the same perturbable system for each test."""
-    return BSS.IO.readPerturbableSystem(
-        f"{url}/perturbable_system0.prm7",
-        f"{url}/perturbable_system0.rst7",
-        f"{url}/perturbable_system1.prm7",
-        f"{url}/perturbable_system1.rst7",
-    )
-
-
-@pytest.fixture(scope="module")
-def solvated_perturbable_system():
-    """Re-use the same solvated perturbable system for each test."""
-    return BSS.IO.readPerturbableSystem(
-        f"{url}/solvated_perturbable_system0.prm7",
-        f"{url}/solvated_perturbable_system0.rst7",
-        f"{url}/solvated_perturbable_system1.prm7",
-        f"{url}/solvated_perturbable_system1.rst7",
     )
 
 

--- a/tests/Process/test_amber.py
+++ b/tests/Process/test_amber.py
@@ -13,7 +13,7 @@ from tests.conftest import url, has_amber
 restraints = BSS.Protocol._position_restraint_mixin._PositionRestraintMixin.restraints()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def rna_system():
     """An RNA system for re-use."""
     return BSS.IO.readMolecules(
@@ -21,7 +21,7 @@ def rna_system():
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def large_protein_system():
     """A large protein system for re-use."""
     return BSS.IO.readMolecules(

--- a/tests/Process/test_gromacs.py
+++ b/tests/Process/test_gromacs.py
@@ -19,23 +19,6 @@ from tests.conftest import url, has_amber, has_gromacs, has_openff
 restraints = BSS.Protocol._position_restraint_mixin._PositionRestraintMixin.restraints()
 
 
-@pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
-@pytest.fixture(scope="session")
-def perturbable_system():
-    """Re-use the same perturbable system for each test."""
-    return BSS.IO.readPerturbableSystem(
-        f"{url}/complex_vac0.prm7.bz2",
-        f"{url}/complex_vac0.rst7.bz2",
-        f"{url}/complex_vac1.prm7.bz2",
-        f"{url}/complex_vac1.rst7.bz2",
-    )
-
-
 @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
 @pytest.mark.parametrize("restraint", restraints)
 def test_minimise(system, restraint):

--- a/tests/Process/test_namd.py
+++ b/tests/Process/test_namd.py
@@ -8,18 +8,6 @@ from tests.conftest import url, has_namd
 restraints = BSS.Protocol._position_restraint_mixin._PositionRestraintMixin.restraints()
 
 
-@pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(
-        [
-            "tests/input/alanin.psf",
-            f"tests/input/alanin.pdb",
-            f"tests/input/alanin.params",
-        ]
-    )
-
-
 @pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
 @pytest.mark.parametrize("restraint", restraints)
 def test_minimise(system, restraint):

--- a/tests/Process/test_namd.py
+++ b/tests/Process/test_namd.py
@@ -8,21 +8,33 @@ from tests.conftest import url, has_namd
 restraints = BSS.Protocol._position_restraint_mixin._PositionRestraintMixin.restraints()
 
 
+@pytest.fixture(scope="module")
+def namd_system():
+    """Re-use the same molecuar system for each test."""
+    return BSS.IO.readMolecules(
+        [
+            "tests/input/alanin.psf",
+            f"tests/input/alanin.pdb",
+            f"tests/input/alanin.params",
+        ]
+    )
+
+
 @pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
 @pytest.mark.parametrize("restraint", restraints)
-def test_minimise(system, restraint):
+def test_minimise(namd_system, restraint):
     """Test a minimisation protocol."""
 
     # Create a short minimisation protocol.
     protocol = BSS.Protocol.Minimisation(steps=100, restraint=restraint)
 
     # Run the process, check that it finished without error, and returns a system.
-    run_process(system, protocol)
+    run_process(namd_system, protocol)
 
 
 @pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
 @pytest.mark.parametrize("restraint", restraints)
-def test_equilibrate(system, restraint):
+def test_equilibrate(namd_system, restraint):
     """Test an equilibration protocol."""
 
     # Create a short equilibration protocol.
@@ -31,11 +43,11 @@ def test_equilibrate(system, restraint):
     )
 
     # Run the process, check that it finished without error, and returns a system.
-    run_process(system, protocol)
+    run_process(namd_system, protocol)
 
 
 @pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
-def test_heat(system):
+def test_heat(namd_system):
     """Test a heating protocol."""
 
     # Create a short heating protocol.
@@ -46,11 +58,11 @@ def test_heat(system):
     )
 
     # Run the process, check that it finished without error, and returns a system.
-    run_process(system, protocol)
+    run_process(namd_system, protocol)
 
 
 @pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
-def test_cool(system):
+def test_cool(namd_system):
     """Test a cooling protocol."""
 
     # Create a short heating protocol.
@@ -61,12 +73,12 @@ def test_cool(system):
     )
 
     # Run the process, check that it finished without error, and returns a system.
-    run_process(system, protocol)
+    run_process(namd_system, protocol)
 
 
 @pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
 @pytest.mark.parametrize("restraint", restraints)
-def test_production(system, restraint):
+def test_production(namd_system, restraint):
     """Test a production protocol."""
 
     # Create a short production protocol.
@@ -75,14 +87,14 @@ def test_production(system, restraint):
     )
 
     # Run the process, check that it finished without error, and returns a system.
-    run_process(system, protocol)
+    run_process(namd_system, protocol)
 
 
-def run_process(system, protocol):
+def run_process(namd_system, protocol):
     """Helper function to run various simulation protocols."""
 
     # Initialise the NAMD process.
-    process = BSS.Process.Namd(system, protocol, name="test")
+    process = BSS.Process.Namd(namd_system, protocol, name="test")
 
     # Start the NAMD simulation.
     process.start()

--- a/tests/Process/test_openmm.py
+++ b/tests/Process/test_openmm.py
@@ -8,12 +8,6 @@ from tests.conftest import url, has_amber, has_gromacs, has_openff
 restraints = BSS.Protocol._position_restraint_mixin._PositionRestraintMixin.restraints()
 
 
-@pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
 @pytest.mark.parametrize("restraint", restraints)
 def test_minimise(system, restraint):
     """Test a minimisation protocol."""

--- a/tests/Process/test_single_point_energy.py
+++ b/tests/Process/test_single_point_energy.py
@@ -5,8 +5,8 @@ import BioSimSpace as BSS
 from tests.conftest import url, has_amber, has_gromacs
 
 
-@pytest.fixture(scope="session")
-def system():
+@pytest.fixture(scope="module")
+def ubiquitin_system():
     """Re-use the same molecuar system for each test."""
     return BSS.IO.readMolecules(
         [f"{url}/ubiquitin.prm7.bz2", f"{url}/ubiquitin.rst7.bz2"]
@@ -17,17 +17,19 @@ def system():
     has_amber is False or has_gromacs is False,
     reason="Requires that both AMBER and GROMACS are installed.",
 )
-def test_amber_gromacs(system):
+def test_amber_gromacs(ubiquitin_system):
     """Single point energy comparison between AMBER and GROMACS."""
 
     # Create a single-step minimisation protocol.
     protocol = BSS.Protocol.Minimisation(steps=1)
 
     # Create a process to run with AMBER.
-    process_amb = BSS.Process.Amber(system, protocol)
+    process_amb = BSS.Process.Amber(ubiquitin_system, protocol)
 
     # Create a process to run with GROMACS.
-    process_gmx = BSS.Process.Gromacs(system, protocol, extra_options={"nsteps": 0})
+    process_gmx = BSS.Process.Gromacs(
+        ubiquitin_system, protocol, extra_options={"nsteps": 0}
+    )
 
     # Run the AMBER process and wait for it to finish.
     process_amb.start()
@@ -57,23 +59,25 @@ def test_amber_gromacs(system):
     has_amber is False or has_gromacs is False,
     reason="Requires that both AMBER and GROMACS are installed.",
 )
-def test_amber_gromacs_triclinic(system):
+def test_amber_gromacs_triclinic(ubiquitin_system):
     """Single point energy comparison between AMBER and GROMACS in a triclinic box."""
 
     # Swap the space for a triclinic cell (truncated octahedron).
     from sire.legacy.Vol import TriclinicBox
 
     triclinic_box = TriclinicBox.truncatedOctahedron(50)
-    system._sire_object.setProperty("space", triclinic_box)
+    ubiquitin_system._sire_object.setProperty("space", triclinic_box)
 
     # Create a single-step minimisation protocol.
     protocol = BSS.Protocol.Minimisation(steps=1)
 
     # Create a process to run with AMBER.
-    process_amb = BSS.Process.Amber(system, protocol)
+    process_amb = BSS.Process.Amber(ubiquitin_system, protocol)
 
     # Create a process to run with GROMACS.
-    process_gmx = BSS.Process.Gromacs(system, protocol, extra_options={"nsteps": 0})
+    process_gmx = BSS.Process.Gromacs(
+        ubiquitin_system, protocol, extra_options={"nsteps": 0}
+    )
 
     # Run the AMBER process and wait for it to finish.
     process_amb.start()

--- a/tests/Process/test_somd.py
+++ b/tests/Process/test_somd.py
@@ -9,23 +9,6 @@ import BioSimSpace as BSS
 url = BSS.tutorialUrl()
 
 
-@pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
-@pytest.fixture(scope="session")
-def perturbable_system():
-    """Re-use the same perturbable system for each test."""
-    return BSS.IO.readPerturbableSystem(
-        f"{url}/perturbable_system0.prm7",
-        f"{url}/perturbable_system0.rst7",
-        f"{url}/perturbable_system1.prm7",
-        f"{url}/perturbable_system1.rst7",
-    )
-
-
 def test_minimise(system):
     """Test a minimisation protocol."""
 

--- a/tests/Protocol/test_protocol.py
+++ b/tests/Protocol/test_protocol.py
@@ -6,12 +6,6 @@ import BioSimSpace as BSS
 # using strings of unit-based types.
 
 
-@pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
 def test_equilibration():
     # Instantiate from types.
     p0 = BSS.Protocol.Equilibration(

--- a/tests/Solvent/test_solvent.py
+++ b/tests/Solvent/test_solvent.py
@@ -11,7 +11,7 @@ from tests.conftest import has_gromacs
 
 
 @pytest.fixture(scope="module")
-def system():
+def kigaki_system():
     return BSS.IO.readMolecules(
         BSS.IO.expand(
             BSS.tutorialUrl(), ["kigaki_xtal_water.gro", "kigaki_xtal_water.top"]
@@ -25,7 +25,7 @@ def system():
     [partial(BSS.Solvent.solvate, "tip3p"), BSS.Solvent.tip3p],
 )
 @pytest.mark.skipif(not has_gromacs, reason="Requires GROMACS to be installed")
-def test_crystal_water(system, match_water, function):
+def test_crystal_water(kigaki_system, match_water, function):
     """
     Test that user defined crystal waters can be preserved during
     solvation and on write to GroTop format.
@@ -35,13 +35,13 @@ def test_crystal_water(system, match_water, function):
     if match_water:
         num_matches = 0
     else:
-        num_matches = len(system.search("resname COF").molecules())
+        num_matches = len(kigaki_system.search("resname COF").molecules())
 
     # Create the box parameters.
     box, angles = BSS.Box.cubic(5.5 * BSS.Units.Length.nanometer)
 
     # Create the solvated system.
-    solvated = function(system, box, angles, match_water=match_water)
+    solvated = function(kigaki_system, box, angles, match_water=match_water)
 
     # Search for the crystal waters in the solvated system.
     try:

--- a/tests/Stream/test_stream.py
+++ b/tests/Stream/test_stream.py
@@ -4,11 +4,6 @@ import pytest
 import BioSimSpace as BSS
 
 
-@pytest.fixture
-def system(scope="session"):
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
 @pytest.fixture(autouse=True)
 def run_around_tests():
     yield

--- a/tests/Trajectory/test_trajectory.py
+++ b/tests/Trajectory/test_trajectory.py
@@ -14,12 +14,6 @@ from tests.conftest import url, has_mdanalysis, has_mdtraj
 
 
 @pytest.fixture(scope="session")
-def system():
-    """A system object with the same topology as the trajectories."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
-@pytest.fixture(scope="session")
 def traj_sire(system):
     """A trajectory object using the Sire backend."""
     return BSS.Trajectory.Trajectory(

--- a/tests/_SireWrappers/test_molecule.py
+++ b/tests/_SireWrappers/test_molecule.py
@@ -5,11 +5,6 @@ import BioSimSpace as BSS
 from tests.conftest import url, has_amber
 
 
-@pytest.fixture(scope="session")
-def system():
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
 @pytest.mark.skipif(has_amber is False, reason="Requires AMBER to be installed.")
 def test_makeCompatibleWith():
     # Load the original PDB file. In this representation the system contains

--- a/tests/_SireWrappers/test_search_result.py
+++ b/tests/_SireWrappers/test_search_result.py
@@ -7,12 +7,6 @@ url = BSS.tutorialUrl()
 
 
 @pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
-@pytest.fixture(scope="session")
 def molecule(system):
     """Re-use the same molecule for each test."""
     return system[0]

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -9,12 +9,6 @@ from tests.conftest import url, has_amber, has_openff
 
 
 @pytest.fixture(scope="session")
-def system():
-    """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
-
-
-@pytest.fixture(scope="session")
 def rna_system():
     """An RNA system for re-use."""
     return BSS.IO.readMolecules(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 collect_ignore_glob = ["*/out_test*.py"]
 
 import os
+import pytest
 
 from pathlib import Path
 
@@ -55,3 +56,33 @@ has_alchemlyb = _have_imported(_alchemlyb)
 
 # Allow tests to be run from any directory.
 root_fp = Path(__file__).parent.resolve()
+
+# Fixtures for tests.
+
+
+@pytest.fixture(scope="session")
+def system():
+    """Solvated alanine dipeptide system."""
+    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+
+
+@pytest.fixture(scope="module")
+def perturbable_system():
+    """A vacuum perturbable system."""
+    return BSS.IO.readPerturbableSystem(
+        f"{url}/perturbable_system0.prm7",
+        f"{url}/perturbable_system0.rst7",
+        f"{url}/perturbable_system1.prm7",
+        f"{url}/perturbable_system1.rst7",
+    )
+
+
+@pytest.fixture(scope="module")
+def solvated_perturbable_system():
+    """A solvated perturbable system."""
+    return BSS.IO.readPerturbableSystem(
+        f"{url}/solvated_perturbable_system0.prm7",
+        f"{url}/solvated_perturbable_system0.rst7",
+        f"{url}/solvated_perturbable_system1.prm7",
+        f"{url}/solvated_perturbable_system1.rst7",
+    )


### PR DESCRIPTION
This PR adds some final fixes ahead of the 2024.1.0 release. Once complete, I'll synchronise with the Exscientia remote and do the release PR.

Changes are:

* Switch to using `os.path.join` to create file names throughout. I haven't updated in the Sandpit too, since they only use macOS and Linux so are unaffected. I don't think the existing code was a problem, but this should hopefully avoid any future issues. (Most of the functionality that was updated doesn't work on Windows anyway.)
* Closes #273 by adding the `fileformat` property to systems that are created from a single molecule. (This caused the metadynamics demo to fail, since the file format of an extracted molecule was used to determine the best engine to run the simulation with.)
* Closes #274 by making sure that _all_ protocols have a `getRestraint` method, which returns `None` if it isn't derived from `PositionRestraintMixin`.
* Closes #275 by adding the missing `thermostat_time_constant` option to the metadynamics protocol.
* I've refactored the test fixtures to move the common systems into the `conftest` file.
* I've added tests for steered molecular dynamics, metadynamics, and funnel metadynamics. The first two are only run locally, since they require a PLUMED patched version of GROMACS. These tests will make it easier to catch issues with the tutorials suite.

Checklist:

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods