### PR TITLE
Add support for the ABCG2 charge method

### DIFF
--- a/actions/update_recipe.py
+++ b/actions/update_recipe.py
@@ -19,7 +19,12 @@ print(f"conda recipe in {condadir}")
 
 # Store the name of the recipe and template YAML files.
 recipe = os.path.join(condadir, "meta.yaml")
-template = os.path.join(condadir, "template.yaml")
+
+# If the BSS_TEMPLATE environment variable is set, use that as the template.
+if "BSS_TEMPLATE" in os.environ:
+    template = os.environ["BSS_TEMPLATE"]
+else:
+    template = os.path.join(condadir, "template.yaml")
 
 # Now parse all of the requirements
 run_reqs = parse_requirements(os.path.join(srcdir, "requirements.txt"))

--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -112,6 +112,25 @@ if _amber_home is not None:
     if not _os.path.isfile(_parmchk_exe):
         raise IOError("Missing parmchk executable: '%s'" % _parmchk_exe)
 
+# Check for ABCG2 support.
+_has_abcg2 = False
+
+try:
+    cmd = "antechamber -L"
+    proc = _subprocess.run(
+        _Utils.command_split(cmd),
+        shell=False,
+        stdout=_subprocess.PIPE,
+        stderr=_subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode == 0:
+        # Check the output for ABCG2 support.
+        if "abcg2" in proc.stdout:
+            _has_abcg2 = True
+except:
+    pass
+
 
 class AmberProtein(_protocol.Protocol):
     """A class for handling AMBER protein force field models."""
@@ -833,6 +852,11 @@ class GAFF(_protocol.Protocol):
 
     # A list of supported charge methods.
     _charge_methods = ["RESP", "CM2", "MUL", "BCC", "ESP", "GAS"]
+
+    # Add ABCG2 to the list of charge methods if it is supported.
+    # This requires Antechamber > 24.0.
+    if _has_abcg2:
+        _charge_methods.append("ABCG2")
 
     def __init__(
         self,

--- a/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Parameters/_Protocol/_amber.py
@@ -112,6 +112,25 @@ if _amber_home is not None:
     if not _os.path.isfile(_parmchk_exe):
         raise IOError("Missing parmchk executable: '%s'" % _parmchk_exe)
 
+# Check for ABCG2 support.
+_has_abcg2 = False
+
+try:
+    cmd = "antechamber -L"
+    proc = _subprocess.run(
+        _Utils.command_split(cmd),
+        shell=False,
+        stdout=_subprocess.PIPE,
+        stderr=_subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode == 0:
+        # Check the output for ABCG2 support.
+        if "abcg2" in proc.stdout:
+            _has_abcg2 = True
+except:
+    pass
+
 
 class AmberProtein(_protocol.Protocol):
     """A class for handling AMBER protein force field models."""
@@ -833,6 +852,11 @@ class GAFF(_protocol.Protocol):
 
     # A list of supported charge methods.
     _charge_methods = ["RESP", "CM2", "MUL", "BCC", "ESP", "GAS"]
+
+    # Add ABCG2 to the list of charge methods if it is supported.
+    # This requires Antechamber > 24.0.
+    if _has_abcg2:
+        _charge_methods.append("ABCG2")
 
     def __init__(
         self,


### PR DESCRIPTION
This PR adds support for the new ABCG2 charge method from `ambertools` 2024. Currently this can't be tested since the build pulls in `ambertools` 2023 due to dependency constraints. However, I've tested the logic locally and it correctly detects when ABCG2 is available.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]