### PR TITLE
Fix 424

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -1183,13 +1183,16 @@ class Relative:
         # Step size.
         data_step = [round((i.index[-1][0] - i.index[-2][0]), 1) for i in data]
 
+        # Start time.
+        start_time = [i.index[0][0] for i in data]
+
         # Get the upper and lower bounds for truncate.
         truncate_lower = [
-            (data_len[i] * (truncate_lower / 100)) * data_step[i]
+            (start_time[i] + (data_len[i] * (truncate_lower / 100)) * data_step[i])
             for i in range(len(data_len))
         ]
         truncate_upper = [
-            (data_len[i] * (truncate_upper / 100)) * data_step[i]
+            (start_time[i] + (data_len[i] * (truncate_upper / 100)) * data_step[i])
             for i in range(len(data_len))
         ]
 

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -1177,23 +1177,21 @@ class Relative:
         # Copy the data.
         raw_data = data
 
-        # Data length.
-        data_len = [len(i) for i in data]
-
-        # Step size.
-        data_step = [round((i.index[-1][0] - i.index[-2][0]), 1) for i in data]
-
         # Start time.
         start_time = [i.index[0][0] for i in data]
 
-        # Get the upper and lower bounds for truncate.
+        # End time.
+        end_time = [i.index[-1][0] for i in data]
+
+        # Get the lower and upper bounds for the truncation.
         truncate_lower = [
-            (start_time[i] + (data_len[i] * (truncate_lower / 100)) * data_step[i])
-            for i in range(len(data_len))
+            start_time[i] + (end_time[i] - start_time[i]) * (truncate_lower / 100)
+            for i in range(len(data))
         ]
+
         truncate_upper = [
-            (start_time[i] + (data_len[i] * (truncate_upper / 100)) * data_step[i])
-            for i in range(len(data_len))
+            start_time[i] + (end_time[i] - start_time[i]) * (truncate_upper / 100)
+            for i in range(len(data))
         ]
 
         try:


### PR DESCRIPTION
This PR closes #424 by shifting the lower and upper bounds used for data truncation by the start time for each data frame. In addition, the bounds are only determined using fractions of the time interval between the first and last samples, which allows for the sample spacing to change over time. This is all the `alchemlyb` code uses internally, i.e. it just drops data outside of the lower and upper bound.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]