### PR TITLE
Fix issue #348

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -115,7 +115,9 @@ from sire.legacy import Mol as _SireMol
 from sire.legacy import System as _SireSystem
 
 from ... import _isVerbose
+from ... import Convert as _Convert
 from ... import IO as _IO
+from ..._Exceptions import ConversionError as _ConversionError
 from ..._Exceptions import IncompatibleError as _IncompatibleError
 from ..._Exceptions import ThirdPartyError as _ThirdPartyError
 from ..._SireWrappers import Molecule as _Molecule
@@ -243,82 +245,20 @@ class OpenForceField(_protocol.Protocol):
                 else:
                     raise IOError(msg) from None
         else:
-            # If the molecule was originally loaded from an SDF format file,
-            # then write back to the same format.
-            fileformat_prop = self._property_map.get("fileformat", "fileformat")
-            if (
-                molecule._sire_object.hasProperty(fileformat_prop)
-                and "SDF" in molecule._sire_object.property("fileformat").value()
-            ):
-                # Write the molecule to SDF format.
-                try:
-                    _IO.saveMolecules(
-                        _os.path.join(str(work_dir), "molecule"),
-                        molecule,
-                        "sdf",
-                        property_map=self._property_map,
-                    )
-                except Exception as e:
-                    msg = "Failed to write the molecule to 'SDF' format."
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
-
-            # Otherwise, go via an intermediate PDB file and use RDKit to try
-            # to recover stereochemistry.
-            else:
-                # Write the molecule to a PDB file.
-                try:
-                    _IO.saveMolecules(
-                        _os.path.join(str(work_dir), "molecule"),
-                        molecule,
-                        "pdb",
-                        property_map=self._property_map,
-                    )
-                except Exception as e:
-                    msg = "Failed to write the molecule to 'PDB' format."
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
-
-                # Create an RDKit molecule from the PDB file.
-                try:
-                    rdmol = _Chem.MolFromPDBFile(
-                        _os.path.join(str(work_dir), "molecule.pdb"), removeHs=False
-                    )
-                except Exception as e:
-                    msg = "RDKit was unable to read the molecular PDB file!"
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise _ThirdPartyError(msg) from e
-                    else:
-                        raise _ThirdPartyError(msg) from None
-
-                # Use RDKit to write back to SDF format.
-                try:
-                    writer = _Chem.SDWriter(
-                        _os.path.join(str(work_dir), "molecule.sdf")
-                    )
-                    writer.write(rdmol)
-                    writer.close()
-                except Exception as e:
-                    msg = "RDKit was unable to write the molecular SDF file!"
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise _ThirdPartyError(msg) from e
-                    else:
-                        raise _ThirdPartyError(msg) from None
-
-            # Create the Open Forcefield Molecule from the intermediate SDF file,
-            # as recommended by @j-wags and @mattwthompson.
+            # Try converting to RDKit format.
             try:
-                off_molecule = _OpenFFMolecule.from_file(
-                    _os.path.join(str(work_dir), "molecule.sdf")
-                )
+                rdmol = _Convert.toRDKit(molecule, property_map=self._property_map)
+            except Exception as e:
+                msg = "Failed to convert molecule to RDKit format."
+                if _isVerbose():
+                    msg += ": " + getattr(e, "message", repr(e))
+                    raise (msg) from e
+                else:
+                    raise _ConversionError(msg) from None
+
+            # Create the Open Forcefield Molecule from the RDKit molecule.
+            try:
+                off_molecule = _OpenFFMolecule.from_rdkit(rdmol)
             except Exception as e:
                 msg = "Unable to create OpenFF Molecule!"
                 if _isVerbose():

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -115,7 +115,9 @@ from sire.legacy import Mol as _SireMol
 from sire.legacy import System as _SireSystem
 
 from ... import _isVerbose
+from ... import Convert as _Convert
 from ... import IO as _IO
