### PR TITLE
Fix issue #330

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -310,15 +310,24 @@ class AmberProtein(_protocol.Protocol):
         if work_dir is None:
             work_dir = _os.getcwd()
 
-        # Flag whether the molecule is a SMILES string.
+        # Try to create a molecule from the SMILES string.
         if isinstance(molecule, str):
-            is_smiles = True
-        else:
-            is_smiles = False
+            try:
+                smiles = molecule
+                molecule = _smiles(molecule)
+                edit_mol = molecule._sire_object.edit()
+                edit_mol = edit_mol.rename(f"smiles:{smiles}").molecule()
+                molecule._sire_object = edit_mol.commit()
+            except Exception as e:
+                msg = "Unable to convert SMILES to Molecule using RDKit."
+                if _isVerbose():
+                    msg += ": " + getattr(e, "message", repr(e))
+                    raise _ThirdPartyError(msg) from e
+                else:
+                    raise _ThirdPartyError(msg) from None
 
-        if not is_smiles:
-            # Create a copy of the molecule.
-            new_mol = molecule.copy()
+        # Create a copy of the molecule.
+        new_mol = molecule.copy()
 
         # Choose the program to run with depending on the force field compatibility.
         # If tLEaP and pdb2gmx are supported, default to tLEaP, then use pdb2gmx if
@@ -328,8 +337,7 @@ class AmberProtein(_protocol.Protocol):
         if self._tleap:
             if _tleap_exe is not None:
                 output = self._run_tleap(molecule, str(work_dir))
-                if not is_smiles:
-                    new_mol._ion_water_model = self._water_model
+                new_mol._ion_water_model = self._water_model
             # Otherwise, try using pdb2gmx.
             elif self._pdb2gmx:
                 if _gmx_exe is not None:
@@ -371,41 +379,23 @@ class AmberProtein(_protocol.Protocol):
         # Make the molecule 'mol' compatible with 'par_mol'. This will create
         # a mapping between atom indices in the two molecules and add all of
         # the new properties from 'par_mol' to 'mol'.
-        if is_smiles:
-            new_mol = par_mol
-
-            # We'll now add MolName and ResName info to the molecule, since
-            # this will be missing.
-
-            # Rename the molecule with the original SMILES string.
-            edit_mol = new_mol._sire_object.edit()
-            edit_mol = edit_mol.rename(molecule).molecule()
-
-            # Rename the residue LIG.
-            resname = _SireMol.ResName("LIG")
-            edit_mol = edit_mol.residue(_SireMol.ResIdx(0)).rename(resname).molecule()
-
-            # Commit the changes.
-            new_mol._sire_object = edit_mol.commit()
-
+        if self._ensure_compatible:
+            new_mol.makeCompatibleWith(
+                par_mol,
+                property_map=self._property_map,
+                overwrite=True,
+                verbose=False,
+            )
         else:
-            if self._ensure_compatible:
+            try:
                 new_mol.makeCompatibleWith(
                     par_mol,
                     property_map=self._property_map,
                     overwrite=True,
                     verbose=False,
                 )
-            else:
-                try:
-                    new_mol.makeCompatibleWith(
-                        par_mol,
-                        property_map=self._property_map,
-                        overwrite=True,
-                        verbose=False,
-                    )
-                except:
-                    new_mol = par_mol
+            except:
+                new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield
@@ -1009,9 +999,12 @@ class GAFF(_protocol.Protocol):
 
         # Convert SMILES to a molecule.
         if isinstance(molecule, str):
-            is_smiles = True
             try:
+                smiles = molecule
                 new_mol = _smiles(molecule)
+                edit_mol = new_mol._sire_object.edit()
+                edit_mol = edit_mol.rename(f"smiles:{smiles}").molecule()
+                new_mol._sire_object = edit_mol.commit()
             except Exception as e:
                 msg = "Unable to convert SMILES to Molecule using RDKit."
                 if _isVerbose():
@@ -1020,7 +1013,6 @@ class GAFF(_protocol.Protocol):
                 else:
                     raise _ThirdPartyError(msg) from None
         else:
-            is_smiles = False
             new_mol = molecule.copy()
 
         # Use the net molecular charge passed as an option.
@@ -1251,45 +1243,23 @@ class GAFF(_protocol.Protocol):
                     # Make the molecule 'mol' compatible with 'par_mol'. This will create
                     # a mapping between atom indices in the two molecules and add all of
                     # the new properties from 'par_mol' to 'mol'.
