### PR TITLE
Fix Trajectory object cannot handle system generated from file

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -2908,7 +2908,7 @@ class Amber(_process.Process):
         for file in _Path(self.workDir()).glob("*.out.offset"):
             os.remove(file)
 
-    def saveMetric(
+    def _saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -2951,7 +2951,15 @@ class Amber(_process.Process):
                 f"{self.workDir()}/{self._name}.out",
                 T=self._protocol.getTemperature() / _Units.Temperature.kelvin,
             )
-            if "u_nk" in energy and energy["u_nk"] is not None:
-                energy["u_nk"].to_parquet(path=f"{self.workDir()}/{u_nk}", index=True)
-            if "dHdl" in energy and energy["dHdl"] is not None:
-                energy["dHdl"].to_parquet(path=f"{self.workDir()}/{dHdl}", index=True)
+            with _warnings.catch_warnings():
+                _warnings.filterwarnings(
+                    "ignore", message="The DataFrame has column names of mixed type."
+                )
+                if "u_nk" in energy and energy["u_nk"] is not None:
+                    energy["u_nk"].to_parquet(
+                        path=f"{self.workDir()}/{u_nk}", index=True
+                    )
+                if "dHdl" in energy and energy["dHdl"] is not None:
+                    energy["dHdl"].to_parquet(
+                        path=f"{self.workDir()}/{dHdl}", index=True
+                    )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2861,7 +2861,7 @@ class Gromacs(_process.Process):
         else:
             return self._traj_file
 
-    def saveMetric(
+    def _saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2898,10 +2898,18 @@ class Gromacs(_process.Process):
                 f"{self.workDir()}/{self._name}.xvg",
                 T=self._protocol.getTemperature() / _Units.Temperature.kelvin,
             )
-            if "u_nk" in energy:
-                energy["u_nk"].to_parquet(path=f"{self.workDir()}/{u_nk}", index=True)
-            if "dHdl" in energy:
-                energy["dHdl"].to_parquet(path=f"{self.workDir()}/{dHdl}", index=True)
+            with _warnings.catch_warnings():
+                _warnings.filterwarnings(
+                    "ignore", message="The DataFrame has column names of mixed type."
+                )
+                if "u_nk" in energy:
+                    energy["u_nk"].to_parquet(
+                        path=f"{self.workDir()}/{u_nk}", index=True
+                    )
+                if "dHdl" in energy:
+                    energy["dHdl"].to_parquet(
+                        path=f"{self.workDir()}/{dHdl}", index=True
+                    )
 
 
 def _is_minimisation(config):

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -399,19 +399,21 @@ class Gromacs(_process.Process):
                 match_waters=False,
                 property_map=self._property_map,
             )
+            self._apply_ABFE_restraint()
 
-            # Write the restraint to the topology file
-            if self._restraint:
-                with open(topol_file, "a") as f:
-                    f.write("\n")
-                    f.write(
-                        self._restraint.toString(
-                            engine="GROMACS",
-                            perturbation_type=self._protocol.getPerturbationType(),
-                            restraint_lambda="restraint"
-                            in self._protocol.getLambda(type="series"),
-                        )
+    def _apply_ABFE_restraint(self):
+        # Write the restraint to the topology file
+        if self._restraint:
+            with open(self._top_file, "a") as f:
+                f.write("\n")
+                f.write(
+                    self._restraint.toString(
+                        engine="GROMACS",
+                        perturbation_type=self._protocol.getPerturbationType(),
+                        restraint_lambda="restraint"
+                        in self._protocol.getLambda(type="series"),
                     )
+                )
 
     def _generate_config(self):
         """Generate GROMACS configuration file strings."""
@@ -488,6 +490,7 @@ class Gromacs(_process.Process):
                 if isinstance(self._protocol, _Protocol._FreeEnergyMixin)
                 else None
             )
