### PR TITLE
Fix issue #376

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,7 +43,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "biosimspace"
-copyright = "2017-2024"
+copyright = "2017-2025"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/python/BioSimSpace/Align/__init__.py
+++ b/python/BioSimSpace/Align/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Box/__init__.py
+++ b/python/BioSimSpace/Box/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Box/_box.py
+++ b/python/BioSimSpace/Box/_box.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Convert/__init__.py
+++ b/python/BioSimSpace/Convert/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Convert/_convert.py
+++ b/python/BioSimSpace/Convert/_convert.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/FreeEnergy/__init__.py
+++ b/python/BioSimSpace/FreeEnergy/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/FreeEnergy/_atm.py
+++ b/python/BioSimSpace/FreeEnergy/_atm.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #          Matthew Burman <matthew@openbiosim.org>

--- a/python/BioSimSpace/FreeEnergy/_ddg.py
+++ b/python/BioSimSpace/FreeEnergy/_ddg.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #          Matthew Burman <matthew@openbiosim.org>

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/FreeEnergy/_utils.py
+++ b/python/BioSimSpace/FreeEnergy/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Gateway/__init__.py
+++ b/python/BioSimSpace/Gateway/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Gateway/_node.py
+++ b/python/BioSimSpace/Gateway/_node.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Gateway/_requirements.py
+++ b/python/BioSimSpace/Gateway/_requirements.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Gateway/_resources.py
+++ b/python/BioSimSpace/Gateway/_resources.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/IO/__init__.py
+++ b/python/BioSimSpace/IO/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/IO/_file_cache.py
+++ b/python/BioSimSpace/IO/_file_cache.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/MD/__init__.py
+++ b/python/BioSimSpace/MD/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/MD/_md.py
+++ b/python/BioSimSpace/MD/_md.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/MD/_utils.py
+++ b/python/BioSimSpace/MD/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/__init__.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_collective_variable.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_collective_variable.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_distance.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_distance.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_funnel.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
@@ -172,6 +172,15 @@ class RMSD(_CollectiveVariable):
                         "Values of 'reference_mapping' must be of type 'int'"
                     )
 
+                if k < 0 or k >= reference.nMolecules():
+                    raise ValueError(
+                        "Keys of 'reference_mapping' must be in the range [0, nMolecules)"
+                    )
+                if v < 0 or v >= system.nMolecules():
+                    raise ValueError(
+                        "Values of 'reference_mapping' must be in the range [0, nMolecules)"
+                    )
+
                 # Make sure the mapped molecules have the same number of atoms.
                 if reference[k].nAtoms() != system[v].nAtoms():
                     raise _IncompatibleError(

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_rmsd.py
@@ -172,11 +172,17 @@ class RMSD(_CollectiveVariable):
                         "Values of 'reference_mapping' must be of type 'int'"
                     )
 
-                if k < 0 or k >= reference.nMolecules():
+                # Allow negative indeices.
+                if k < 0:
+                    k += reference.nMolecules()
+                if v < 0:
+                    v += system.nMolecules()
+
+                if k >= reference.nMolecules():
                     raise ValueError(
                         "Keys of 'reference_mapping' must be in the range [0, nMolecules)"
                     )
