### PR TITLE
Fix issue #299

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -764,7 +764,7 @@ def saveMolecules(
             continue
 
         # Add the file format to the property map.
-        _property_map["fileformat"] = _SireBase.wrap(format)
+        _property_map["fileformat"] = format
 
         # Warn the user if any molecules are parameterised with a force field
         # that uses geometric combining rules. While we can write this to file

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -111,8 +111,10 @@ def parameterise(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if not isinstance(forcefield, str):
@@ -208,8 +210,10 @@ def _parameterise_amber_protein(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if not isinstance(forcefield, str):
@@ -314,8 +318,10 @@ def gaff(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if _amber_home is None:
@@ -407,8 +413,10 @@ def gaff2(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if _amber_home is None:
@@ -506,8 +514,10 @@ def _parameterise_openff(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     from sire.legacy.Base import findExe as _findExe
@@ -1068,8 +1078,10 @@ def _make_amber_protein_function(name):
         Returns
         -------
 
-        molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-            The parameterised molecule.
+        process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+            A process to parameterise the molecule in the background. Call the
+            .getMolecule() method on the returned process to block until the
+            parameterisation is complete and get the parameterised molecule.
         """
         return _parameterise_amber_protein(
             name,
@@ -1133,8 +1145,10 @@ def _make_openff_function(name):
         Returns
         -------
 
-        molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-            The parameterised molecule.
+        process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+            A process to parameterise the molecule in the background. Call the
+            .getMolecule() method on the returned process to block until the
+            parameterisation is complete and get the parameterised molecule.
         """
         return _parameterise_openff(
             name,

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -764,7 +764,7 @@ def saveMolecules(
             continue
 
         # Add the file format to the property map.
-        _property_map["fileformat"] = _SireBase.wrap(format)
+        _property_map["fileformat"] = format
 
         # Warn the user if any molecules are parameterised with a force field
         # that uses geometric combining rules. While we can write this to file

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -111,8 +111,10 @@ def parameterise(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if not isinstance(forcefield, str):
@@ -208,8 +210,10 @@ def _parameterise_amber_protein(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if not isinstance(forcefield, str):
@@ -314,8 +318,10 @@ def gaff(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if _amber_home is None:
@@ -407,8 +413,10 @@ def gaff2(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     if _amber_home is None:
@@ -506,8 +514,10 @@ def _parameterise_openff(
     Returns
     -------
 
-    molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-        The parameterised molecule.
+    process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+        A process to parameterise the molecule in the background. Call the
+        .getMolecule() method on the returned process to block until the
+        parameterisation is complete and get the parameterised molecule.
     """
 
     from sire.legacy.Base import findExe as _findExe
@@ -1068,8 +1078,10 @@ def _make_amber_protein_function(name):
         Returns
         -------
 
-        molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-            The parameterised molecule.
+        process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+            A process to parameterise the molecule in the background. Call the
+            .getMolecule() method on the returned process to block until the
+            parameterisation is complete and get the parameterised molecule.
         """
         return _parameterise_amber_protein(
             name,
@@ -1133,8 +1145,10 @@ def _make_openff_function(name):
         Returns
         -------
 
-        molecule : :class:`Molecule <BioSimSpace._SireWrappers.Molecule>`
-            The parameterised molecule.
+        process : :class:`Process <BioSimSpace.Parameters._process.Process>`
+            A process to parameterise the molecule in the background. Call the
+            .getMolecule() method on the returned process to block until the
+            parameterisation is complete and get the parameterised molecule.
         """
         return _parameterise_openff(
             name,


### PR DESCRIPTION
This PR closes #299 but not using `sire.legacy.Base.wrap` for string values in the `property_map`, which were incorrectly being cast to `GeneralUnit`. This allows Mol2 files to be written from by `BioSimSpace.IO.saveMolecules`. This superseds #298.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
