### PR TITLE
Fix issue #344

### DIFF
--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -1162,8 +1162,13 @@ def merge(
                             "perturbation will likely be unstable."
                         )
 
-    # Set the "connectivity" property.
-    edit_mol.setProperty("connectivity", conn)
+    # Set the "connectivity" property. If the end state connectivity is the same,
+    # then we can just set the "connectivity" property.
+    if conn0 == conn1:
+        edit_mol.setProperty("connectivity", conn0)
+    else:
+        edit_mol.setProperty("connectivity0", conn0)
+        edit_mol.setProperty("connectivity1", conn1)
 
     # Create the CLJNBPairs matrices.
     ff = molecule0.property(ff0)


### PR DESCRIPTION
This PR fixes #344 by reverting the way in which the connectivity property is set. While we generally handle perturbations that _don't_ change connectivity, we do require that the end state properties differ, These properties will be used by Sire to infer situations where the perturbation involves a connectivity change.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]