-                if v < 0 or v >= system.nMolecules():
+                if v >= system.nMolecules():
                     raise ValueError(
                         "Values of 'reference_mapping' must be in the range [0, nMolecules)"
                     )

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_torsion.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_torsion.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/CollectiveVariable/_utils.py
+++ b/python/BioSimSpace/Metadynamics/CollectiveVariable/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/__init__.py
+++ b/python/BioSimSpace/Metadynamics/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/_bound.py
+++ b/python/BioSimSpace/Metadynamics/_bound.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/_grid.py
+++ b/python/BioSimSpace/Metadynamics/_grid.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/_metadynamics.py
+++ b/python/BioSimSpace/Metadynamics/_metadynamics.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/_restraint.py
+++ b/python/BioSimSpace/Metadynamics/_restraint.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Metadynamics/_utils.py
+++ b/python/BioSimSpace/Metadynamics/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Node/__init__.py
+++ b/python/BioSimSpace/Node/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Node/_node.py
+++ b/python/BioSimSpace/Node/_node.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Notebook/__init__.py
+++ b/python/BioSimSpace/Notebook/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Notebook/_plot.py
+++ b/python/BioSimSpace/Notebook/_plot.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Notebook/_view.py
+++ b/python/BioSimSpace/Notebook/_view.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_Protocol/__init__.py
+++ b/python/BioSimSpace/Parameters/_Protocol/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_openforcefield.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_Protocol/_protocol.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_protocol.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/__init__.py
+++ b/python/BioSimSpace/Parameters/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_process.py
+++ b/python/BioSimSpace/Parameters/_process.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Parameters/_utils.py
+++ b/python/BioSimSpace/Parameters/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/__init__.py
+++ b/python/BioSimSpace/Process/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_amber.py
+++ b/python/BioSimSpace/Process/_amber.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_atm.py
+++ b/python/BioSimSpace/Process/_atm.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #          Matthew Burman <matthew@openbiosim.org>

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_namd.py
+++ b/python/BioSimSpace/Process/_namd.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -397,7 +397,7 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[colvar.getReferenceIndex()]]
+                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing
@@ -631,7 +631,8 @@ class Plumed:
 
                 # Write the reference PDB file.
                 with open(
-                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"), "w"
+                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"),
+                    "w",
                 ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")
@@ -1007,7 +1008,7 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[colvar.getReferenceIndex()]]
+                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing
@@ -1232,7 +1233,7 @@ class Plumed:
 
                 # Write the reference PDB file.
                 with open(
-                    _os.path.join(str(self._work_dir), "reference_%i.pdb" % num_rmsd),
+                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"),
                     "w",
                 ) as file:
                     for line in colvar.getReferencePDB():

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -377,7 +377,10 @@ class Plumed:
                 )
 
                 # Store the indices of the largest and second largest molecules.
-                molecules = [sorted_nums[-1][1], sorted_nums[-2][1]]
+                if sorted_nums[-1][1] not in molecules:
+                    molecules.append(sorted_nums[-1][1])
+                if sorted_nums[-2][1] not in molecules:
+                    molecules.append(sorted_nums[-2][1])
 
                 # The funnel collective variable requires an auxiliary file for
                 # PLUMED versions < 2.7.
@@ -397,7 +400,10 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
+                for i in colvar.getMoleculeIndices():
+                    num = system._mol_nums[i]
+                    if num not in molecules:
+                        molecules.append(num)
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing
@@ -1008,7 +1014,10 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
+                for i in colvar.getMoleculeIndices():
+                    num = system._mol_nums[i]
+                    if num not in molecules:
+                        molecules.append(num)
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing

--- a/python/BioSimSpace/Process/_plumed.py
+++ b/python/BioSimSpace/Process/_plumed.py
@@ -623,12 +623,15 @@ class Plumed:
             elif isinstance(colvar, _CollectiveVariable.RMSD):
                 num_rmsd += 1
                 arg_name = "r%d" % num_rmsd
