### PR TITLE
Add support for ff19SB force field

### DIFF
--- a/python/BioSimSpace/Parameters/_parameters.py
+++ b/python/BioSimSpace/Parameters/_parameters.py
@@ -37,16 +37,14 @@ __all__ = [
 
 # A dictionary mapping AMBER protein force field names to their pdb2gmx
 # compatibility. Note that the names specified below will be used for the
-# parameterisation functions, so they should be suitably formatted. Once we
-# have CMAP support we should be able to determine the available force fields
-# by scanning the AmberTools installation directory, as we do for those from
-# OpenFF.
+# parameterisation functions, so they should be suitably formatted.
 _amber_protein_forcefields = {
     "ff03": True,
     "ff99": True,
     "ff99SB": False,
     "ff99SBildn": False,
     "ff14SB": False,
+    "ff19SB": False,
 }
 
 from .. import _amber_home, _gmx_exe, _gmx_path, _isVerbose

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_parameters.py
@@ -37,16 +37,14 @@ __all__ = [
 
 # A dictionary mapping AMBER protein force field names to their pdb2gmx
 # compatibility. Note that the names specified below will be used for the
-# parameterisation functions, so they should be suitably formatted. Once we
-# have CMAP support we should be able to determine the available force fields
-# by scanning the AmberTools installation directory, as we do for those from
-# OpenFF.
+# parameterisation functions, so they should be suitably formatted.
 _amber_protein_forcefields = {
     "ff03": True,
     "ff99": True,
     "ff99SB": False,
     "ff99SBildn": False,
     "ff14SB": False,
+    "ff19SB": False,
 }
 
 from .. import _amber_home, _gmx_exe, _gmx_path, _isVerbose

--- a/tests/Parameters/test_parameters.py
+++ b/tests/Parameters/test_parameters.py
@@ -208,3 +208,18 @@ def test_broken_sdf_formal_charge():
     from math import isclose
 
     assert isclose(charge.value(), 0.0, abs_tol=1e-6)
+
+
+def test_ff19SB():
+    """
+    Test that the ff19SB force field can be used to parameterise a molecule.
+    """
+
+    # Load the molecule.
+    mol = BSS.IO.readMolecules(f"{url}/4LYT_Fixed.pdb.bz2")[0]
+
+    # Parameterise the molecule with ff19SB.
+    mol = BSS.Parameters.ff19SB(mol).getMolecule()
+
+    # Make sure the molecule has CMAP terms.
+    assert mol._sire_object.hasProperty("cmap")

--- a/tests/Sandpit/Exscientia/Parameters/test_parameters.py
+++ b/tests/Sandpit/Exscientia/Parameters/test_parameters.py
@@ -213,3 +213,18 @@ def test_broken_sdf_formal_charge():
     from math import isclose
 
     assert isclose(charge.value(), 0.0, abs_tol=1e-6)
+
+
+def test_ff19SB():
+    """
+    Test that the ff19SB force field can be used to parameterise a molecule.
+    """
+
+    # Load the molecule.
+    mol = BSS.IO.readMolecules(f"{url}/4LYT_Fixed.pdb.bz2")[0]
+
+    # Parameterise the molecule with ff19SB.
+    mol = BSS.Parameters.ff19SB(mol).getMolecule()
+
+    # Make sure the molecule has CMAP terms.
+    assert mol._sire_object.hasProperty("cmap")


### PR DESCRIPTION
This PR builds off the new Sire CMAP feature to add support for the ff19SB force field. I've added tests to make sure that it can be used to parameterise a protein and that the resulting molecule contains a `cmap` property.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]