-                    if is_smiles:
-                        new_mol = par_mol
-
-                        # We'll now add MolName and ResName info to the molecule, since
-                        # this will be missing.
-
-                        # Rename the molecule with the original SMILES string.
-                        edit_mol = new_mol._sire_object.edit()
-                        edit_mol = edit_mol.rename(molecule).molecule()
-
-                        # Rename the residue LIG.
-                        resname = _SireMol.ResName("LIG")
-                        edit_mol = (
-                            edit_mol.residue(_SireMol.ResIdx(0))
-                            .rename(resname)
-                            .molecule()
+                    if self._ensure_compatible:
+                        new_mol.makeCompatibleWith(
+                            par_mol,
+                            property_map=self._property_map,
+                            overwrite=True,
+                            verbose=False,
                         )
-
-                        # Commit the changes.
-                        new_mol._sire_object = edit_mol.commit()
-
                     else:
-                        if self._ensure_compatible:
+                        try:
                             new_mol.makeCompatibleWith(
                                 par_mol,
                                 property_map=self._property_map,
                                 overwrite=True,
                                 verbose=False,
                             )
-                        else:
-                            try:
-                                new_mol.makeCompatibleWith(
-                                    par_mol,
-                                    property_map=self._property_map,
-                                    overwrite=True,
-                                    verbose=False,
-                                )
-                            except:
-                                new_mol = par_mol
+                        except:
+                            new_mol = par_mol
 
                     # Record the forcefield used to parameterise the molecule.
                     new_mol._forcefield = ff

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -310,15 +310,24 @@ class AmberProtein(_protocol.Protocol):
         if work_dir is None:
             work_dir = _os.getcwd()
 
-        # Flag whether the molecule is a SMILES string.
+        # Try to create a molecule from the SMILES string.
         if isinstance(molecule, str):
-            is_smiles = True
-        else:
-            is_smiles = False
+            try:
+                smiles = molecule
+                molecule = _smiles(molecule)
+                edit_mol = molecule._sire_object.edit()
+                edit_mol = edit_mol.rename(f"smiles:{smiles}").molecule()
+                molecule._sire_object = edit_mol.commit()
+            except Exception as e:
+                msg = "Unable to convert SMILES to Molecule using RDKit."
+                if _isVerbose():
+                    msg += ": " + getattr(e, "message", repr(e))
+                    raise _ThirdPartyError(msg) from e
+                else:
+                    raise _ThirdPartyError(msg) from None
 
-        if not is_smiles:
-            # Create a copy of the molecule.
-            new_mol = molecule.copy()
+        # Create a copy of the molecule.
+        new_mol = molecule.copy()
 
         # Choose the program to run with depending on the force field compatibility.
         # If tLEaP and pdb2gmx are supported, default to tLEaP, then use pdb2gmx if
@@ -328,8 +337,7 @@ class AmberProtein(_protocol.Protocol):
         if self._tleap:
             if _tleap_exe is not None:
                 output = self._run_tleap(molecule, str(work_dir))
-                if not is_smiles:
-                    new_mol._ion_water_model = self._water_model
+                new_mol._ion_water_model = self._water_model
             # Otherwise, try using pdb2gmx.
             elif self._pdb2gmx:
                 if _gmx_exe is not None:
@@ -371,41 +379,23 @@ class AmberProtein(_protocol.Protocol):
         # Make the molecule 'mol' compatible with 'par_mol'. This will create
         # a mapping between atom indices in the two molecules and add all of
         # the new properties from 'par_mol' to 'mol'.
-        if is_smiles:
-            new_mol = par_mol
-
-            # We'll now add MolName and ResName info to the molecule, since
-            # this will be missing.
-
-            # Rename the molecule with the original SMILES string.
-            edit_mol = new_mol._sire_object.edit()
-            edit_mol = edit_mol.rename(molecule).molecule()
-
-            # Rename the residue LIG.
-            resname = _SireMol.ResName("LIG")
-            edit_mol = edit_mol.residue(_SireMol.ResIdx(0)).rename(resname).molecule()
-
-            # Commit the changes.
-            new_mol._sire_object = edit_mol.commit()
-
+        if self._ensure_compatible:
+            new_mol.makeCompatibleWith(
+                par_mol,
+                property_map=self._property_map,
+                overwrite=True,
+                verbose=False,
+            )
         else:
-            if self._ensure_compatible:
+            try:
                 new_mol.makeCompatibleWith(
                     par_mol,
                     property_map=self._property_map,
                     overwrite=True,
                     verbose=False,
                 )
-            else:
-                try:
-                    new_mol.makeCompatibleWith(
-                        par_mol,
-                        property_map=self._property_map,
-                        overwrite=True,
-                        verbose=False,
-                    )
-                except:
-                    new_mol = par_mol
+            except:
+                new_mol = par_mol
 
         # Record the forcefield used to parameterise the molecule.
         new_mol._forcefield = self._forcefield
@@ -1009,9 +999,12 @@ class GAFF(_protocol.Protocol):
 
         # Convert SMILES to a molecule.
         if isinstance(molecule, str):
-            is_smiles = True
             try:
+                smiles = molecule
                 new_mol = _smiles(molecule)
+                edit_mol = new_mol._sire_object.edit()
+                edit_mol = edit_mol.rename(f"smiles:{smiles}").molecule()
+                new_mol._sire_object = edit_mol.commit()
             except Exception as e:
                 msg = "Unable to convert SMILES to Molecule using RDKit."
                 if _isVerbose():
@@ -1020,7 +1013,6 @@ class GAFF(_protocol.Protocol):
                 else:
                     raise _ThirdPartyError(msg) from None
         else:
-            is_smiles = False
             new_mol = molecule.copy()
 
         # Use the net molecular charge passed as an option.
@@ -1251,45 +1243,23 @@ class GAFF(_protocol.Protocol):
                     # Make the molecule 'mol' compatible with 'par_mol'. This will create
                     # a mapping between atom indices in the two molecules and add all of
                     # the new properties from 'par_mol' to 'mol'.
-                    if is_smiles:
-                        new_mol = par_mol
-
-                        # We'll now add MolName and ResName info to the molecule, since
-                        # this will be missing.
-
-                        # Rename the molecule with the original SMILES string.
-                        edit_mol = new_mol._sire_object.edit()
-                        edit_mol = edit_mol.rename(molecule).molecule()
-
-                        # Rename the residue LIG.
-                        resname = _SireMol.ResName("LIG")
-                        edit_mol = (
-                            edit_mol.residue(_SireMol.ResIdx(0))
-                            .rename(resname)
-                            .molecule()
+                    if self._ensure_compatible:
+                        new_mol.makeCompatibleWith(
+                            par_mol,
+                            property_map=self._property_map,
+                            overwrite=True,
+                            verbose=False,
                         )
-
-                        # Commit the changes.
-                        new_mol._sire_object = edit_mol.commit()
-
                     else:
-                        if self._ensure_compatible:
+                        try:
                             new_mol.makeCompatibleWith(
                                 par_mol,
                                 property_map=self._property_map,
                                 overwrite=True,
                                 verbose=False,
                             )
-                        else:
-                            try:
-                                new_mol.makeCompatibleWith(
-                                    par_mol,
-                                    property_map=self._property_map,
-                                    overwrite=True,
-                                    verbose=False,
-                                )
-                            except:
-                                new_mol = par_mol
+                        except:
+                            new_mol = par_mol
 
                     # Record the forcefield used to parameterise the molecule.
                     new_mol._forcefield = ff

--- a/tests/Parameters/test_parameters.py
+++ b/tests/Parameters/test_parameters.py
@@ -137,3 +137,33 @@ def test_leap_commands(molecule0):
             assert line_pre[-1] < line_post[0]
             for x in range(len(line_post) - 1):
                 assert line_post[x] < line_post[x + 1]
+
+
+@pytest.mark.skipif(
+    has_antechamber is False or has_tleap is False,
+    reason="Requires AmberTools/antechamber and tLEaP to be installed.",
+)
+def test_smiles_stereo():
+    """
+    Test that SMILES string stereochemistry is correctly preserved when
+    parameterising a molecule.
+    """
+
+    from rdkit import Chem
+
+    # Define the SMILES string.
+    smiles = "CC[C@@H](O)C"
+
+    # Create the parameterised molecule.
+    mol = BSS.Parameters.gaff(smiles).getMolecule()
+
+    # Convert to RDKit format.
+    rdmol0 = Chem.MolFromSmiles(smiles)
+    rdmol1 = BSS.Convert.toRDKit(mol)
+
+    # Get the SMILES string.
+    rdmol0_smiles = Chem.MolToSmiles(rdmol0)
+    rdmol1_smiles = Chem.MolToSmiles(Chem.RemoveHs(rdmol1))
+
+    # Make sure the SMILES strings are the same.
+    assert rdmol0_smiles == rdmol1_smiles

--- a/tests/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/tests/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -142,3 +142,33 @@ def test_leap_commands(molecule0):
             assert line_pre[-1] < line_post[0]
             for x in range(len(line_post) - 1):
                 assert line_post[x] < line_post[x + 1]
+
+
+@pytest.mark.skipif(
+    has_antechamber is False or has_tleap is False,
+    reason="Requires AmberTools/antechamber and tLEaP to be installed.",
+)
+def test_smiles_stereo():
+    """
+    Test that SMILES string stereochemistry is correctly preserved when
+    parameterising a molecule.
+    """
+
+    from rdkit import Chem
+
+    # Define the SMILES string.
+    smiles = "CC[C@@H](O)C"
+
+    # Create the parameterised molecule.
+    mol = BSS.Parameters.gaff(smiles).getMolecule()
+
+    # Convert to RDKit format.
+    rdmol0 = Chem.MolFromSmiles(smiles)
+    rdmol1 = BSS.Convert.toRDKit(mol)
+
+    # Get the SMILES string.
+    rdmol0_smiles = Chem.MolToSmiles(rdmol0)
+    rdmol1_smiles = Chem.MolToSmiles(Chem.RemoveHs(rdmol1))
+
+    # Make sure the SMILES strings are the same.
+    assert rdmol0_smiles == rdmol1_smiles


### PR DESCRIPTION
This PR closes #330 by preserving SMILES based molecule properties when parameterising. Previously, `BioSimSpace.Convert.smiles` was only used to create an intermediate molecule during parameterisation, so any properties that were generated at this point were _not_ part of the returned molecule. This PR fixes this by adding them to the molecule, hence preserving attributes that are required for stereochemistry.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

## Suggested reviewers:
@mb2055 