-                colvar_string = "%s: RMSD REFERENCE=reference.pdb" % arg_name
+                colvar_string = "%s: RMSD REFERENCE=reference_%d.pdb" % (
+                    arg_name,
+                    num_rmsd,
+                )
                 colvar_string += " TYPE=%s" % colvar.getAlignmentType().upper()
 
                 # Write the reference PDB file.
                 with open(
-                    _os.path.join(str(self._work_dir), "reference.pdb"), "w"
+                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"), "w"
                 ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")

--- a/python/BioSimSpace/Process/_process.py
+++ b/python/BioSimSpace/Process/_process.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_process_runner.py
+++ b/python/BioSimSpace/Process/_process_runner.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_task.py
+++ b/python/BioSimSpace/Process/_task.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Process/_utils.py
+++ b/python/BioSimSpace/Process/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/__init__.py
+++ b/python/BioSimSpace/Protocol/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_atm.py
+++ b/python/BioSimSpace/Protocol/_atm.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #          Matthew Burman <matthew@openbiosim.org>

--- a/python/BioSimSpace/Protocol/_custom.py
+++ b/python/BioSimSpace/Protocol/_custom.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_equilibration.py
+++ b/python/BioSimSpace/Protocol/_equilibration.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_free_energy_equilibration.py
+++ b/python/BioSimSpace/Protocol/_free_energy_equilibration.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_free_energy_minimisation.py
+++ b/python/BioSimSpace/Protocol/_free_energy_minimisation.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_free_energy_mixin.py
+++ b/python/BioSimSpace/Protocol/_free_energy_mixin.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_free_energy_production.py
+++ b/python/BioSimSpace/Protocol/_free_energy_production.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Protocol/_metadynamics.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_minimisation.py
+++ b/python/BioSimSpace/Protocol/_minimisation.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_position_restraint_mixin.py
+++ b/python/BioSimSpace/Protocol/_position_restraint_mixin.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_production.py
+++ b/python/BioSimSpace/Protocol/_production.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_protocol.py
+++ b/python/BioSimSpace/Protocol/_protocol.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_steering.py
+++ b/python/BioSimSpace/Protocol/_steering.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Protocol/_utils.py
+++ b/python/BioSimSpace/Protocol/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_align.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_align.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_merge.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Box/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Box/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Box/_box.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Box/_box.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_alchemical_free_energy.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint_search.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Gateway/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Gateway/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Gateway/_node.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Gateway/_node.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Gateway/_requirements.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Gateway/_requirements.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Gateway/_resources.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Gateway/_resources.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_file_cache.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/IO/_io.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/MD/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/MD/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/MD/_md.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/MD/_md.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/MD/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/MD/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_collective_variable.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_collective_variable.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_distance.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_distance.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_funnel.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
@@ -56,6 +56,7 @@ class RMSD(_CollectiveVariable):
         reference,
         align_selection,
         rmsd_selection,
+        reference_mapping=None,
         hill_width=_Length(0.1, "nanometer"),
         lower_bound=None,
         upper_bound=None,
@@ -84,6 +85,11 @@ class RMSD(_CollectiveVariable):
         rmsd_selection : str
             A Sire selection string that defines the atoms to be used
             when calculating the RMSD.
+
+        reference_mapping : dict
+            A dictionary mapping molecule indices in the reference to
+            those in the system. This must be used when the reference
+            represents a sub-set of the system.
 
         hill_width : :class:`Length <BioSimSpace.Types.Length>`
             The width of the Gaussian hill used to sample this variable.
@@ -137,19 +143,51 @@ class RMSD(_CollectiveVariable):
 
         sire_reference = System(reference._sire_object)
 
-        # Make sure that the reference system is compatible with the system.
-        if system.nMolecules() != reference.nMolecules():
-            raise _IncompatibleError(
-                "The number of molecules in 'system' and 'reference' must match."
-            )
-        if system.nResidues() != reference.nResidues():
-            raise _IncompatibleError(
-                "The number of residues in 'system' and 'reference' must match."
-            )
-        if system.nAtoms() != reference.nAtoms():
-            raise _IncompatibleError(
-                "The number of atoms in 'system' and 'reference' must match."
-            )
+        if reference_mapping is None:
+            # Make sure that the reference system is compatible with the system.
+            if system.nMolecules() != reference.nMolecules():
+                raise _IncompatibleError(
+                    "The number of molecules in 'system' and 'reference' must match."
+                )
+            if system.nResidues() != reference.nResidues():
+                raise _IncompatibleError(
+                    "The number of residues in 'system' and 'reference' must match."
+                )
+            if system.nAtoms() != reference.nAtoms():
+                raise _IncompatibleError(
+                    "The number of atoms in 'system' and 'reference' must match."
+                )
+
+            self._reference_mapping = {i: i for i in range(system.nMolecules())}
+        else:
+            if not isinstance(reference_mapping, dict):
+                raise TypeError("'reference_mapping' must be of type 'dict'")
+
+            # Validate the mapping.
+            for k, v in reference_mapping.items():
+                if not isinstance(k, int):
+                    raise TypeError("Keys of 'reference_mapping' must be of type 'int'")
+                if not isinstance(v, int):
+                    raise TypeError(
+                        "Values of 'reference_mapping' must be of type 'int'"
+                    )
+
+                if k < 0 or k >= reference.nMolecules():
+                    raise ValueError(
+                        "Keys of 'reference_mapping' must be in the range [0, nMolecules)"
+                    )
+                if v < 0 or v >= system.nMolecules():
+                    raise ValueError(
+                        "Values of 'reference_mapping' must be in the range [0, nMolecules)"
+                    )
+
+                # Make sure the mapped molecules have the same number of atoms.
+                if reference[k].nAtoms() != system[v].nAtoms():
+                    raise _IncompatibleError(
+                        "Molecules mapped via the 'reference_mapping' must have the same number of atoms."
+                    )
+
+            self._reference_mapping = reference_mapping
 
         # Validate alignment selection string.
         if not isinstance(align_selection, str):
@@ -195,8 +233,11 @@ class RMSD(_CollectiveVariable):
             if atom.molecule().number() not in mol_nums:
                 mol_nums.add(atom.molecule().number())
 
-        # Set to store the molecule indices in the system.
+        # List to store the molecule indices in the system.
         self._molecule_indices = []
+
+        # List to store index pairs for the mapped molecule (system, reference).
+        molecule_pairs = []
 
         # List to store the absolute atom indices.
         abs_atom_indices = []
@@ -212,8 +253,14 @@ class RMSD(_CollectiveVariable):
             # Extract the molecule from the reference system.
             molecule = reference._sire_object[num]
 
-            # Work out the index of the molecule in the system.
-            self._molecule_indices.append(system.getIndex(_Molecule(molecule)))
+            # Work out the index of the molecule in the reference.
+            index = reference.getIndex(_Molecule(molecule))
+
+            # Map the index to the system.
+            self._molecule_indices.append(self._reference_mapping[index])
+
+            # Store the index pair.
+            molecule_pairs.append((self._reference_mapping[index], index))
 
             # Set of atoms to select.
             selected = set()
@@ -298,7 +345,7 @@ class RMSD(_CollectiveVariable):
         self._initial_value = self._compute_initial_rmsd(
             system,
             reference,
-            self._molecule_indices,
+            molecule_pairs,
             align_indices,
             rmsd_indices,
             property_map,
@@ -490,7 +537,7 @@ class RMSD(_CollectiveVariable):
         self,
         system,
         reference,
-        molecule_indices,
+        molecule_pairs,
         align_indices,
         rmsd_indices,
         property_map={},
@@ -510,9 +557,9 @@ class RMSD(_CollectiveVariable):
             system, i.e. contain the same residues as the matching molecule
             in the same order.
 
-        molecule_indices : [int]
-            The indices of molecules in the system that contain atoms involved
-            in alignment and RMSD.
+        molecule_pairs : [(int, int), ...]
+            The indices of molecules in the system and reference that contain
+            atoms involved in alignment and RMSD.
 
         align_indices : {Sire.Mol.MolNum: [Sire.Mol.AtomIdx, ...]}
             A dictionary mapping molecules to the indices of atoms that will
@@ -547,11 +594,17 @@ class RMSD(_CollectiveVariable):
                 "'reference' must be of type 'BioSimSpace._SireWrappers.System'."
             )
 
-        if not isinstance(molecule_indices, list):
-            raise TypeError("'molecule_indices' must be a list of integers.")
-        for idx in molecule_indices:
-            if not type(idx) is int:
-                raise TypeError("'molecule_indices' must be a list of integers.")
+        if not isinstance(molecule_pairs, list):
+            raise TypeError("'molecule_pairs' must be a list of integer tuples.")
+        for pair in molecule_pairs:
+            if not isinstance(pair, tuple):
+                raise TypeError("'molecule_pairs' must be a list of integer tuples.")
+            if len(pair) != 2:
+                raise ValueError("'molecule_pairs' must be a list of integer tuples.")
+            if not isinstance(pair[0], int):
+                raise TypeError("'molecule_pairs' must be a list of integer tuples.")
+            if not isinstance(pair[1], int):
+                raise TypeError("'molecule_pairs' must be a list of integer tuples.")
 
         if not isinstance(align_indices, dict):
             raise TypeError("'align_indices' must be a dictionary.")
@@ -609,9 +662,9 @@ class RMSD(_CollectiveVariable):
         num_rmsd = 0
 
         # Loop over the molecules.
-        for idx in molecule_indices:
-            mol = system[idx]
-            ref = reference[idx]
+        for idx_system, idx_ref in molecule_pairs:
+            mol = system[idx_system]
+            ref = reference[idx_ref]
 
             align_mapping = {}
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_rmsd.py
@@ -172,11 +172,17 @@ class RMSD(_CollectiveVariable):
                         "Values of 'reference_mapping' must be of type 'int'"
                     )
 
