### PR TITLE
Fix issue #347

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -841,6 +841,7 @@ class GAFF(_protocol.Protocol):
         net_charge=None,
         ensure_compatible=True,
         property_map={},
+        **kwargs,
     ):
         """
         Constructor.
@@ -873,6 +874,10 @@ class GAFF(_protocol.Protocol):
             A dictionary that maps system "properties" to their user defined
             values. This allows the user to refer to properties with their
             own naming scheme, e.g. { "charge" : "my-charge" }
+
+        **kwargs: dict
+            Additional keyword arguments. These can be used to pass custom
+            parameters to the Antechamber program.
         """
 
         if type(version) is not int:
@@ -911,6 +916,11 @@ class GAFF(_protocol.Protocol):
                 raise TypeError(
                     "'net_charge' must be of type 'int', or `BioSimSpace.Types.Charge'"
                 )
+
+        # Check the kwargs to see whether acdoctor is enabled.
+        self._acdoctor = kwargs.get("acdoctor", True)
+        if not isinstance(self._acdoctor, bool):
+            raise TypeError("'acdoctor' must be of type 'bool'")
 
         # Set the version.
         self._version = version
@@ -1085,6 +1095,10 @@ class GAFF(_protocol.Protocol):
             self._charge_method.lower(),
             charge,
         )
+
+        # Disable acdoctor if requested.
+        if not self._acdoctor:
+            command += " -dr no"
 
         with open(_os.path.join(str(work_dir), "README.txt"), "w") as file:
             # Write the command to file.

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -362,6 +362,7 @@ def gaff(
         charge_method=charge_method,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
+        **kwargs,
     )
 
     # Run the parameterisation protocol in the background and return
@@ -460,6 +461,7 @@ def gaff2(
         charge_method=charge_method,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
+        **kwargs,
     )
 
     # Run the parameterisation protocol in the background and return

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -841,6 +841,7 @@ class GAFF(_protocol.Protocol):
         net_charge=None,
         ensure_compatible=True,
         property_map={},
+        **kwargs,
     ):
         """
         Constructor.
@@ -873,6 +874,10 @@ class GAFF(_protocol.Protocol):
             A dictionary that maps system "properties" to their user defined
             values. This allows the user to refer to properties with their
             own naming scheme, e.g. { "charge" : "my-charge" }
+
+        **kwargs: dict
+            Additional keyword arguments. These can be used to pass custom
+            parameters to the Antechamber program.
         """
 
         if type(version) is not int:
@@ -911,6 +916,11 @@ class GAFF(_protocol.Protocol):
                 raise TypeError(
                     "'net_charge' must be of type 'int', or `BioSimSpace.Types.Charge'"
                 )
+
+        # Check the kwargs to see whether acdoctor is enabled.
+        self._acdoctor = kwargs.get("acdoctor", True)
+        if not isinstance(self._acdoctor, bool):
+            raise TypeError("'acdoctor' must be of type 'bool'")
 
         # Set the version.
         self._version = version
@@ -1085,6 +1095,10 @@ class GAFF(_protocol.Protocol):
             self._charge_method.lower(),
             charge,
         )
+
+        # Disable acdoctor if requested.
+        if not self._acdoctor:
+            command += " -dr no"
 
         with open(_os.path.join(str(work_dir), "README.txt"), "w") as file:
             # Write the command to file.

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -362,6 +362,7 @@ def gaff(
         charge_method=charge_method,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
+        **kwargs,
     )
 
     # Run the parameterisation protocol in the background and return
@@ -460,6 +461,7 @@ def gaff2(
         charge_method=charge_method,
         ensure_compatible=ensure_compatible,
         property_map=property_map,
+        **kwargs,
     )
 
     # Run the parameterisation protocol in the background and return

--- a/tests/Parameters/test_parameters.py
+++ b/tests/Parameters/test_parameters.py
@@ -167,3 +167,24 @@ def test_smiles_stereo():
 
     # Make sure the SMILES strings are the same.
     assert rdmol0_smiles == rdmol1_smiles
+
+
+@pytest.mark.skipif(
+    has_antechamber is False or has_tleap is False,
+    reason="Requires AmberTools/antechamber and tLEaP to be installed.",
+)
+def test_acdoctor():
+    """
+    Test that parameterising negatively charged molecules works when acdoctor
+    is disabled.
+    """
+
+    # Load the molecule.
+    mol = BSS.IO.readMolecules(f"{url}/negative_charge.sdf")[0]
+
+    # Make sure parameterisation fails when acdoctor is enabled.
+    with pytest.raises(BSS._Exceptions.ParameterisationError):
+        BSS.Parameters.gaff(mol).getMolecule()
+
+    # Make sure parameterisation works when acdoctor is disabled.
+    mol = BSS.Parameters.gaff(mol, acdoctor=False).getMolecule()

--- a/tests/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/tests/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -172,3 +172,24 @@ def test_smiles_stereo():
 
     # Make sure the SMILES strings are the same.
     assert rdmol0_smiles == rdmol1_smiles
+
+
+@pytest.mark.skipif(
+    has_antechamber is False or has_tleap is False,
+    reason="Requires AmberTools/antechamber and tLEaP to be installed.",
+)
+def test_acdoctor():
+    """
+    Test that parameterising negatively charged molecules works when acdoctor
+    is disabled.
+    """
+
+    # Load the molecule.
+    mol = BSS.IO.readMolecules(f"{url}/negative_charge.sdf")[0]
+
+    # Make sure parameterisation fails when acdoctor is enabled.
+    with pytest.raises(BSS._Exceptions.ParameterisationError):
+        BSS.Parameters.gaff(mol).getMolecule()
+
+    # Make sure parameterisation works when acdoctor is disabled.
+    mol = BSS.Parameters.gaff(mol, acdoctor=False).getMolecule()


### PR DESCRIPTION
This PR closes #347 by allowing the Antechamber `acdoctor` mode to be disabled via a kwarg when using `BioSimSpace.Parameters.gaff/gaff2`, or via `BioSimSpace.Parameters.parameterise`.

I'll re-trigger the CI once the Sire development packages have finished building.

@noahharrison64: Tagging you in so that you can test.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

