### PR TITLE
Allow user to force stereo inference

### DIFF
--- a/python/BioSimSpace/Convert/_convert.py
+++ b/python/BioSimSpace/Convert/_convert.py
@@ -47,6 +47,7 @@ import rdkit.Chem as _Chem
 from sire import convert as _sire_convert
 from sire import smiles as _sire_smiles
 
+import sire.legacy.Base as _SireBase
 import sire.legacy.Mol as _SireMol
 import sire.legacy.System as _SireSystem
 import sire.legacy.Vol as _SireVol
@@ -192,7 +193,7 @@ def to(obj, format="biosimspace", property_map={}, **kwargs):
         force_stereo_inference = kwargs["force_stereo_inference"]
         if not isinstance(force_stereo_inference, bool):
             raise TypeError("'force_stereo_inference' must be of type 'bool'.")
-        property_map["force_stereo_inference"] = force_stereo_inference
+        property_map["force_stereo_inference"] = _SireBase.wrap(force_stereo_inference)
 
     # Special handling for OpenMM conversion. Currently this is a one-way (toOpenMM)
     # conversion only and is only supported for specific Sire and BioSimSpace types.
@@ -548,7 +549,7 @@ def toRDKit(obj, force_stereo_inference=False, property_map={}):
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'.")
 
-    property_map["force_stereo_inference"] = force_stereo_inference
+    property_map["force_stereo_inference"] = _SireBase.wrap(force_stereo_inference)
 
     return to(obj, format="rdkit", property_map=property_map)
 

--- a/python/BioSimSpace/Convert/_convert.py
+++ b/python/BioSimSpace/Convert/_convert.py
@@ -146,7 +146,7 @@ def supportedFormats():
     return _sire_convert.supported_formats()
 
 
-def to(obj, format="biosimspace", property_map={}):
+def to(obj, format="biosimspace", property_map={}, **kwargs):
     """
     Convert an object to a specified format.
 
@@ -186,6 +186,13 @@ def to(obj, format="biosimspace", property_map={}):
 
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'.")
+
+    # Check for force_stereo_inference in kwargs.
+    if "force_stereo_inference" in kwargs:
+        force_stereo_inference = kwargs["force_stereo_inference"]
+        if not isinstance(force_stereo_inference, bool):
+            raise TypeError("'force_stereo_inference' must be of type 'bool'.")
+        property_map["force_stereo_inference"] = force_stereo_inference
 
     # Special handling for OpenMM conversion. Currently this is a one-way (toOpenMM)
     # conversion only and is only supported for specific Sire and BioSimSpace types.
@@ -508,7 +515,7 @@ def toOpenMM(obj, property_map={}):
         )
 
 
-def toRDKit(obj, property_map={}):
+def toRDKit(obj, force_stereo_inference=False, property_map={}):
     """
     Convert an object to RDKit format.
 
@@ -517,6 +524,11 @@ def toRDKit(obj, property_map={}):
 
     obj :
         The input object to convert.
+
+    bool : force_stereo_inference
+        Whether to force inference of stereochemistry, overriding any
+        stereochemistry present in the input object. This is useful when
+        the object has been loaded from a file with invalid stereochemistry.
 
     property_map : dict
         A dictionary that maps system "properties" to their user defined
@@ -529,6 +541,15 @@ def toRDKit(obj, property_map={}):
     converted_obj :
        The object in OpenMM format.
     """
+
+    if not isinstance(force_stereo_inference, bool):
+        raise TypeError("'force_stereo_inference' must be of type 'bool'.")
+
+    if not isinstance(property_map, dict):
+        raise TypeError("'property_map' must be of type 'dict'.")
+
+    property_map["force_stereo_inference"] = force_stereo_inference
+
     return to(obj, format="rdkit", property_map=property_map)
 
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
@@ -47,6 +47,7 @@ import rdkit.Chem as _Chem
 from sire import convert as _sire_convert
 from sire import smiles as _sire_smiles
 
+import sire.legacy.Base as _SireBase
 import sire.legacy.Mol as _SireMol
 import sire.legacy.System as _SireSystem
 import sire.legacy.Vol as _SireVol
@@ -192,7 +193,7 @@ def to(obj, format="biosimspace", property_map={}, **kwargs):
         force_stereo_inference = kwargs["force_stereo_inference"]
         if not isinstance(force_stereo_inference, bool):
             raise TypeError("'force_stereo_inference' must be of type 'bool'.")
-        property_map["force_stereo_inference"] = force_stereo_inference
+        property_map["force_stereo_inference"] = _SireBase.wrap(force_stereo_inference)
 
     # Special handling for OpenMM conversion. Currently this is a one-way (toOpenMM)
     # conversion only and is only supported for specific Sire and BioSimSpace types.
@@ -548,7 +549,7 @@ def toRDKit(obj, force_stereo_inference=False, property_map={}):
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'.")
 
-    property_map["force_stereo_inference"] = force_stereo_inference
+    property_map["force_stereo_inference"] = _SireBase.wrap(force_stereo_inference)
 
     return to(obj, format="rdkit", property_map=property_map)
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Convert/_convert.py
@@ -146,7 +146,7 @@ def supportedFormats():
     return _sire_convert.supported_formats()
 
 
-def to(obj, format="biosimspace", property_map={}):
+def to(obj, format="biosimspace", property_map={}, **kwargs):
     """
     Convert an object to a specified format.
 
@@ -186,6 +186,13 @@ def to(obj, format="biosimspace", property_map={}):
 
     if not isinstance(property_map, dict):
         raise TypeError("'property_map' must be of type 'dict'.")
+
+    # Check for force_stereo_inference in kwargs.
+    if "force_stereo_inference" in kwargs:
+        force_stereo_inference = kwargs["force_stereo_inference"]
+        if not isinstance(force_stereo_inference, bool):
+            raise TypeError("'force_stereo_inference' must be of type 'bool'.")
+        property_map["force_stereo_inference"] = force_stereo_inference
 
     # Special handling for OpenMM conversion. Currently this is a one-way (toOpenMM)
     # conversion only and is only supported for specific Sire and BioSimSpace types.
@@ -508,7 +515,7 @@ def toOpenMM(obj, property_map={}):
         )
 
 
-def toRDKit(obj, property_map={}):
+def toRDKit(obj, force_stereo_inference=False, property_map={}):
     """
     Convert an object to RDKit format.
 
@@ -517,6 +524,11 @@ def toRDKit(obj, property_map={}):
 
     obj :
         The input object to convert.
+
+    bool : force_stereo_inference
+        Whether to force inference of stereochemistry, overriding any
+        stereochemistry present in the input object. This is useful when
+        the object has been loaded from a file with invalid stereochemistry.
 
     property_map : dict
         A dictionary that maps system "properties" to their user defined
@@ -529,6 +541,15 @@ def toRDKit(obj, property_map={}):
     converted_obj :
        The object in OpenMM format.
     """
+
+    if not isinstance(force_stereo_inference, bool):
+        raise TypeError("'force_stereo_inference' must be of type 'bool'.")
+
+    if not isinstance(property_map, dict):
+        raise TypeError("'property_map' must be of type 'dict'.")
+
+    property_map["force_stereo_inference"] = force_stereo_inference
+
     return to(obj, format="rdkit", property_map=property_map)
 
 


### PR DESCRIPTION
This PR is a companion to OpenBioSim/sire#290, which exposes the `force_stereo_inference` kwarg on `BioSimSpace.Convert.toRDKit()`. This has been tested via Sire itself.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]