-                if k < 0 or k >= reference.nMolecules():
+                # Allow negative indeices.
+                if k < 0:
+                    k += reference.nMolecules()
+                if v < 0:
+                    v += system.nMolecules()
+
+                if k >= reference.nMolecules():
                     raise ValueError(
                         "Keys of 'reference_mapping' must be in the range [0, nMolecules)"
                     )
-                if v < 0 or v >= system.nMolecules():
+                if v >= system.nMolecules():
                     raise ValueError(
                         "Values of 'reference_mapping' must be in the range [0, nMolecules)"
                     )

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_torsion.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_torsion.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/CollectiveVariable/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_bound.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_bound.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_grid.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_grid.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_metadynamics.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_metadynamics.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_restraint.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Metadynamics/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Node/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Node/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Node/_node.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Node/_node.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/_plot.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Notebook/_view.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Notebook/_view.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_openforcefield.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_protocol.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_protocol.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_process.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_namd.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -397,7 +397,7 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[colvar.getReferenceIndex()]]
+                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing
@@ -631,7 +631,8 @@ class Plumed:
 
                 # Write the reference PDB file.
                 with open(
-                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"), "w"
+                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"),
+                    "w",
                 ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")
@@ -1007,7 +1008,7 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[colvar.getReferenceIndex()]]
+                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing
@@ -1232,7 +1233,7 @@ class Plumed:
 
                 # Write the reference PDB file.
                 with open(
-                    _os.path.join(str(self._work_dir), "reference_%i.pdb" % num_rmsd),
+                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"),
                     "w",
                 ) as file:
                     for line in colvar.getReferencePDB():

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -377,7 +377,10 @@ class Plumed:
                 )
 
                 # Store the indices of the largest and second largest molecules.
