### PR TITLE
Fix issue #335

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -887,14 +887,14 @@ class System(_SireWrapper):
             else:
                 raise ValueError(f"System doesn't contain molecule: {mol}")
 
-        # Update the Sire object.
-        self._sire_object = system
+            # Update the Sire object.
+            self._sire_object = system
 
-        # Reset the index mappings.
-        self._reset_mappings()
+            # Reset the index mappings.
+            self._reset_mappings()
 
-        # Update the molecule numbers.
-        self._mol_nums = self._sire_object.molNums()
+            # Update the molecule numbers.
+            self._mol_nums = self._sire_object.molNums()
 
     def getMolecule(self, index):
         """

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -887,14 +887,14 @@ class System(_SireWrapper):
             else:
                 raise ValueError(f"System doesn't contain molecule: {mol}")
 
-        # Update the Sire object.
-        self._sire_object = system
+            # Update the Sire object.
+            self._sire_object = system
 
-        # Reset the index mappings.
-        self._reset_mappings()
+            # Reset the index mappings.
+            self._reset_mappings()
 
-        # Update the molecule numbers.
-        self._mol_nums = self._sire_object.molNums()
+            # Update the molecule numbers.
+            self._mol_nums = self._sire_object.molNums()
 
     def getMolecule(self, index):
         """


### PR DESCRIPTION
This PR fixes #335 by ensuring that the underlying Sire object of a BioSimSpace system is updated during the inner loop when updating molecules within the system. Otherwise, only the final molecule will be updated.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]