### PR TITLE
Fix issue #354

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1238,8 +1238,9 @@ class System(_SireWrapper):
 
         from sire.system import System
 
-        # Create a cursor.
-        cursor = System(self._sire_object).cursor()
+        # Create a cursor for the non-perturbable molecules.
+        system = System(self._sire_object)
+        cursor = system["not property is_perturbable"].cursor()
 
         # Rotate all vector properties.
 
@@ -1267,8 +1268,15 @@ class System(_SireWrapper):
         except:
             pass
 
+        # Update the molecules in the system.
+        system.update(cursor.commit())
+        self._sire_object = system._system
+
         # Now deal with any perturbable molecules.
         if self.nPerturbableMolecules() > 0:
+            # Create a cursor for the perturbable molecules.
+            cursor = system["property is_perturbable"].cursor()
+
             # Coordinates.
             try:
                 prop_name = property_map.get("coordinates", "coordinates") + "0"
@@ -1307,8 +1315,9 @@ class System(_SireWrapper):
             except:
                 pass
 
-        # Commit the changes.
-        self._sire_object = cursor.commit()._system
+            # Update the perturbable molecules in the system.
+            system.update(cursor.commit())
+            self._sire_object = system._system
 
     def reduceBoxVectors(self, bias=0, property_map={}):
         """

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1186,8 +1186,9 @@ class System(_SireWrapper):
 
         from sire.system import System
 
-        # Create a cursor.
-        cursor = System(self._sire_object).cursor()
+        # Create a cursor for the non-perturbable molecules.
+        system = System(self._sire_object)
+        cursor = system["not property is_perturbable"].cursor()
 
         # Rotate all vector properties.
 
@@ -1215,8 +1216,15 @@ class System(_SireWrapper):
         except:
             pass
 
+        # Update the molecules in the system.
+        system.update(cursor.commit())
+        self._sire_object = system._system
+
         # Now deal with any perturbable molecules.
         if self.nPerturbableMolecules() > 0:
+            # Create a cursor for the perturbable molecules.
+            cursor = system["property is_perturbable"].cursor()
+
             # Coordinates.
             try:
                 prop_name = property_map.get("coordinates", "coordinates") + "0"
@@ -1255,8 +1263,9 @@ class System(_SireWrapper):
             except:
                 pass
 
-        # Commit the changes.
-        self._sire_object = cursor.commit()._system
+            # Update the perturbable molecules in the system.
+            system.update(cursor.commit())
+            self._sire_object = system._system
 
     def reduceBoxVectors(self, bias=0, property_map={}):
         """


### PR DESCRIPTION
This PR closes #354 by rotating perturbable and non-perturbable molecules _independently_ when rotating a simulation box as part of a reduction. Previously both sets of molecules were rotated at the _same_ time, using the property map to specify the name of the coordinates (or velocity) property to use. This would raise an exception for the first molecule without this property, hence the actual perturbable ligand was never rotated.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

Tagging @mark-mackey-cresset so that you can test this.