-                molecules = [sorted_nums[-1][1], sorted_nums[-2][1]]
+                if sorted_nums[-1][1] not in molecules:
+                    molecules.append(sorted_nums[-1][1])
+                if sorted_nums[-2][1] not in molecules:
+                    molecules.append(sorted_nums[-2][1])
 
                 # The funnel collective variable requires an auxiliary file for
                 # PLUMED versions < 2.7.
@@ -397,7 +400,10 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
+                for i in colvar.getMoleculeIndices():
+                    num = system._mol_nums[i]
+                    if num not in molecules:
+                        molecules.append(num)
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing
@@ -1008,7 +1014,10 @@ class Plumed:
 
             # RMSD.
             elif isinstance(colvar, _CollectiveVariable.RMSD):
-                molecules = [system._mol_nums[i] for i in colvar.getMoleculeIndices()]
+                for i in colvar.getMoleculeIndices():
+                    num = system._mol_nums[i]
+                    if num not in molecules:
+                        molecules.append(num)
 
             # Loop over all of the atoms. Make sure the index is valid and
             # check if we need to create an entity for the molecule containing

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_plumed.py
@@ -117,8 +117,8 @@ class Plumed:
         self._work_dir = work_dir
 
         # Set the location of the HILLS and COLVAR files.
-        self._hills_file = "%s/HILLS" % self._work_dir
-        self._colvar_file = "%s/COLVAR" % self._work_dir
+        self._hills_file = _os.path.join(str(self._work_dir), "HILLS")
+        self._colvar_file = _os.path.join(str(self._work_dir), "COLVAR")
 
         # The number of collective variables and total number of components.
         self._num_colvar = 0
@@ -250,11 +250,11 @@ class Plumed:
 
         # Always remove pygtail offset files.
         try:
-            _os.remove("%s/COLVAR.offset" % self._work_dir)
+            _os.remove(_os.path.join(str(self._work_dir), "COLVAR.offset"))
         except:
             pass
         try:
-            _os.remove("%s/HILLS.offset" % self._work_dir)
+            _os.remove(_os.path.join(str(self._work_dir), "HILLS.offset"))
         except:
             pass
 
@@ -623,11 +623,16 @@ class Plumed:
             elif isinstance(colvar, _CollectiveVariable.RMSD):
                 num_rmsd += 1
                 arg_name = "r%d" % num_rmsd
-                colvar_string = "%s: RMSD REFERENCE=reference.pdb" % arg_name
+                colvar_string = "%s: RMSD REFERENCE=reference_%d.pdb" % (
+                    arg_name,
+                    num_rmsd,
+                )
                 colvar_string += " TYPE=%s" % colvar.getAlignmentType().upper()
 
                 # Write the reference PDB file.
