### PR TITLE
Fix issue #340

### DIFF
--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -304,6 +304,7 @@ class Amber(_process.Process):
 
                     # Set the simulation box.
                     system.setBox(*_cubic(box_length))
+                    reference_system.setBox(*_cubic(box_length))
 
             # Apply SOMD1 compatibility to the perturbation.
             if (
@@ -322,6 +323,7 @@ class Amber(_process.Process):
         else:
             # Check for perturbable molecules and convert to the chosen end state.
             system = self._checkPerturbable(system)
+            reference_system = self._checkPerturbable(self._reference_system)
 
         # RST file (coordinates).
         try:

--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -2115,6 +2115,9 @@ class Namd(_process.Process):
         # Copy the original system.
         s = system.copy()
 
+        # Convert to the chosen end state.
+        s = self._checkPerturbable(s)
+
         # Keyword restraint.
         if isinstance(restraint, str):
             # Loop over all molecules by number.

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -254,6 +254,7 @@ class OpenMM(_process.Process):
 
         # Check for perturbable molecules and convert to the chosen end state.
         system = self._checkPerturbable(system)
+        reference_system = self._checkPerturbable(self._reference_system)
 
         # Create the input files...
 
@@ -274,7 +275,7 @@ class OpenMM(_process.Process):
                 file = _os.path.splitext(self._ref_file)[0]
                 _IO.saveMolecules(
                     file,
-                    self._reference_system,
+                    reference_system,
                     "rst7",
                     property_map=self._property_map,
                 )

--- a/tests/Process/test_amber.py
+++ b/tests/Process/test_amber.py
@@ -243,6 +243,17 @@ def test_backbone_restraint_mask_rna(rna_system):
     assert "   restraintmask=\"@P,C5',C3',O3',O5'\"," in config
 
 
+@pytest.mark.skipif(has_amber is False, reason="Requires AMBER to be installed.")
+def test_perturbable_restraint(perturbable_system):
+    """Test a free energy perturbation protocol."""
+
+    # Create a short minimisation prototocol with a restraint.
+    protocol = BSS.Protocol.Minimisation(steps=100, restraint="heavy")
+
+    # Run the process, check that it finished without error, and returns a system.
+    run_process(perturbable_system, protocol)
+
+
 def run_process(system, protocol, check_data=False):
     """Helper function to run various simulation protocols."""
 

--- a/tests/Process/test_namd.py
+++ b/tests/Process/test_namd.py
@@ -90,6 +90,17 @@ def test_production(namd_system, restraint):
     run_process(namd_system, protocol)
 
 
+@pytest.mark.skipif(has_namd is False, reason="Requires NAMD to be installed.")
+def test_perturbable_restraint(perturbable_system):
+    """Test a free energy perturbation protocol."""
+
+    # Create a short minimisation prototocol with a restraint.
+    protocol = BSS.Protocol.Minimisation(steps=100, restraint="heavy")
+
+    # Run the process, check that it finished without error, and returns a system.
+    run_process(perturbable_system, protocol)
+
+
 def run_process(namd_system, protocol):
     """Helper function to run various simulation protocols."""
 

--- a/tests/Process/test_openmm.py
+++ b/tests/Process/test_openmm.py
@@ -111,6 +111,16 @@ def test_parmed_triclinic():
     run_process(system, protocol)
 
 
+def test_perturbable_restraint(perturbable_system):
+    """Test a free energy perturbation protocol."""
+
+    # Create a short minimisation prototocol with a restraint.
+    protocol = BSS.Protocol.Minimisation(steps=100, restraint="heavy")
+
+    # Run the process, check that it finished without error, and returns a system.
+    run_process(perturbable_system, protocol)
+
+
 def run_process(system, protocol):
     """Helper function to run various simulation protocols."""
 


### PR DESCRIPTION
This PR closes #340 by converting the reference system to the chosen end state _before_ writing to a coordinate file to be used for restraints. This ensures that the `coordinates` property is correctly detected.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