+from ..._Exceptions import ConversionError as _ConversionError
 from ..._Exceptions import IncompatibleError as _IncompatibleError
 from ..._Exceptions import ThirdPartyError as _ThirdPartyError
 from ..._SireWrappers import Molecule as _Molecule
@@ -243,82 +245,20 @@ class OpenForceField(_protocol.Protocol):
                 else:
                     raise IOError(msg) from None
         else:
-            # If the molecule was originally loaded from an SDF format file,
-            # then write back to the same format.
-            fileformat_prop = self._property_map.get("fileformat", "fileformat")
-            if (
-                molecule._sire_object.hasProperty(fileformat_prop)
-                and "SDF" in molecule._sire_object.property("fileformat").value()
-            ):
-                # Write the molecule to SDF format.
-                try:
-                    _IO.saveMolecules(
-                        _os.path.join(str(work_dir), "molecule"),
-                        molecule,
-                        "sdf",
-                        property_map=self._property_map,
-                    )
-                except Exception as e:
-                    msg = "Failed to write the molecule to 'SDF' format."
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
-
-            # Otherwise, go via an intermediate PDB file and use RDKit to try
-            # to recover stereochemistry.
-            else:
-                # Write the molecule to a PDB file.
-                try:
-                    _IO.saveMolecules(
-                        _os.path.join(str(work_dir), "molecule"),
-                        molecule,
-                        "pdb",
-                        property_map=self._property_map,
-                    )
-                except Exception as e:
-                    msg = "Failed to write the molecule to 'PDB' format."
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise IOError(msg) from e
-                    else:
-                        raise IOError(msg) from None
-
-                # Create an RDKit molecule from the PDB file.
-                try:
-                    rdmol = _Chem.MolFromPDBFile(
-                        _os.path.join(str(work_dir), "molecule.pdb"), removeHs=False
-                    )
-                except Exception as e:
-                    msg = "RDKit was unable to read the molecular PDB file!"
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise _ThirdPartyError(msg) from e
-                    else:
-                        raise _ThirdPartyError(msg) from None
-
-                # Use RDKit to write back to SDF format.
-                try:
-                    writer = _Chem.SDWriter(
-                        _os.path.join(str(work_dir), "molecule.sdf")
-                    )
-                    writer.write(rdmol)
-                    writer.close()
-                except Exception as e:
-                    msg = "RDKit was unable to write the molecular SDF file!"
-                    if _isVerbose():
-                        msg += ": " + getattr(e, "message", repr(e))
-                        raise _ThirdPartyError(msg) from e
-                    else:
-                        raise _ThirdPartyError(msg) from None
-
-            # Create the Open Forcefield Molecule from the intermediate SDF file,
-            # as recommended by @j-wags and @mattwthompson.
+            # Try converting to RDKit format.
             try:
-                off_molecule = _OpenFFMolecule.from_file(
-                    _os.path.join(str(work_dir), "molecule.sdf")
-                )
+                rdmol = _Convert.toRDKit(molecule, property_map=self._property_map)
+            except Exception as e:
+                msg = "Failed to convert molecule to RDKit format."
+                if _isVerbose():
+                    msg += ": " + getattr(e, "message", repr(e))
+                    raise (msg) from e
+                else:
+                    raise _ConversionError(msg) from None
+
+            # Create the Open Forcefield Molecule from the RDKit molecule.
+            try:
+                off_molecule = _OpenFFMolecule.from_rdkit(rdmol)
             except Exception as e:
                 msg = "Unable to create OpenFF Molecule!"
                 if _isVerbose():


### PR DESCRIPTION
This PR closes #348 by using direct conversion to/from and RDKit format intermediate for parameterisation with OpenFF. This avoids issues using intermediate file formats, e.g. PDB or SDF. We first convert from SIre/BioSimSpace to RDKit, then create an OpenFF molecule directly from this using the `Molecule.from_rdkit()` functionality.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]