+            self._apply_ABFE_restraint()
             self.addToConfig(
                 config.generateGromacsConfig(
                     extra_options={**config_options, **self._extra_options},

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
@@ -911,16 +911,6 @@ class Process:
 
         # The process isn't running.
         if not self.isRunning():
-            try:
-                self.saveMetric()
-            except Exception:
-                exception_info = traceback.format_exc()
-                with open(f"{self.workDir()}/{self._name}.err", "a+") as f:
-                    f.write("Exception Information during saveMetric():\n")
-                    f.write("======================\n")
-                    f.write(exception_info)
-                    f.write("\n\n")
-
             return
 
         if max_time is not None:
@@ -1650,12 +1640,25 @@ class Process:
         """Generate the dictionary of command-line arguments."""
         self.clearArgs()
 
+    def _saveMetric(self, filename, u_nk, dHdl):
+        """The abstract function to save the metric and free energy data. Need to be
+        defined for each MD engine."""
+        pass
+
     def saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """The abstract function to save the metric and free energy data. Need to be
         defined for each MD engine."""
-        pass
+        try:
+            self._saveMetric(filename, u_nk, dHdl)
+        except Exception:
+            exception_info = traceback.format_exc()
+            with open(f"{self.workDir()}/{self._name}.err", "a+") as f:
+                f.write("Exception Information during saveMetric():\n")
+                f.write("======================\n")
+                f.write(exception_info)
+                f.write("\n\n")
 
     def _convert_datadict_keys(self, datadict_keys):
         """This function is a helper function for saveMetric that converts a

--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -1109,6 +1109,10 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
     # Store the formats associated with the reference system.
     formats = reference.fileFormat()
 
+    # Convert NoneType to empty list.
+    if formats is None:
+        formats = []
+
     # Write the frame coordinates/velocities to file.
     coord_file = work_dir + f"/{str(_uuid.uuid4())}.coords"
     top_file = work_dir + f"/{str(_uuid.uuid4())}.top"

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
@@ -1,18 +1,18 @@
-import pytest
-
 import numpy as np
-
-from sire.legacy.Units import angstrom3 as _Sire_angstrom3
-from sire.legacy.Units import k_boltz as _k_boltz
-from sire.legacy.Units import meter3 as _Sire_meter3
-from sire.legacy.Units import mole as _Sire_mole
+import pytest
+from sire.legacy.Units import (
+    angstrom3 as _Sire_angstrom3,
+    k_boltz as _k_boltz,
+    meter3 as _Sire_meter3,
+    mole as _Sire_mole,
+)
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Align import decouple
 from BioSimSpace.Sandpit.Exscientia.FreeEnergy import Restraint
-from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
-from BioSimSpace.Sandpit.Exscientia.Units.Angle import radian, degree
+from BioSimSpace.Sandpit.Exscientia.Units.Angle import degree, radian
 from BioSimSpace.Sandpit.Exscientia.Units.Energy import kcal_per_mol
+from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 from BioSimSpace.Sandpit.Exscientia.Units.Temperature import kelvin
 
 # Store the tutorial URL.
@@ -73,6 +73,28 @@ def boresch_restraint_component():
     }
 
     return system, restraint_dict
+
+
+@pytest.mark.parametrize(
+    ("protocol", "posres"),
+    [
+        (BSS.Protocol.FreeEnergy, "heavy"),
+        (BSS.Protocol.FreeEnergy, None),
+    ],
+)
+def test_top_write(
+    boresch_restraint_component, protocol, posres, tmp_path, boresch_restraint
+):
+    system, restraint_dict = boresch_restraint_component
+    bss_protocol = protocol(restraint=posres)
+    BSS.Process.Gromacs(
+        system,
+        bss_protocol,
+        work_dir=str(tmp_path),
+        restraint=boresch_restraint,
+    )
+    with open(str(tmp_path / "gromacs.top"), "r") as f:
+        assert "intermolecular_interactions" in f.read()
 
 
 @pytest.fixture(scope="session")

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -407,7 +407,7 @@ class TestsaveMetric:
             alchemical_system,
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
-        process.wait()
+        process.saveMetric()
         with open(process.workDir() + "/amber.err", "r") as f:
             text = f.read()
             assert "Exception Information" in text

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -383,10 +383,18 @@ class TestGetRecord:
             perturbable_system,
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
-        process.wait()
+        process.saveMetric()
         with open(process.workDir() + "/gromacs.err", "r") as f:
             text = f.read()
             assert "Exception Information" in text
+
+
+def test_error_saveMetric(perturbable_system):
+    protocol = BSS.Protocol.FreeEnergy()
+    process = BSS.Process.Gromacs(perturbable_system, protocol)
+    process.saveMetric()
+    with open(f"{process.workDir()}/{process._name}.err", "r") as f:
+        assert "Exception Information during saveMetric():" in f.read()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
The `Trajectory` object expect the `system` object to be generated from `Process`, which should populate the `system.fileFormat()`.
However, if one generate the `system` object from files. The `system.fileFormat()` won't get populated resulting in unexpected behaviour of `Trajectory`.
This bug will not affect the production where all `system` object will be generated from `Process`, but will affect the tests where `system` object is generated from file.
This will be fixed in the upstream so I have just pushed a small fix here to avoid file conflict when we sync with the upstream. 