-                with open("%s/reference.pdb" % self._work_dir, "w") as file:
+                with open(
+                    _os.path.join(str(self._work_dir), f"reference_{num_rmsd}.pdb"), "w"
+                ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")
 
@@ -870,7 +875,9 @@ class Plumed:
             metad_string += (
                 " GRID_WFILE=GRID GRID_WSTRIDE=%s" % protocol.getHillFrequency()
             )
-            if is_restart and _os.path.isfile(f"{self._work_dir}/GRID"):
+            if is_restart and _os.path.isfile(
+                _os.path.join(str(self._work_dir), "GRID")
+            ):
                 metad_string += " GRID_RFILE=GRID"
             metad_string += " CALC_RCT"
 
@@ -940,7 +947,7 @@ class Plumed:
 
         # Always remove pygtail offset files.
         try:
-            _os.remove("%s/COLVAR.offset" % self._work_dir)
+            _os.remove(_os.path.join(str(self._work_dir), "COLVAR.offset"))
         except:
             pass
 
@@ -1225,7 +1232,8 @@ class Plumed:
 
                 # Write the reference PDB file.
                 with open(
-                    "%s/reference_%i.pdb" % (self._work_dir, num_rmsd), "w"
+                    _os.path.join(str(self._work_dir), "reference_%i.pdb" % num_rmsd),
+                    "w",
                 ) as file:
                     for line in colvar.getReferencePDB():
                         file.write(line + "\n")
@@ -1449,8 +1457,8 @@ class Plumed:
             raise ValueError("'kt' must have value > 0")
 
         # Delete any existing FES directotry and create a new one.
-        _shutil.rmtree(f"{self._work_dir}/fes", ignore_errors=True)
-        _os.makedirs(f"{self._work_dir}/fes")
+        _shutil.rmtree(_os.path.join(str(self._work_dir), "fes"), ignore_errors=True)
+        _os.makedirs(_os.path.join(str(self._work_dir), "fes"))
 
         # Create the command string.
         command = "%s sum_hills --hills ../HILLS --mintozero" % self._exe
@@ -1466,7 +1474,7 @@ class Plumed:
         free_energies = []
 
         # Move to the working directory.
-        with _Utils.cd(self._work_dir + "/fes"):
+        with _Utils.cd(_os.path.join(str(self._work_dir), "fes")):
             # Run the sum_hills command as a background process.
             proc = _subprocess.run(
                 _Utils.command_split(command),
@@ -1556,7 +1564,7 @@ class Plumed:
                 _os.remove(fes)
 
         # Remove the FES output directory.
-        _shutil.rmtree(f"{self._work_dir}/fes", ignore_errors=True)
+        _shutil.rmtree(_os.path.join(str(self._work_dir), "fes"), ignore_errors=True)
 
         return tuple(free_energies)
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process_runner.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process_runner.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_somd.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_task.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_task.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_custom.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_custom.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_equilibration.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_equilibration.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_metadynamics.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_minimisation.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_minimisation.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_production.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_production.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_protocol.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_protocol.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_steering.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_steering.py
@@ -1,7 +1,7 @@
 #####################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Solvent/_solvent.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Stream/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Stream/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Stream/_stream.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Stream/_stream.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_angle.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_angle.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_area.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_area.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_base_units.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_charge.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_charge.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_coordinate.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_coordinate.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_energy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_energy.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_length.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_length.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_pressure.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_pressure.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_temperature.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_temperature.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_time.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_time.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_type.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_vector.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_vector.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_volume.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_volume.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Angle/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Angle/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Area/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Area/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Charge/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Charge/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Energy/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Energy/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Length/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Length/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Pressure/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Pressure/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Temperature/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Temperature/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Time/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Time/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/Volume/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/Volume/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/Units/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Units/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/_exceptions.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Exceptions/_exceptions.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_atom.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_atom.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_bond.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_bond.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecules.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecules.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_residue.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_residue.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_search_result.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_search_result.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_sire_wrapper.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_utils.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/_command_split.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/_command_split.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Christopher Woods <chryswoods@hey.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/_contextmanagers.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/_contextmanagers.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/_module_stub.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/_module_stub.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/_Utils/_workdir.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_Utils/_workdir.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/Exscientia/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Sandpit/__init__.py
+++ b/python/BioSimSpace/Sandpit/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Solvent/__init__.py
+++ b/python/BioSimSpace/Solvent/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Stream/__init__.py
+++ b/python/BioSimSpace/Stream/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Stream/_stream.py
+++ b/python/BioSimSpace/Stream/_stream.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Trajectory/__init__.py
+++ b/python/BioSimSpace/Trajectory/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/__init__.py
+++ b/python/BioSimSpace/Types/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_angle.py
+++ b/python/BioSimSpace/Types/_angle.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_area.py
+++ b/python/BioSimSpace/Types/_area.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_base_units.py
+++ b/python/BioSimSpace/Types/_base_units.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_charge.py
+++ b/python/BioSimSpace/Types/_charge.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_coordinate.py
+++ b/python/BioSimSpace/Types/_coordinate.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_energy.py
+++ b/python/BioSimSpace/Types/_energy.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_length.py
+++ b/python/BioSimSpace/Types/_length.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_pressure.py
+++ b/python/BioSimSpace/Types/_pressure.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_temperature.py
+++ b/python/BioSimSpace/Types/_temperature.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_time.py
+++ b/python/BioSimSpace/Types/_time.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_type.py
+++ b/python/BioSimSpace/Types/_type.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_vector.py
+++ b/python/BioSimSpace/Types/_vector.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Types/_volume.py
+++ b/python/BioSimSpace/Types/_volume.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Angle/__init__.py
+++ b/python/BioSimSpace/Units/Angle/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Area/__init__.py
+++ b/python/BioSimSpace/Units/Area/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Charge/__init__.py
+++ b/python/BioSimSpace/Units/Charge/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Energy/__init__.py
+++ b/python/BioSimSpace/Units/Energy/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Length/__init__.py
+++ b/python/BioSimSpace/Units/Length/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Pressure/__init__.py
+++ b/python/BioSimSpace/Units/Pressure/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Temperature/__init__.py
+++ b/python/BioSimSpace/Units/Temperature/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Time/__init__.py
+++ b/python/BioSimSpace/Units/Time/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/Volume/__init__.py
+++ b/python/BioSimSpace/Units/Volume/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/Units/__init__.py
+++ b/python/BioSimSpace/Units/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Config/__init__.py
+++ b/python/BioSimSpace/_Config/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Config/_amber.py
+++ b/python/BioSimSpace/_Config/_amber.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Config/_config.py
+++ b/python/BioSimSpace/_Config/_config.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Config/_gromacs.py
+++ b/python/BioSimSpace/_Config/_gromacs.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Config/_somd.py
+++ b/python/BioSimSpace/_Config/_somd.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Exceptions/__init__.py
+++ b/python/BioSimSpace/_Exceptions/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Exceptions/_exceptions.py
+++ b/python/BioSimSpace/_Exceptions/_exceptions.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/__init__.py
+++ b/python/BioSimSpace/_SireWrappers/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_atom.py
+++ b/python/BioSimSpace/_SireWrappers/_atom.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_bond.py
+++ b/python/BioSimSpace/_SireWrappers/_bond.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_molecules.py
+++ b/python/BioSimSpace/_SireWrappers/_molecules.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_residue.py
+++ b/python/BioSimSpace/_SireWrappers/_residue.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_search_result.py
+++ b/python/BioSimSpace/_SireWrappers/_search_result.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_SireWrappers/_utils.py
+++ b/python/BioSimSpace/_SireWrappers/_utils.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Utils/__init__.py
+++ b/python/BioSimSpace/_Utils/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Utils/_command_split.py
+++ b/python/BioSimSpace/_Utils/_command_split.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Christopher Woods <chryswoods@hey.com>
 #

--- a/python/BioSimSpace/_Utils/_contextmanagers.py
+++ b/python/BioSimSpace/_Utils/_contextmanagers.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Utils/_module_stub.py
+++ b/python/BioSimSpace/_Utils/_module_stub.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/_Utils/_workdir.py
+++ b/python/BioSimSpace/_Utils/_workdir.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/python/BioSimSpace/__init__.py
+++ b/python/BioSimSpace/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # BioSimSpace: Making biomolecular simulation a breeze!
 #
-# Copyright: 2017-2024
+# Copyright: 2017-2025
 #
 # Authors: Lester Hedges <lester.hedges@gmail.com>
 #

--- a/tests/Metadynamics/test_metadynamics.py
+++ b/tests/Metadynamics/test_metadynamics.py
@@ -45,11 +45,19 @@ def test_metadynamics(system):
     reason="Local test requiring PLUMED patched GROMACS.",
 )
 def test_steering(system):
+
+    # Create a reference containing the first and third molecule from the system.
+    reference = (system[0] + system[2]).toSystem()
+
     # Create the collective variable. Here we align on molecule index 1
     # and all atoms not belonging to to the ALA residue in molecule index 0.
     # We compute the RSMD using the atoms belonging to the ALA residue.
     cv = BSS.Metadynamics.CollectiveVariable.RMSD(
-        system, system, "(molidx 0 and not resname ALA) or molidx 1", "resname ALA"
+        system,
+        reference,
+        "(molidx 0 and not resname ALA) or molidx 1",
+        "resname ALA",
+        reference_mapping={0: 0, 1: 2},
     )
 
     # Add some stages.

--- a/tests/Metadynamics/test_metadynamics.py
+++ b/tests/Metadynamics/test_metadynamics.py
@@ -45,11 +45,12 @@ def test_metadynamics(system):
     reason="Local test requiring PLUMED patched GROMACS.",
 )
 def test_steering(system):
