### PR TITLE
Add method to remove the space property from a system

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1670,6 +1670,9 @@ class System(_SireWrapper):
         if len(box) != 3:
             raise ValueError("'angles' must contain three items.")
 
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'.")
+
         # Convert sizes to Anstrom.
         vec = [x.angstroms().value() for x in box]
 
@@ -1720,6 +1723,9 @@ class System(_SireWrapper):
             The box vector angles: yz, xz, and xy.
         """
 
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'.")
+
         # Get the "space" property and convert to a list of BioSimSpace.Type.Length
         # objects.
         try:
@@ -1750,6 +1756,28 @@ class System(_SireWrapper):
             angles = None
 
         return box, angles
+
+    def removeBox(self, property_map={}):
+        """
+        Remove the simulation box from the system.
+
+        Parameters
+        ----------
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+        """
+
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+
+        # Remove the "space" property.
+        try:
+            self._sire_object.removeProperty(property_map.get("space", "space"))
+        except:
+            pass
 
     def makeWhole(self, property_map={}):
         """

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1587,6 +1587,9 @@ class System(_SireWrapper):
         if len(box) != 3:
             raise ValueError("'angles' must contain three items.")
 
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+
         # Convert sizes to Anstrom.
         vec = [x.angstroms().value() for x in box]
 
@@ -1637,6 +1640,9 @@ class System(_SireWrapper):
             The box vector angles: yz, xz, and xy.
         """
 
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+
         # Get the "space" property and convert to a list of BioSimSpace.Type.Length
         # objects.
         try:
@@ -1667,6 +1673,28 @@ class System(_SireWrapper):
             angles = None
 
         return box, angles
+
+    def removeBox(self, property_map={}):
+        """
+        Remove the simulation box from the system.
+
+        Parameters
+        ----------
+
+        property_map : dict
+            A dictionary that maps system "properties" to their user defined
+            values. This allows the user to refer to properties with their
+            own naming scheme, e.g. { "charge" : "my-charge" }
+        """
+
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+
+        # Remove the "space" property.
+        try:
+            self._sire_object.removeProperty(property_map.get("space", "space"))
+        except:
+            pass
 
     def makeWhole(self, property_map={}):
         """

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -494,3 +494,17 @@ def test_set_water_property_preserve(system):
 
     # Make sure the property is preserved.
     assert system[-1]._sire_object.hasProperty("test")
+
+
+def test_remove_box(system):
+    # Make a copy of the system.
+    system = system.copy()
+
+    # Make sure the box is present.
+    assert "space" in system._sire_object.propertyKeys()
+
+    # Remove the box.
+    system.removeBox()
+
+    # Make sure the box is removed.
+    assert not "space" in system._sire_object.propertyKeys()

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -484,3 +484,17 @@ def test_set_water_property_preserve(system):
 
     # Make sure the property is preserved.
     assert system[-1]._sire_object.hasProperty("test")
+
+
+def test_remove_box(system):
+    # Make a copy of the system.
+    system = system.copy()
+
+    # Make sure the box is present.
+    assert "space" in system._sire_object.propertyKeys()
+
+    # Remove the box.
+    system.removeBox()
+
+    # Make sure the box is removed.
+    assert not "space" in system._sire_object.propertyKeys()


### PR DESCRIPTION
This PR adds a method to `BioSimSpace._SireWrappers.System` to remove the space property from a system. At present this doesn't warn the user if there is more than one molecule, e.g. it's not a vacuum system. I'm happy to add this if useful. (I imagine the use case here is removing water from a box, then removing the space.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]


