### PR TITLE
Don't perturb LJ sigma for ghost atoms

### DIFF
--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -693,8 +693,8 @@ def merge(
                     .molecule()
                 )
 
-    # Create a null LJParameter.
-    null_lj = _SireMM.LJParameter()
+    # Tolerance for zero sigma values.
+    null_lj_sigma = 1e-9
 
     # Atoms with zero LJ sigma values need to have their sigma values set to the
     # value from the other end state.
@@ -704,7 +704,7 @@ def merge(
         lj1 = atom.property("LJ1")
 
         # Lambda = 0 state has a zero sigma value.
-        if lj0.sigma() == null_lj.sigma():
+        if abs(lj0.sigma().value()) <= null_lj_sigma:
             # Use the sigma value from the lambda = 1 state.
             edit_mol = (
                 edit_mol.atom(atom.index())
@@ -713,7 +713,7 @@ def merge(
             )
 
         # Lambda = 1 state has a zero sigma value.
-        if lj1.sigma() == null_lj.sigma():
+        if abs(lj1.sigma().value()) <= null_lj_sigma:
             # Use the sigma value from the lambda = 0 state.
             edit_mol = (
                 edit_mol.atom(atom.index())

--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -693,32 +693,31 @@ def merge(
                     .molecule()
                 )
 
-    # Store a dummy element.
-    dummy = _SireMol.Element(0)
+    # Create a null LJParameter.
+    null_lj = _SireMM.LJParameter()
 
-    # Set the LJ sigma paramater to the value of the opposite end state for any
-    # dummy atoms.
+    # Atoms with zero LJ sigma values need to have their sigma values set to the
+    # value from the other end state.
     for atom in edit_mol.atoms():
-        # Lambda = 0 is a dummy atom.
-        if atom.property("element0") == dummy:
-            lj0 = edit_mol.atom(atom.index()).property("LJ0")
-            lj1 = edit_mol.atom(atom.index()).property("LJ1")
+        # Get the end state LJ sigma values.
+        lj0 = atom.property("LJ0")
+        lj1 = atom.property("LJ1")
 
-            # Set the sigma parameter at lambda = 0.
+        # Lambda = 0 state has a zero sigma value.
+        if lj0.sigma() == null_lj.sigma():
+            # Use the sigma value from the lambda = 1 state.
             edit_mol = (
                 edit_mol.atom(atom.index())
-                .setProperty("LJ0", _SireMM.LJParameter(lj1.sigma(), lj0.epsilon()))
+                .set_property("LJ0", _SireMM.LJParameter(lj1.sigma(), lj0.epsilon()))
                 .molecule()
             )
-        # Lambda = 1 is a dummy atom.
-        if atom.property("element1") == dummy:
-            lj0 = edit_mol.atom(atom.index()).property("LJ0")
-            lj1 = edit_mol.atom(atom.index()).property("LJ1")
 
-            # Set the sigma parameter at lambda = 1.
+        # Lambda = 1 state has a zero sigma value.
+        if lj1.sigma() == null_lj.sigma():
+            # Use the sigma value from the lambda = 0 state.
             edit_mol = (
                 edit_mol.atom(atom.index())
-                .setProperty("LJ1", _SireMM.LJParameter(lj0.sigma(), lj1.epsilon()))
+                .set_property("LJ1", _SireMM.LJParameter(lj0.sigma(), lj1.epsilon()))
                 .molecule()
             )
 

--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -693,6 +693,32 @@ def merge(
                     .molecule()
                 )
 
+    # Set the LJ sigma paramater to the value of the opposite end state for any
+    # dummy atoms.
+    for atom in edit_mol.atoms():
+        # Lambda = 0 is a dummy atom.
+        if atom.property("ambertype0") == "du":
+            lj0 = edit_mol.atom(atom.index()).property("LJ0")
+            lj1 = edit_mol.atom(atom.index()).property("LJ1")
+
+            # Set the sigma parameter at lambda = 0.
+            edit_mol = (
+                edit_mol.atom(atom.index())
+                .setProperty("LJ0", _SireMM.LJParameter(lj1.sigma(), lj0.epsilon()))
+                .molecule()
+            )
+        # Lambda = 1 is a dummy atom.
+        if atom.property("ambertype1") == "du":
+            lj0 = edit_mol.atom(atom.index()).property("LJ0")
+            lj1 = edit_mol.atom(atom.index()).property("LJ1")
+
+            # Set the sigma parameter at lambda = 1.
+            edit_mol = (
+                edit_mol.atom(atom.index())
+                .setProperty("LJ1", _SireMM.LJParameter(lj0.sigma(), lj1.epsilon()))
+                .molecule()
+            )
+
     # We now need to merge "bond", "angle", "dihedral", and "improper" parameters.
     # To do so, we extract the properties from molecule1, then add the additional
     # properties from molecule0, making sure to update the atom indices, and bond

--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -693,11 +693,14 @@ def merge(
                     .molecule()
                 )
 
+    # Store a dummy element.
+    dummy = _SireMol.Element(0)
+
     # Set the LJ sigma paramater to the value of the opposite end state for any
     # dummy atoms.
     for atom in edit_mol.atoms():
         # Lambda = 0 is a dummy atom.
-        if atom.property("ambertype0") == "du":
+        if atom.property("element0") == dummy:
             lj0 = edit_mol.atom(atom.index()).property("LJ0")
             lj1 = edit_mol.atom(atom.index()).property("LJ1")
 
@@ -708,7 +711,7 @@ def merge(
                 .molecule()
             )
         # Lambda = 1 is a dummy atom.
-        if atom.property("ambertype1") == "du":
+        if atom.property("element1") == dummy:
             lj0 = edit_mol.atom(atom.index()).property("LJ0")
             lj1 = edit_mol.atom(atom.index()).property("LJ1")
 

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -2989,11 +2989,13 @@ def _has_dummy(mol, idxs, is_lambda1=False):
     element_dummy = _SireMol.Element(0)
     ambertype_dummy = "du"
 
+    # Check that the molecule has the ambertype property.
+    has_ambertype = mol.hasProperty(ambertype_prop)
+
     # Check whether an of the atoms is a dummy.
     for idx in idxs:
-        if (
-            mol.atom(idx).property(element_prop) == element_dummy
-            or mol.atom(idx).property(ambertype_prop) == ambertype_dummy
+        if mol.atom(idx).property(element_prop) == element_dummy or (
+            has_ambertype and mol.atom(idx).property(ambertype_prop) == ambertype_dummy
         ):
             return True
 
@@ -3046,6 +3048,9 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     element_dummy = _SireMol.Element(0)
     ambertype_dummy = "du"
 
+    # Check that the molecule has the ambertype property.
+    has_ambertype = mol.hasProperty(ambertype_prop)
+
     # Initialise a list to store the state of each atom.
     is_dummy = []
 
@@ -3057,7 +3062,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     for idx in idxs:
         is_dummy.append(
             mol.atom(idx).property(element_prop) == element_dummy
-            or mol.atom(idx).property(ambertype_prop) == ambertype_dummy
+            or (
+                has_ambertype
+                and mol.atom(idx).property(ambertype_prop) == ambertype_dummy
+            )
         )
 
     if len(is_dummy) == 1:

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -1129,6 +1129,10 @@ def _to_pert_file(
 
         # 1) Atoms.
 
+        # Store a null LJParameter object for dummy atoms. SOMD requires that
+        # both sigma and epsilon are set to zero for dummy atoms.
+        dummy_lj = _SireMM.LJParameter()
+
         def atom_sorting_criteria(atom):
             LJ0 = atom.property("LJ0")
             LJ1 = atom.property("LJ1")
@@ -1155,6 +1159,13 @@ def _to_pert_file(
                     # Get the initial/final Lennard-Jones properties.
                     LJ0 = atom.property("LJ0")
                     LJ1 = atom.property("LJ1")
+
+                    # Dummy atom at lambda = 0.
+                    if _is_dummy(mol, atom.index(), is_lambda1=False):
+                        LJ0 = dummy_lj
+                    # Dummy atom at lambda = 1.
+                    if _is_dummy(mol, atom.index(), is_lambda1=True):
+                        LJ1 = dummy_lj
 
                     # Atom data.
                     file.write("        name           %s\n" % atom.name().value())
@@ -1198,6 +1209,13 @@ def _to_pert_file(
                     # Get the initial/final Lennard-Jones properties.
                     LJ0 = atom.property("LJ0")
                     LJ1 = atom.property("LJ1")
+
+                    # Dummy atom at lambda = 0.
+                    if _is_dummy(mol, idx, is_lambda1=False):
+                        LJ0 = dummy_lj
+                    # Dummy atom at lambda = 1.
+                    if _is_dummy(mol, idx, is_lambda1=True):
+                        LJ1 = dummy_lj
 
                     # Atom data.
                     file.write("        name           %s\n" % atom.name().value())
@@ -1252,11 +1270,11 @@ def _to_pert_file(
 
                 # Set LJ/charge based on requested perturbed term.
                 if perturbation_type == "discharge_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if is_dummy(mol, idx, is_lambda1=True):
                             atom_type1 = atom_type0
 
                             # In this step, only remove charges from soft-core perturbations.
@@ -1270,7 +1288,7 @@ def _to_pert_file(
 
                         # If perturbing FROM dummy:
                         else:
-                            # All terms have already been perturbed in "5_grow_soft".
+                            # All terms have already been perturbed in "grow_soft".
                             atom_type1 = atom_type0
                             LJ0_value = LJ1_value = (
                                 LJ0.sigma().value(),
@@ -1290,11 +1308,11 @@ def _to_pert_file(
                         charge0_value = charge1_value = atom.property("charge0").value()
 
                 elif perturbation_type == "vanish_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # allow atom types to change.
                             atom_type0 = atom_type0
                             atom_type1 = atom_type1
@@ -1308,7 +1326,7 @@ def _to_pert_file(
 
                         # If perturbing FROM dummy:
                         else:
-                            # All terms have already been perturbed in "5_grow_soft".
+                            # All terms have already been perturbed in "grow_soft".
                             atom_type1 = atom_type0
                             LJ0_value = LJ1_value = (
                                 LJ0.sigma().value(),
@@ -1328,11 +1346,11 @@ def _to_pert_file(
                         charge0_value = charge1_value = atom.property("charge0").value()
 
                 elif perturbation_type == "flip":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # atom types have already been changed.
                             atom_type0 = atom_type1
 
@@ -1342,7 +1360,7 @@ def _to_pert_file(
 
                         # If perturbing FROM dummy:
                         else:
-                            # All terms have already been perturbed in "5_grow_soft".
+                            # All terms have already been perturbed in "grow_soft".
                             atom_type1 = atom_type0
                             LJ0_value = LJ1_value = (
                                 LJ0.sigma().value(),
@@ -1362,11 +1380,11 @@ def _to_pert_file(
                         charge1_value = atom.property("charge1").value()
 
                 elif perturbation_type == "grow_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # atom types have already been changed.
                             atom_type0 = atom_type1
 
@@ -1398,11 +1416,11 @@ def _to_pert_file(
                         charge0_value = charge1_value = atom.property("charge1").value()
 
                 elif perturbation_type == "charge_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # atom types have already been changed.
                             atom_type0 = atom_type1
 
@@ -2985,6 +3003,7 @@ def _has_dummy(mol, idxs, is_lambda1=False):
 def _is_dummy(mol, idxs, is_lambda1=False):
     """
     Internal function to return whether each atom is a dummy.
+    If a single index is pased, then a single boolean is returned.
 
     Parameters
     ----------
@@ -3030,6 +3049,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     # Initialise a list to store the state of each atom.
     is_dummy = []
 
+    # Convert single index to list.
+    if not isinstance(idxs, list):
+        idxs = [idxs]
+
     # Check whether each of the atoms is a dummy.
     for idx in idxs:
         is_dummy.append(
@@ -3037,7 +3060,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
             or mol.atom(idx).property(ambertype_prop) == ambertype_dummy
         )
 
-    return is_dummy
+    if len(is_dummy) == 1:
+        return is_dummy[0]
+    else:
+        return is_dummy
 
 
 def _random_suffix(basename, size=4, chars=_string.ascii_uppercase + _string.digits):

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
@@ -739,8 +739,8 @@ def merge(
                     edit_mol.atom(idx).setProperty(name, atom.property(prop)).molecule()
                 )
 
-    # Create a null LJParameter.
-    null_lj = _SireMM.LJParameter()
+    # Tolerance for zero sigma values.
+    null_lj_sigma = 1e-9
 
     # Atoms with zero LJ sigma values need to have their sigma values set to the
     # value from the other end state.
@@ -750,7 +750,7 @@ def merge(
         lj1 = atom.property("LJ1")
 
         # Lambda = 0 state has a zero sigma value.
-        if lj0.sigma() == null_lj.sigma():
+        if abs(lj0.sigma().value()) <= null_lj_sigma:
             # Use the sigma value from the lambda = 1 state.
             edit_mol = (
                 edit_mol.atom(atom.index())
@@ -759,7 +759,7 @@ def merge(
             )
 
         # Lambda = 1 state has a zero sigma value.
-        if lj1.sigma() == null_lj.sigma():
+        if abs(lj1.sigma().value()) <= null_lj_sigma:
             # Use the sigma value from the lambda = 0 state.
             edit_mol = (
                 edit_mol.atom(atom.index())

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
@@ -739,11 +739,14 @@ def merge(
                     edit_mol.atom(idx).setProperty(name, atom.property(prop)).molecule()
                 )
 
+    # Store a dummy element.
+    dummy = _SireMol.Element(0)
+
     # Set the LJ sigma paramater to the value of the opposite end state for any
     # dummy atoms.
     for atom in edit_mol.atoms():
         # Lambda = 0 is a dummy atom.
-        if atom.property("ambertype0") == "du":
+        if atom.property("element0") == dummy:
             lj0 = edit_mol.atom(atom.index()).property("LJ0")
             lj1 = edit_mol.atom(atom.index()).property("LJ1")
 
@@ -754,7 +757,7 @@ def merge(
                 .molecule()
             )
         # Lambda = 1 is a dummy atom.
-        if atom.property("ambertype1") == "du":
+        if atom.property("element1") == dummy:
             lj0 = edit_mol.atom(atom.index()).property("LJ0")
             lj1 = edit_mol.atom(atom.index()).property("LJ1")
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
@@ -739,32 +739,31 @@ def merge(
                     edit_mol.atom(idx).setProperty(name, atom.property(prop)).molecule()
                 )
 
-    # Store a dummy element.
-    dummy = _SireMol.Element(0)
+    # Create a null LJParameter.
+    null_lj = _SireMM.LJParameter()
 
-    # Set the LJ sigma paramater to the value of the opposite end state for any
-    # dummy atoms.
+    # Atoms with zero LJ sigma values need to have their sigma values set to the
+    # value from the other end state.
     for atom in edit_mol.atoms():
-        # Lambda = 0 is a dummy atom.
-        if atom.property("element0") == dummy:
-            lj0 = edit_mol.atom(atom.index()).property("LJ0")
-            lj1 = edit_mol.atom(atom.index()).property("LJ1")
+        # Get the end state LJ sigma values.
+        lj0 = atom.property("LJ0")
+        lj1 = atom.property("LJ1")
 
-            # Set the sigma parameter at lambda = 0.
+        # Lambda = 0 state has a zero sigma value.
+        if lj0.sigma() == null_lj.sigma():
+            # Use the sigma value from the lambda = 1 state.
             edit_mol = (
                 edit_mol.atom(atom.index())
-                .setProperty("LJ0", _SireMM.LJParameter(lj1.sigma(), lj0.epsilon()))
+                .set_property("LJ0", _SireMM.LJParameter(lj1.sigma(), lj0.epsilon()))
                 .molecule()
             )
-        # Lambda = 1 is a dummy atom.
-        if atom.property("element1") == dummy:
-            lj0 = edit_mol.atom(atom.index()).property("LJ0")
-            lj1 = edit_mol.atom(atom.index()).property("LJ1")
 
-            # Set the sigma parameter at lambda = 1.
+        # Lambda = 1 state has a zero sigma value.
+        if lj1.sigma() == null_lj.sigma():
+            # Use the sigma value from the lambda = 0 state.
             edit_mol = (
                 edit_mol.atom(atom.index())
-                .setProperty("LJ1", _SireMM.LJParameter(lj0.sigma(), lj1.epsilon()))
+                .set_property("LJ1", _SireMM.LJParameter(lj0.sigma(), lj1.epsilon()))
                 .molecule()
             )
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
@@ -739,6 +739,32 @@ def merge(
                     edit_mol.atom(idx).setProperty(name, atom.property(prop)).molecule()
                 )
 
+    # Set the LJ sigma paramater to the value of the opposite end state for any
+    # dummy atoms.
+    for atom in edit_mol.atoms():
+        # Lambda = 0 is a dummy atom.
+        if atom.property("ambertype0") == "du":
+            lj0 = edit_mol.atom(atom.index()).property("LJ0")
+            lj1 = edit_mol.atom(atom.index()).property("LJ1")
+
+            # Set the sigma parameter at lambda = 0.
+            edit_mol = (
+                edit_mol.atom(atom.index())
+                .setProperty("LJ0", _SireMM.LJParameter(lj1.sigma(), lj0.epsilon()))
+                .molecule()
+            )
+        # Lambda = 1 is a dummy atom.
+        if atom.property("ambertype1") == "du":
+            lj0 = edit_mol.atom(atom.index()).property("LJ0")
+            lj1 = edit_mol.atom(atom.index()).property("LJ1")
+
+            # Set the sigma parameter at lambda = 1.
+            edit_mol = (
+                edit_mol.atom(atom.index())
+                .setProperty("LJ1", _SireMM.LJParameter(lj0.sigma(), lj1.epsilon()))
+                .molecule()
+            )
+
     # We now need to merge "bond", "angle", "dihedral", and "improper" parameters.
     # To do so, we extract the properties from molecule1, then add the additional
     # properties from molecule0, making sure to update the atom indices, and bond

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -3349,11 +3349,13 @@ def _has_dummy(mol, idxs, is_lambda1=False):
     element_dummy = _SireMol.Element(0)
     ambertype_dummy = "du"
 
+    # Check that the molecule has the ambertype property.
+    has_ambertype = mol.hasProperty(ambertype_prop)
+
     # Check whether an of the atoms is a dummy.
     for idx in idxs:
-        if (
-            mol.atom(idx).property(element_prop) == element_dummy
-            or mol.atom(idx).property(ambertype_prop) == ambertype_dummy
+        if mol.atom(idx).property(element_prop) == element_dummy or (
+            has_ambertype and mol.atom(idx).property(ambertype_prop) == ambertype_dummy
         ):
             return True
 
@@ -3406,6 +3408,9 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     element_dummy = _SireMol.Element(0)
     ambertype_dummy = "du"
 
+    # Check that the molecule has the ambertype property.
+    has_ambertype = mol.hasProperty(ambertype_prop)
+
     # Initialise a list to store the state of each atom.
     is_dummy = []
 
@@ -3417,7 +3422,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     for idx in idxs:
         is_dummy.append(
             mol.atom(idx).property(element_prop) == element_dummy
-            or mol.atom(idx).property(ambertype_prop) == ambertype_dummy
+            or (
+                has_ambertype
+                and mol.atom(idx).property(ambertype_prop) == ambertype_dummy
+            )
         )
 
     if len(is_dummy) == 1:

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -1209,6 +1209,10 @@ def _to_pert_file(
 
         # 1) Atoms.
 
+        # Store a null LJParameter object for dummy atoms. SOMD requires that
+        # both sigma and epsilon are set to zero for dummy atoms.
+        dummy_lj = _SireMM.LJParameter()
+
         def atom_sorting_criteria(atom):
             LJ0 = atom.property("LJ0")
             LJ1 = atom.property("LJ1")
@@ -1235,6 +1239,13 @@ def _to_pert_file(
                     # Get the initial/final Lennard-Jones properties.
                     LJ0 = atom.property("LJ0")
                     LJ1 = atom.property("LJ1")
+
+                    # Dummy atom at lambda = 0.
+                    if _is_dummy(mol, atom.index(), is_lambda1=False):
+                        LJ0 = dummy_lj
+                    # Dummy atom at lambda = 1.
+                    if _is_dummy(mol, atom.index(), is_lambda1=True):
+                        LJ1 = dummy_lj
 
                     # Atom data.
                     file.write("        name           %s\n" % atom.name().value())
@@ -1279,6 +1290,13 @@ def _to_pert_file(
                     LJ0 = atom.property("LJ0")
                     LJ1 = atom.property("LJ1")
 
+                    # Dummy atom at lambda = 0.
+                    if _is_dummy(mol, idx, is_lambda1=False):
+                        LJ0 = dummy_lj
+                    # Dummy atom at lambda = 1.
+                    if _is_dummy(mol, idx, is_lambda1=True):
+                        LJ1 = dummy_lj
+
                     # Atom data.
                     file.write("        name           %s\n" % atom.name().value())
                     file.write(
@@ -1317,6 +1335,10 @@ def _to_pert_file(
 
                     # Only require the initial Lennard-Jones properties.
                     LJ0 = atom.property("LJ0")
+
+                    # Dummy atom at lambda = 0.
+                    if _is_dummy(mol, atom.index(), is_lambda1=False):
+                        LJ0 = dummy_lj
 
                     # Atom data. Create dummy pert file with identical initial and final properties.
                     file.write("        name           %s\n" % atom.name().value())
@@ -1359,6 +1381,10 @@ def _to_pert_file(
 
                     # Only require the initial Lennard-Jones properties.
                     LJ0 = atom.property("LJ0")
+
+                    # Dummy atom at lambda = 0.
+                    if _is_dummy(mol, idx, is_lambda1=False):
+                        LJ0 = dummy_lj
 
                     # Atom data. Create dummy pert file with identical initial and final properties.
                     file.write("        name           %s\n" % atom.name().value())
@@ -1400,6 +1426,10 @@ def _to_pert_file(
                     LJ1 = atom.property("LJ1")
                     charge1_value = atom.property("charge1").value()
 
+                    # Dummy atom at lambda = 1.
+                    if _is_dummy(mol, atom.index(), is_lambda1=True):
+                        LJ1 = dummy_lj
+
                     # Atom data. Create dummy pert file with identical initial and final properties.
                     file.write("        name           %s\n" % atom.name().value())
                     file.write(
@@ -1436,6 +1466,10 @@ def _to_pert_file(
                     # Only require the final Lennard-Jones and charge properties.
                     LJ1 = atom.property("LJ1")
                     charge1_value = atom.property("charge1").value()
+
+                    # Dummy atom at lambda = 1.
+                    if _is_dummy(mol, idx, is_lambda1=True):
+                        LJ1 = dummy_lj
 
                     # Atom data. Create dummy pert file with identical initial and final properties.
                     file.write("        name           %s\n" % atom.name().value())
@@ -1478,6 +1512,13 @@ def _to_pert_file(
                 LJ0 = atom.property("LJ0")
                 LJ1 = atom.property("LJ1")
 
+                # Dummy atom at lambda = 0.
+                if _is_dummy(mol, idx, is_lambda1=False):
+                    LJ0 = dummy_lj
+                # Dummy atom at lambda = 1.
+                if _is_dummy(mol, idx, is_lambda1=True):
+                    LJ1 = dummy_lj
+
                 # Atom data.
                 # Get the atom types:
                 atom_type0 = atom.property("ambertype0")
@@ -1485,11 +1526,11 @@ def _to_pert_file(
 
                 # Set LJ/charge based on requested perturbed term.
                 if perturbation_type == "discharge_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             atom_type1 = atom_type0
 
                             # In this step, only remove charges from soft-core perturbations.
@@ -1503,7 +1544,7 @@ def _to_pert_file(
 
                         # If perturbing FROM dummy:
                         else:
-                            # All terms have already been perturbed in "5_grow_soft".
+                            # All terms have already been perturbed in "grow_soft".
                             atom_type1 = atom_type0
                             LJ0_value = LJ1_value = (
                                 LJ0.sigma().value(),
@@ -1523,11 +1564,11 @@ def _to_pert_file(
                         charge0_value = charge1_value = atom.property("charge0").value()
 
                 elif perturbation_type == "vanish_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # allow atom types to change.
                             atom_type0 = atom_type0
                             atom_type1 = atom_type1
@@ -1541,7 +1582,7 @@ def _to_pert_file(
 
                         # If perturbing FROM dummy:
                         else:
-                            # All terms have already been perturbed in "5_grow_soft".
+                            # All terms have already been perturbed in "grow_soft".
                             atom_type1 = atom_type0
                             LJ0_value = LJ1_value = (
                                 LJ0.sigma().value(),
@@ -1561,11 +1602,11 @@ def _to_pert_file(
                         charge0_value = charge1_value = atom.property("charge0").value()
 
                 elif perturbation_type == "flip":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # atom types have already been changed.
                             atom_type0 = atom_type1
 
@@ -1575,7 +1616,7 @@ def _to_pert_file(
 
                         # If perturbing FROM dummy:
                         else:
-                            # All terms have already been perturbed in "5_grow_soft".
+                            # All terms have already been perturbed in "grow_soft".
                             atom_type1 = atom_type0
                             LJ0_value = LJ1_value = (
                                 LJ0.sigma().value(),
@@ -1595,11 +1636,11 @@ def _to_pert_file(
                         charge1_value = atom.property("charge1").value()
 
                 elif perturbation_type == "grow_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # atom types have already been changed.
                             atom_type0 = atom_type1
 
@@ -1631,11 +1672,11 @@ def _to_pert_file(
                         charge0_value = charge1_value = atom.property("charge1").value()
 
                 elif perturbation_type == "charge_soft":
-                    if atom.property("element0") == _SireMol.Element(
-                        "X"
-                    ) or atom.property("element1") == _SireMol.Element("X"):
+                    if _is_dummy(mol, idx, is_lambda1=False) or _is_dummy(
+                        mol, idx, is_lambda1=True
+                    ):
                         # If perturbing TO dummy:
-                        if atom.property("element1") == _SireMol.Element("X"):
+                        if _is_dummy(mol, idx, is_lambda1=True):
                             # atom types have already been changed.
                             atom_type0 = atom_type1
 
@@ -3322,6 +3363,7 @@ def _has_dummy(mol, idxs, is_lambda1=False):
 def _is_dummy(mol, idxs, is_lambda1=False):
     """
     Internal function to return whether each atom is a dummy.
+    If a single index is pased, then a single boolean is returned.
 
     Parameters
     ----------
@@ -3367,6 +3409,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     # Initialise a list to store the state of each atom.
     is_dummy = []
 
+    # Convert single index to list.
+    if not isinstance(idxs, list):
+        idxs = [idxs]
+
     # Check whether each of the atoms is a dummy.
     for idx in idxs:
         is_dummy.append(
@@ -3374,7 +3420,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
             or mol.atom(idx).property(ambertype_prop) == ambertype_dummy
         )
 
-    return is_dummy
+    if len(is_dummy) == 1:
+        return is_dummy[0]
+    else:
+        return is_dummy
 
 
 def _random_suffix(basename, size=4, chars=_string.ascii_uppercase + _string.digits):


### PR DESCRIPTION
This PR switches to not perturbing the LJ sigma parameter for ghost atoms so that merged molecules created by BioSimSpace are compatible with  SOMD2 by default. We still preserve the existing behaviour (zero sigma and epsilon) for SOMD1. The PR also includes a few modifications to harden the checking of dummy atoms during the pert file writing stage. (This isn't needed during merging, since we are explicitly setting the appropriate molecule and atom properties.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@chryswoods
