### PR TITLE
Synchronise with Exscientia remote

### DIFF
--- a/.github/workflows/Sandpit_exs.yml
+++ b/.github/workflows/Sandpit_exs.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macOS-latest",]
+        os: ["ubuntu-latest", ]
         python-version: ["3.10",]
 
     steps:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependency
         run: |
-          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.10 ambertools gromacs "sire=2023.5" "alchemlyb>=2.1" pytest openff-interchange pint=0.21 rdkit "jaxlib>0.3.7" tqdm
+          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.10 ambertools gromacs "sire=2024.1.0" "alchemlyb>=2.1" pytest openff-interchange pint=0.21 rdkit "jaxlib>0.3.7" tqdm
           python -m pip install git+https://github.com/Exscientia/MDRestraintsGenerator.git
           # For the testing of BSS.FreeEnergy.AlchemicalFreeEnergy.analysis
           python -m pip install https://github.com/alchemistry/alchemtest/archive/master.zip

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -92,6 +92,9 @@ _MDRestraintsGenerator = _try_import(
     install_command="pip install MDRestraintsGenerator",
 )
 if _have_imported(_MDRestraintsGenerator):
+    from Bio import BiopythonDeprecationWarning
+
+    _warnings.simplefilter("ignore", BiopythonDeprecationWarning)
     from MDRestraintsGenerator import search as _search
     from MDRestraintsGenerator.restraints import (
         FindBoreschRestraint as _FindBoreschRestraint,

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -145,6 +145,14 @@ class Amber(_process.Process):
             property_map,
         )
 
+        if (
+            not isinstance(protocol, _Protocol._FreeEnergyMixin)
+            and system.nPerturbableMolecules()
+        ):
+            raise _IncompatibleError(
+                "Perturbable system is not compatible with none free energy protocol."
+            )
+
         # Set the package name.
         self._package_name = "AMBER"
 
@@ -2936,7 +2944,7 @@ class Amber(_process.Process):
         for file in _Path(self.workDir()).glob("*.out.offset"):
             os.remove(file)
 
