### PR TITLE
Improve robustness of restraint search and fix torsional force constant bug

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,7 +63,7 @@ Tutorials
 =========
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    tutorials/index
 
@@ -71,7 +71,7 @@ Detailed Guides
 ===============
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    guides/index
 
@@ -93,7 +93,7 @@ Support
 Contributing
 ============
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    contributing/index
    contributors

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -590,6 +590,14 @@ class RestraintSearch:
                 f"traj {type(traj)} must be of type 'BioSimSpace.Trajectory._trajectory.Trajectory'"
             )
 
+        n_frames = traj.nFrames()
+        if not n_frames >= 50:
+            _warnings.warn(
+                f"The trajectory for restraint selection has less than 50 frames ({n_frames} frames). "
+                "This may result in poor restraint selection with excessively high force constants. "
+                "Consider running a longer simulation or saving more frames."
+            )
+
         if not isinstance(temperature, _Temperature):
             raise ValueError(
                 f"temperature {type(temperature)} must be of type 'BioSimSpace.Types.Temperature'"
@@ -666,6 +674,19 @@ class RestraintSearch:
         # Find decoupled molecule and use it to create ligand selection
         decoupled_mol = _system.getDecoupledMolecules()[0]
         decoupled_resname = decoupled_mol.getResidues()[0].name()
+
+        # Warn the user if the decoupled molecule is water or a macromoelcule
+        if decoupled_mol.isWater():
+            _warnings.warn(
+                "The decoupled molecule is water. Ensure that this is intended. Using constrained water hydrogens as anchor "
+                "points may produce instabilities."
+            )
+
+        if decoupled_mol.nResidues() > 1:
+            _warnings.warn(
+                "The decoupled molecule has more than one residue and is likely a macromolecule. Ensure that this is intended."
+            )
+
 
         ligand_selection_str = f"((resname {decoupled_resname}) and (not name H*))"
         if append_to_ligand_selection:
@@ -1012,6 +1033,17 @@ class RestraintSearch:
         """
 
         lig_selection = u.select_atoms(ligand_selection_str)
+        
+        # Ensure that there are no shared atoms between the ligand selection and all possible receptor selections.
+        all_possible_receptor_selection = u.select_atoms(receptor_selection_str)
+        shared_atoms = [atom for atom in lig_selection if atom in all_possible_receptor_selection]
+        if shared_atoms:
+            raise _AnalysisError(
+                f"Shared atoms between ligand and receptor selections detected. "
+                f"Please ensure that the ligand and receptor selections are mutually exclusive. "
+                f"Shared atoms: {shared_atoms}"
+            )
+
         pair_variance_dict = {}
 
         # Get all receptor atoms within specified distance of cutoff

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -1039,8 +1039,9 @@ class RestraintSearch:
         shared_atoms = [atom for atom in lig_selection if atom in all_possible_receptor_selection]
         if shared_atoms:
             raise _AnalysisError(
-                f"Shared atoms between ligand and receptor selections detected. "
-                f"Please ensure that the ligand and receptor selections are mutually exclusive. "
+                "Shared atoms between ligand and receptor selections detected. "
+                "Please ensure that you are decoupling the intended molecule and that "
+                "the ligand and receptor selections are mutually exclusive. "
                 f"Shared atoms: {shared_atoms}"
             )
 

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -687,7 +687,6 @@ class RestraintSearch:
                 "The decoupled molecule has more than one residue and is likely a macromolecule. Ensure that this is intended."
             )
 
-
         ligand_selection_str = f"((resname {decoupled_resname}) and (not name H*))"
         if append_to_ligand_selection:
             ligand_selection_str += " and "
@@ -1033,10 +1032,12 @@ class RestraintSearch:
         """
 
         lig_selection = u.select_atoms(ligand_selection_str)
-        
+
         # Ensure that there are no shared atoms between the ligand selection and all possible receptor selections.
         all_possible_receptor_selection = u.select_atoms(receptor_selection_str)
-        shared_atoms = [atom for atom in lig_selection if atom in all_possible_receptor_selection]
+        shared_atoms = [
+            atom for atom in lig_selection if atom in all_possible_receptor_selection
+        ]
         if shared_atoms:
             raise _AnalysisError(
                 "Shared atoms between ligand and receptor selections detected. "
@@ -1521,7 +1522,9 @@ class RestraintSearch:
                             dtheta = abs(val - circmean)
                             corrected_values.append(min(dtheta, 2 * _np.pi - dtheta))
                         corrected_values = _np.array(corrected_values)
-                        boresch_dof_data[pair][dof]["var"] = _np.mean(corrected_values ** 2)
+                        boresch_dof_data[pair][dof]["var"] = _np.mean(
+                            corrected_values**2
+                        )
 
                     # Assume Gaussian distributions and calculate force constants for harmonic potentials
                     # so as to reproduce these distributions at 298 K

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -1488,7 +1488,7 @@ class RestraintSearch:
                             dtheta = abs(val - circmean)
                             corrected_values.append(min(dtheta, 2 * _np.pi - dtheta))
                         corrected_values = _np.array(corrected_values)
-                        boresch_dof_data[pair][dof]["var"] = corrected_values.var()
+                        boresch_dof_data[pair][dof]["var"] = _np.mean(corrected_values ** 2)
 
                     # Assume Gaussian distributions and calculate force constants for harmonic potentials
                     # so as to reproduce these distributions at 298 K

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint_search.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint_search.py
@@ -210,40 +210,40 @@ class TestBSS_analysis:
     def test_dG_off_boresch(self, boresch_restraint):
         """Test if the restraint generated has the same energy"""
         restraint, _ = boresch_restraint
-        assert np.isclose(-9.8955, restraint.correction.value(), atol=0.01)
+        assert np.isclose(-9.2133, restraint.correction.value(), atol=0.01)
 
     def test_bond_boresch(self, boresch_restraint):
         restraint, _ = boresch_restraint
         equilibrium_values_r0 = (
             restraint._restraint_dict["equilibrium_values"]["r0"] / nanometer
         )
-        assert np.isclose(0.6057, equilibrium_values_r0, atol=0.001)
+        assert np.isclose(0.4987, equilibrium_values_r0, atol=0.001)
 
     def test_angles_boresch(self, boresch_restraint):
         restraint, _ = boresch_restraint
         equilibrium_values_thetaA0 = (
             restraint._restraint_dict["equilibrium_values"]["thetaA0"] / degree
         )
-        assert np.isclose(140.6085, equilibrium_values_thetaA0, atol=0.001)
+        assert np.isclose(119.3375, equilibrium_values_thetaA0, atol=0.001)
         equilibrium_values_thetaB0 = (
             restraint._restraint_dict["equilibrium_values"]["thetaB0"] / degree
         )
-        assert np.isclose(56.4496, equilibrium_values_thetaB0, atol=0.001)
+        assert np.isclose(100.8382, equilibrium_values_thetaB0, atol=0.001)
 
     def test_dihedrals_boresch(self, boresch_restraint):
         restraint, _ = boresch_restraint
         equilibrium_values_phiA0 = (
             restraint._restraint_dict["equilibrium_values"]["phiA0"] / degree
         )
-        assert np.isclose(21.6173, equilibrium_values_phiA0, atol=0.001)
+        assert np.isclose(29.1947, equilibrium_values_phiA0, atol=0.001)
         equilibrium_values_phiB0 = (
             restraint._restraint_dict["equilibrium_values"]["phiB0"] / degree
         )
-        assert np.isclose(-19.4394, equilibrium_values_phiB0, atol=0.001)
+        assert np.isclose(-136.9009, equilibrium_values_phiB0, atol=0.001)
         equilibrium_values_phiC0 = (
             restraint._restraint_dict["equilibrium_values"]["phiC0"] / degree
         )
-        assert np.isclose(71.3148, equilibrium_values_phiC0, atol=0.001)
+        assert np.isclose(-102.3908, equilibrium_values_phiC0, atol=0.001)
 
     def test_index_boresch(self, boresch_restraint):
         restraint, _ = boresch_restraint
@@ -251,7 +251,7 @@ class TestBSS_analysis:
             k: restraint._restraint_dict["anchor_points"][k].index()
             for k in restraint._restraint_dict["anchor_points"]
         }
-        assert idxs == {"r1": 1560, "r2": 1558, "r3": 1562, "l1": 10, "l2": 9, "l3": 11}
+        assert idxs == {"r1": 1560, "r2": 1558, "r3": 1562, "l1": 8, "l2": 9, "l3": 13}
 
     def test_force_constant_boresch(self, boresch_restraint_k20):
         restraint, _ = boresch_restraint_k20

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint_search.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint_search.py
@@ -136,6 +136,7 @@ class TestMDRestraintsGenerator_analysis:
         with open(outdir / "BoreschRestraint.top", "r") as f:
             assert "intermolecular_interactions" in f.read()
 
+
 @pytest.mark.skipif(
     (has_gromacs is False or has_mdanalysis is False),
     reason="Requires MDAnalysis and Gromacs to be installed.",
@@ -177,7 +178,7 @@ class TestBSS_analysis:
     @pytest.fixture(scope="class")
     def _restraint_search_protein(self, tmp_path_factory):
         # Select the protein as the ligand.
-        return partial(self._restraint_search_general, tmp_path_factory,ligand_idx=0)()
+        return partial(self._restraint_search_general, tmp_path_factory, ligand_idx=0)()
 
     @staticmethod
     @pytest.fixture(scope="class")
@@ -280,7 +281,9 @@ class TestBSS_analysis:
                 cutoff=0.1 * angstrom,
             )
 
-    def test_non_overlapping_anchor_selections_forbidden(self, _restraint_search_protein):
+    def test_non_overlapping_anchor_selections_forbidden(
+        self, _restraint_search_protein
+    ):
         """
         Ensure that anchor atoms cannot be in the same molecule
         (the protein has been selected as the ligand, so we are


### PR DESCRIPTION
# Is this pull request to fix a bug, or to introduce new functionality?

This PR does two things:

1. Fixes https://github.com/OpenBioSim/biosimspace/issues/359
2. Improves the robustness of the ABFE restraint search to strange user input. I've implemented the improvements discussed [here](https://github.com/OpenBioSim/biosimspace_tutorials/issues/28#issuecomment-2434686918). 

I've included the two together to reduce CI runs/ faff, but please let me know if I should create separate PRs in future.

## If this is to fix a bug...

This pull request fixes issue #359?

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

Note that the ordering of candidate anchor points in the restraint search will be slightly different now, as the torsions have less weight when ordering the restraints for selection.

## If this introduces new functionality...

Changes proposed in this pull request:

I now:

 - Ensure that anchors can never be in the same molecule
 - Warn the user if they select the protein/water as the "ligand"
 - Warn the user if they supply very few frames for fitting

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [n]
* I confirm that I have permission to release this code under the GPL3 license: [y]

The tests could be more comprehensive - at the moment I've only added a test to check that an error is raised if the receptor and ligand candidate anchor point lists share atoms. I haven't included tests to check that the correct warnings are being raised. The reason for this was that the only trajectory I can find on the website (https://github.com/OpenBioSim/biosimspace_website/tree/main/structures) only includes the ligand and the protein. This means that I can't select weird "ligands" which aren't the ligand or protein (e.g. water) which don't raise errors for other reasons. If we'd like more complete tests, we could always add a trajectory with e.g. 1 water molecule as well as the complex. However, I have verified that these warnings are raised for one of my test systems, and the code for these checks is very simple.

## Suggested reviewers:
@lohedges 

Thanks.
