### PR TITLE
Improve error messages if no lambda windows found during analysis

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -1435,6 +1435,12 @@ class Relative:
             for part in file.parts:
                 if "lambda" in part:
                     lambdas.append(float(part.split("_")[-1]))
+        if len(lambdas) == 0:
+            raise ValueError(
+                "No lambda windows were detected from the output directory names! "
+                "Ensure that the directory being analysed contains sub-directories"
+                "name e.g `lambda_0`, `lambda_1` containing the output files."
+            )
 
         # Find the temperature for each lambda window.
         temperatures = []
@@ -1516,6 +1522,12 @@ class Relative:
                 for part in file.parts:
                     if "lambda" in part:
                         lambdas.append(float(part.split("_")[-1]))
+        if len(lambdas) == 0:
+            raise ValueError(
+                "No lambda windows were detected from the output directory names! "
+                "Ensure that the directory being analysed contains sub-directories"
+                "name e.g `lambda_0`, `lambda_1` containing the output files."
+            )
 
             # Find the temperature at each lambda window
             temperatures = []
@@ -1685,6 +1697,12 @@ class Relative:
                 for part in file.parts:
                     if "lambda" in part:
                         lambdas.append(float(part.split("_")[-1]))
+        if len(lambdas) == 0:
+            raise ValueError(
+                "No lambda windows were detected from the output directory names! "
+                "Ensure that the directory being analysed contains sub-directories"
+                "name e.g `lambda_0`, `lambda_1` containing the output files."
+            )
 
             temperatures = []
             for file in files:


### PR DESCRIPTION
# Is this pull request to fix a bug, or to introduce new functionality?

If users have generated output without using BSS, the directory structure may not be as BSS expects when parsing lambda windows from directory names. Previously, this lead to a an empty `lambdas` list, and `BSS.FreeEnergy.Analyse` returned `([], correct_overlap_matrix)` without raising an error. The code now explicitly raises an error.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): y
* I confirm that I have added a test for any new functionality in this pull request: n
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: n
* I confirm that I have permission to release this code under the GPL3 license: y

## Suggested reviewers:
@lohedges