-    def saveMetric(
+    def _saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """
@@ -2945,41 +2953,54 @@ class Amber(_process.Process):
         is Free Energy protocol, the dHdl and the u_nk data will be saved in the
         same parquet format as well.
         """
+        if filename is not None:
+            self._init_stdout_dict()
+            if isinstance(self._protocol, _Protocol.Minimisation):
+                datadict_keys = [
+                    ("Time (ps)", None, "getStep"),
+                    (
+                        "PotentialEnergy (kJ/mol)",
+                        _Units.Energy.kj_per_mol,
+                        "getTotalEnergy",
+                    ),
+                ]
+            else:
+                datadict_keys = [
+                    ("Time (ps)", _Units.Time.picosecond, "getTime"),
+                    (
+                        "PotentialEnergy (kJ/mol)",
+                        _Units.Energy.kj_per_mol,
+                        "getPotentialEnergy",
+                    ),
+                    ("Volume (nm^3)", _Units.Volume.nanometer3, "getVolume"),
+                    ("Pressure (bar)", _Units.Pressure.bar, "getPressure"),
+                    (
+                        "Temperature (kelvin)",
+                        _Units.Temperature.kelvin,
+                        "getTemperature",
+                    ),
+                ]
+            # # Disable this now
+            df = self._convert_datadict_keys(datadict_keys)
+            df.to_parquet(path=f"{self.workDir()}/{filename}", index=True)
+        if u_nk is not None or dHdl is not None:
+            _assert_imported(_alchemlyb)
 
-        _assert_imported(_alchemlyb)
-
-        self._init_stdout_dict()
-        datadict = dict()
-        if isinstance(self._protocol, _Protocol.Minimisation):
-            datadict_keys = [
-                ("Time (ps)", None, "getStep"),
-                (
-                    "PotentialEnergy (kJ/mol)",
-                    _Units.Energy.kj_per_mol,
-                    "getTotalEnergy",
-                ),
-            ]
-        else:
-            datadict_keys = [
-                ("Time (ps)", _Units.Time.picosecond, "getTime"),
-                (
-                    "PotentialEnergy (kJ/mol)",
-                    _Units.Energy.kj_per_mol,
-                    "getPotentialEnergy",
-                ),
-                ("Volume (nm^3)", _Units.Volume.nanometer3, "getVolume"),
-                ("Pressure (bar)", _Units.Pressure.bar, "getPressure"),
-                ("Temperature (kelvin)", _Units.Temperature.kelvin, "getTemperature"),
-            ]
-        # # Disable this now
-        df = self._convert_datadict_keys(datadict_keys)
-        df.to_parquet(path=f"{self.workDir()}/{filename}", index=True)
-        if isinstance(self._protocol, _Protocol.FreeEnergy):
-            energy = _extract(
-                f"{self.workDir()}/{self._name}.out",
-                T=self._protocol.getTemperature() / _Units.Temperature.kelvin,
-            )
-            if "u_nk" in energy and energy["u_nk"] is not None:
-                energy["u_nk"].to_parquet(path=f"{self.workDir()}/{u_nk}", index=True)
-            if "dHdl" in energy and energy["dHdl"] is not None:
-                energy["dHdl"].to_parquet(path=f"{self.workDir()}/{dHdl}", index=True)
+            if isinstance(self._protocol, _Protocol.FreeEnergy):
+                energy = _extract(
+                    f"{self.workDir()}/{self._name}.out",
+                    T=self._protocol.getTemperature() / _Units.Temperature.kelvin,
+                )
+                with _warnings.catch_warnings():
+                    _warnings.filterwarnings(
+                        "ignore",
+                        message="The DataFrame has column names of mixed type.",
+                    )
+                    if "u_nk" in energy and energy["u_nk"] is not None:
+                        energy["u_nk"].to_parquet(
+                            path=f"{self.workDir()}/{u_nk}", index=True
+                        )
+                    if "dHdl" in energy and energy["dHdl"] is not None:
+                        energy["dHdl"].to_parquet(
+                            path=f"{self.workDir()}/{dHdl}", index=True
+                        )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
@@ -911,16 +911,6 @@ class Process:
 
         # The process isn't running.
         if not self.isRunning():
-            try:
-                self.saveMetric()
-            except Exception:
-                exception_info = traceback.format_exc()
-                with open(f"{self.workDir()}/{self._name}.err", "a+") as f:
-                    f.write("Exception Information during saveMetric():\n")
-                    f.write("======================\n")
-                    f.write(exception_info)
-                    f.write("\n\n")
-
             return
 
         if max_time is not None:
@@ -1650,12 +1640,25 @@ class Process:
         """Generate the dictionary of command-line arguments."""
         self.clearArgs()
 
+    def _saveMetric(self, filename, u_nk, dHdl):
+        """The abstract function to save the metric and free energy data. Need to be
+        defined for each MD engine."""
+        pass
+
     def saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """The abstract function to save the metric and free energy data. Need to be
         defined for each MD engine."""
-        pass
+        try:
+            self._saveMetric(filename, u_nk, dHdl)
+        except Exception:
+            exception_info = traceback.format_exc()
+            with open(f"{self.workDir()}/{self._name}.err", "a+") as f:
+                f.write("Exception Information during saveMetric():\n")
+                f.write("======================\n")
+                f.write(exception_info)
+                f.write("\n\n")
 
     def _convert_datadict_keys(self, datadict_keys):
         """This function is a helper function for saveMetric that converts a

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1359,7 +1359,11 @@ class System(_SireWrapper):
             The Alchemical Ion or None if there isn't any.
         """
         try:
-            return self.search("mols with property AlchemicalIon").molecules()[0]
+            return (
+                self.search("mols with property AlchemicalIon")
+                .molecules()[0]
+                .getAtoms()[0]
+            )
         except:
             return None
 

--- a/tests/Sandpit/Exscientia/Align/test_alchemical_ion.py
+++ b/tests/Sandpit/Exscientia/Align/test_alchemical_ion.py
@@ -5,7 +5,7 @@ from BioSimSpace.Sandpit.Exscientia.Align._alch_ion import (
     _get_protein_com_idx,
     _mark_alchemical_ion,
 )
-from BioSimSpace.Sandpit.Exscientia._SireWrappers import Molecule
+from BioSimSpace.Sandpit.Exscientia._SireWrappers import Atom
 from tests.conftest import has_gromacs, root_fp
 
 
@@ -45,13 +45,13 @@ def test_getAlchemicalIon(input_system, isalchem, request):
     if isalchem is None:
         assert ion is None
     else:
-        assert isinstance(ion, Molecule)
+        assert isinstance(ion, Atom)
 
 
 @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
 def test_getAlchemicalIonIdx(alchemical_ion_system):
     index = alchemical_ion_system.getAlchemicalIonIdx()
-    assert index == 680
+    assert index == 2053
 
 
 @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
@@ -15,6 +15,8 @@ from BioSimSpace.Sandpit.Exscientia.Units.Energy import kcal_per_mol
 from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 from BioSimSpace.Sandpit.Exscientia.Units.Temperature import kelvin
 
+from tests.conftest import has_gromacs
+
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
 
@@ -75,6 +77,7 @@ def boresch_restraint_component():
     return system, restraint_dict
 
 
+@pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
 @pytest.mark.parametrize(
     ("protocol", "posres"),
     [

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
@@ -1,18 +1,18 @@
-import pytest
-
 import numpy as np
-
-from sire.legacy.Units import angstrom3 as _Sire_angstrom3
-from sire.legacy.Units import k_boltz as _k_boltz
-from sire.legacy.Units import meter3 as _Sire_meter3
-from sire.legacy.Units import mole as _Sire_mole
+import pytest
+from sire.legacy.Units import (
+    angstrom3 as _Sire_angstrom3,
+    k_boltz as _k_boltz,
+    meter3 as _Sire_meter3,
+    mole as _Sire_mole,
+)
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Align import decouple
 from BioSimSpace.Sandpit.Exscientia.FreeEnergy import Restraint
-from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
-from BioSimSpace.Sandpit.Exscientia.Units.Angle import radian, degree
+from BioSimSpace.Sandpit.Exscientia.Units.Angle import degree, radian
 from BioSimSpace.Sandpit.Exscientia.Units.Energy import kcal_per_mol
+from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 from BioSimSpace.Sandpit.Exscientia.Units.Temperature import kelvin
 
 # Store the tutorial URL.
@@ -73,6 +73,28 @@ def boresch_restraint_component():
     }
 
     return system, restraint_dict
+
+
+@pytest.mark.parametrize(
+    ("protocol", "posres"),
+    [
+        (BSS.Protocol.FreeEnergy, "heavy"),
+        (BSS.Protocol.FreeEnergy, None),
+    ],
+)
+def test_top_write(
+    boresch_restraint_component, protocol, posres, tmp_path, boresch_restraint
+):
+    system, restraint_dict = boresch_restraint_component
+    bss_protocol = protocol(restraint=posres)
+    BSS.Process.Gromacs(
+        system,
+        bss_protocol,
+        work_dir=str(tmp_path),
+        restraint=boresch_restraint,
+    )
+    with open(str(tmp_path / "gromacs.top"), "r") as f:
+        assert "intermolecular_interactions" in f.read()
 
 
 @pytest.fixture(scope="session")

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -378,6 +378,10 @@ def test_parse_fep_output(system, protocol):
         assert len(records_sc1) != 0
 
 
+@pytest.mark.skipif(
+    has_amber is False or has_pyarrow is False,
+    reason="Requires AMBER and pyarrow to be installed.",
+)
 class TestsaveMetric:
     @staticmethod
     @pytest.fixture()

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -7,7 +7,12 @@ import pandas as pd
 import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
-from tests.Sandpit.Exscientia.conftest import has_amber, has_pyarrow
+from BioSimSpace.Sandpit.Exscientia._Exceptions import IncompatibleError
+from tests.Sandpit.Exscientia.conftest import (
+    has_amber,
+    has_pyarrow,
+    url,
+)
 from tests.conftest import root_fp
 
 
@@ -401,13 +406,29 @@ class TestsaveMetric:
         process.saveMetric()
         return process
 
+    def test_incompatible_error(self):
+        alchemical_system = BSS.IO.readPerturbableSystem(
+            f"{url}/complex_vac0.prm7.bz2",
+            f"{url}/complex_vac0.rst7.bz2",
+            f"{url}/complex_vac1.prm7.bz2",
+            f"{url}/complex_vac1.rst7.bz2",
+        )
+        with pytest.raises(
+            IncompatibleError,
+            match="Perturbable system is not compatible with none free energy protocol.",
+        ):
+            BSS.Process.Amber(
+                alchemical_system,
+                BSS.Protocol.Minimisation(),
+            )
+
     def test_error_alchemlyb_extract(self, alchemical_system):
         # Create a process using any system and the protocol.
         process = BSS.Process.Amber(
             alchemical_system,
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
-        process.wait()
+        process.saveMetric()
         with open(process.workDir() + "/amber.err", "r") as f:
             text = f.read()
             assert "Exception Information" in text
@@ -433,3 +454,37 @@ class TestsaveMetric:
         process = BSS.Process.Amber(system, BSS.Protocol.Production())
         with pytest.warns(match="Simulation didn't produce any output."):
             process.saveMetric()
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("filename", "u_nk", "dHdl"),
+        [
+            ("metric.parquet", None, None),
+            (None, "u_nk.parquet", None),
+            (None, None, "dHdl.parquet"),
+        ],
+    )
+    def test_selective(alchemical_system, filename, u_nk, dHdl):
+        # Create a process using any system and the protocol.
+        process = BSS.Process.Amber(
+            alchemical_system,
+            BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
+        )
+        shutil.copyfile(
+            f"{root_fp}/Sandpit/Exscientia/output/amber_fep.out",
+            process.workDir() + "/amber.out",
+        )
+        process.saveMetric(filename, u_nk, dHdl)
+        if filename is not None:
+            assert (Path(process.workDir()) / filename).exists()
+        else:
+            assert not (Path(process.workDir()) / "metric.parquet").exists()
+        if u_nk is not None:
+            assert (Path(process.workDir()) / u_nk).exists()
+        else:
+            assert not (Path(process.workDir()) / "u_nk.parquet").exists()
+        if dHdl is not None:
+            # The file doesn't contain dHdl information
+            pass
+        else:
+            assert not (Path(process.workDir()) / "dHdl.parquet").exists()

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -450,6 +450,10 @@ class TestGetRecord:
             assert not (Path(process.workDir()) / "dHdl.parquet").exists()
 
 
+@pytest.mark.skipif(
+    has_gromacs is False or has_pyarrow is False,
+    reason="Requires GROMACS and pyarrow to be installed.",
+)
 def test_error_saveMetric(perturbable_system):
     protocol = BSS.Protocol.FreeEnergy()
     process = BSS.Process.Gromacs(perturbable_system, protocol)

--- a/tests/Sandpit/Exscientia/Process/test_position_restraint.py
+++ b/tests/Sandpit/Exscientia/Process/test_position_restraint.py
@@ -13,7 +13,6 @@ from BioSimSpace.Sandpit.Exscientia.Align._alch_ion import _mark_alchemical_ion
 from BioSimSpace.Sandpit.Exscientia.Units.Energy import kj_per_mol
 from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 from BioSimSpace.Sandpit.Exscientia._SireWrappers import Molecule
-from tests.Sandpit.Exscientia.conftest import has_amber, has_gromacs, has_openff
 from tests.conftest import root_fp
 
 
@@ -36,12 +35,20 @@ def alchemical_ion_system():
     )
     ion = solvated.getMolecule(-1)
     pert_ion = BSS.Align.merge(ion, ion, mapping={0: 0})
+    for lambda_ in [0, 1]:
+        atomtype = pert_ion._sire_object.property(f"atomtype{lambda_}")
+        pert_ion._sire_object = (
+            pert_ion._sire_object.edit()
+            .setProperty(f"ambertype{lambda_}", atomtype)
+            .molecule()
+        )
     pert_ion._sire_object = (
         pert_ion.getAtoms()[0]
         ._sire_object.edit()
         .setProperty("charge1", 0 * SireUnits.mod_electron)
         .molecule()
     )
+
     alchemcial_ion = _mark_alchemical_ion(pert_ion)
     solvated.updateMolecule(solvated.getIndex(ion), alchemcial_ion)
     return solvated
@@ -131,10 +138,6 @@ def protocol(request, restraint, free_energy, minimisation, equilibration, produ
             return BSS.Protocol.Production(**production, **restraint)
 
 
-@pytest.mark.skipif(
-    has_gromacs is False or has_openff is False,
-    reason="Requires GROMACS and openff to be installed",
-)
 def test_gromacs(protocol, system, ref_system, tmp_path):
     proc = BSS.Process.Gromacs(
         system,
@@ -159,11 +162,9 @@ def test_gromacs(protocol, system, ref_system, tmp_path):
     assert len(diff)
 
 
-@pytest.mark.skipif(
-    has_amber is False or has_openff is False,
-    reason="Requires AMBER and openff to be installed",
-)
 def test_amber(protocol, system, ref_system, tmp_path):
+    if not isinstance(protocol, BSS.Protocol._FreeEnergyMixin):
+        pytest.skip("AMBER position restraint only works for free energy protocol")
     proc = BSS.Process.Amber(
         system, protocol, reference_system=ref_system, work_dir=str(tmp_path)
     )
@@ -186,10 +187,6 @@ def test_amber(protocol, system, ref_system, tmp_path):
     assert f"{proc._work_dir}/{proc.getArgs()['-ref']}" == proc._ref_file
 
 
-@pytest.mark.skipif(
-    has_gromacs is False or has_openff is False,
-    reason="Requires GROMACS and openff to be installed",
-)
 @pytest.mark.parametrize(
     "restraint",
     ["backbone", "heavy", "all", "none"],
@@ -235,24 +232,28 @@ def test_gromacs_alchemical_ion(
     assert gro[2].split() == ["1ACE", "HH31", "1", "0.000", "0.000", "0.000"]
 
 
-@pytest.mark.skipif(
-    has_amber is False or has_gromacs is False or has_openff is False,
-    reason="Requires AMBER, GROMACS and OpenFF to be installed",
-)
 @pytest.mark.parametrize(
-    ("restraint", "target"),
+    ("restraint", "protocol", "target"),
     [
-        ("backbone", "@5-7,9,15-17 | @2148 | @8"),
-        ("heavy", "@2,5-7,9,11,15-17,19 | @2148 | @8"),
-        ("all", "@1-22 | @2148 | @8"),
-        ("none", "@2148 | @8"),
+        (
+            "backbone",
+            BSS.Protocol.FreeEnergyEquilibration,
+            "@5-7,9,15-17 | @9,6442,6443",
+        ),
+        (
+            "heavy",
+            BSS.Protocol.FreeEnergyEquilibration,
+            "@2,5-7,9,11,15-17,19 | @9,6442,6443",
+        ),
+        ("all", BSS.Protocol.FreeEnergyEquilibration, "@1-22 | @9,6442,6443"),
+        ("none", BSS.Protocol.FreeEnergyEquilibration, "@9,6442,6443"),
     ],
 )
 def test_amber_alchemical_ion(
-    alchemical_ion_system, restraint, target, alchemical_ion_system_psores
+    alchemical_ion_system, restraint, protocol, target, alchemical_ion_system_psores
 ):
     # Create an equilibration protocol with backbone restraints.
-    protocol = BSS.Protocol.Equilibration(restraint=restraint)
+    protocol = protocol(restraint=restraint)
 
     # Create the process object.
     process = BSS.Process.Amber(

--- a/tests/Sandpit/Exscientia/Process/test_position_restraint.py
+++ b/tests/Sandpit/Exscientia/Process/test_position_restraint.py
@@ -13,6 +13,7 @@ from BioSimSpace.Sandpit.Exscientia.Align._alch_ion import _mark_alchemical_ion
 from BioSimSpace.Sandpit.Exscientia.Units.Energy import kj_per_mol
 from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 from BioSimSpace.Sandpit.Exscientia._SireWrappers import Molecule
+from tests.Sandpit.Exscientia.conftest import has_amber, has_gromacs, has_openff
 from tests.conftest import root_fp
 
 
@@ -138,6 +139,10 @@ def protocol(request, restraint, free_energy, minimisation, equilibration, produ
             return BSS.Protocol.Production(**production, **restraint)
 
 
+@pytest.mark.skipif(
+    has_gromacs is False or has_openff is False,
+    reason="Requires GROMACS and openff to be installed",
+)
 def test_gromacs(protocol, system, ref_system, tmp_path):
     proc = BSS.Process.Gromacs(
         system,
@@ -162,6 +167,10 @@ def test_gromacs(protocol, system, ref_system, tmp_path):
     assert len(diff)
 
 
+@pytest.mark.skipif(
+    has_amber is False or has_openff is False,
+    reason="Requires AMBER and openff to be installed",
+)
 def test_amber(protocol, system, ref_system, tmp_path):
     if not isinstance(protocol, BSS.Protocol._FreeEnergyMixin):
         pytest.skip("AMBER position restraint only works for free energy protocol")
@@ -187,6 +196,10 @@ def test_amber(protocol, system, ref_system, tmp_path):
     assert f"{proc._work_dir}/{proc.getArgs()['-ref']}" == proc._ref_file
 
 
+@pytest.mark.skipif(
+    has_gromacs is False or has_openff is False,
+    reason="Requires GROMACS and openff to be installed",
+)
 @pytest.mark.parametrize(
     "restraint",
     ["backbone", "heavy", "all", "none"],
@@ -232,6 +245,10 @@ def test_gromacs_alchemical_ion(
     assert gro[2].split() == ["1ACE", "HH31", "1", "0.000", "0.000", "0.000"]
 
 
+@pytest.mark.skipif(
+    has_amber is False or has_gromacs is False or has_openff is False,
+    reason="Requires AMBER, GROMACS and OpenFF to be installed",
+)
 @pytest.mark.parametrize(
     ("restraint", "protocol", "target"),
     [

--- a/tests/Sandpit/Exscientia/Process/test_restart.py
+++ b/tests/Sandpit/Exscientia/Process/test_restart.py
@@ -116,6 +116,8 @@ def test_gromacs(protocol, system, tmp_path):
     reason="Requires AMBER and OpenFF to be installed.",
 )
 def test_amber(protocol, system, tmp_path):
+    if not isinstance(protocol, BSS.Protocol._FreeEnergyMixin):
+        pytest.skip("AMBER position restraint only works for free energy protocol")
     BSS.Process.Amber(system, protocol, work_dir=str(tmp_path))
     with open(tmp_path / "amber.cfg", "r") as f:
         cfg = f.read()


### PR DESCRIPTION
This synchronises with the Exscientia remote ahead of the 2024.2.0 release. Annoyingly it appears that many platform specific skipif directives had been removed from the tests, so I've needed to manually re-add them. Hopefully the CI passes, otherwise I'll need to check what else might have been removed. I'll make a note to mention this since there's no reason to do this. Specific dependencies need to be present for the tests to run. Clearly they are only running their own CI on a specific platform, so thought they could remove them as some minor optimisation.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]