-    # Find the indices of the atoms in the ALA residue.
-    rmsd_idx = [x.index() for x in system.search("resname ALA").atoms()]
-
-    # Create the collective variable.
-    cv = BSS.Metadynamics.CollectiveVariable.RMSD(system, system[0], rmsd_idx)
+    # Create the collective variable. Here we align on molecule index 1
+    # and all atoms not belonging to to the ALA residue in molecule index 0.
+    # We compute the RSMD using the atoms belonging to the ALA residue.
+    cv = BSS.Metadynamics.CollectiveVariable.RMSD(
+        system, system, "(molidx 0 and not resname ALA) or molidx 1", "resname ALA"
+    )
 
     # Add some stages.
     start = 0 * BSS.Units.Time.nanosecond

--- a/tests/Protocol/test_protocol.py
+++ b/tests/Protocol/test_protocol.py
@@ -116,8 +116,19 @@ def test_metadynamics():
 
 
 def test_steering(system):
-    # Create a collective variable so we can instantiate a steering protocol.
-    cv = BSS.Metadynamics.CollectiveVariable.RMSD(system, system[0], [0, 1, 2, 3])
+    # Create a reference containing the first and third molecule from the system.
+    reference = (system[0] + system[2]).toSystem()
+
+    # Create the collective variable. Here we align on molecule index 1
+    # and all atoms not belonging to to the ALA residue in molecule index 0.
+    # We compute the RSMD using the atoms belonging to the ALA residue.
+    cv = BSS.Metadynamics.CollectiveVariable.RMSD(
+        system,
+        reference,
+        "(molidx 0 and not resname ALA) or molidx 1",
+        "resname ALA",
+        reference_mapping={0: 0, 1: 2},
+    )
 
     # Create a schedule.
     start = 0 * BSS.Units.Time.nanosecond

--- a/tests/Sandpit/Exscientia/Protocol/test_protocol.py
+++ b/tests/Sandpit/Exscientia/Protocol/test_protocol.py
@@ -122,8 +122,19 @@ def test_metadynamics():
 
 
 def test_steering(system):
-    # Create a collective variable so we can instantiate a steering protocol.
-    cv = BSS.Metadynamics.CollectiveVariable.RMSD(system, system[0], [0, 1, 2, 3])
+    # Create a reference containing the first and third molecule from the system.
+    reference = (system[0] + system[2]).toSystem()
+
+    # Create the collective variable. Here we align on molecule index 1
+    # and all atoms not belonging to to the ALA residue in molecule index 0.
+    # We compute the RSMD using the atoms belonging to the ALA residue.
+    cv = BSS.Metadynamics.CollectiveVariable.RMSD(
+        system,
+        reference,
+        "(molidx 0 and not resname ALA) or molidx 1",
+        "resname ALA",
+        reference_mapping={0: 0, 1: 2},
+    )
 
     # Create a schedule.
     start = 0 * BSS.Units.Time.nanosecond


### PR DESCRIPTION
This PR closes #376 by allowing the user to specify unique atom selections to be used for the RMSD and alignment when using an RMSD restraint. This means that you can use one selection to align to, and another for the calculation of the RMSD itself. The PR also aligns some small differences between the core and Sandpit code bases. (Some minor updates must not have been duplicated.)

Note that this PR creates a necessary API change, so we will need to update the steered MD [tutorial](https://github.com/OpenBioSim/biosimspace_tutorials/tree/main/03_steered_md) accordingly when we do the next release.

Tagging in @AdeleHardie so that you are aware of this change. The updated [unit test](https://github.com/OpenBioSim/biosimspace/blob/95da10af2ae66da23e33a16d1ce82233d64285a9/tests/Metadynamics/test_metadynamics.py#L47) shows how the new API used.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
