### PR TITLE
Add support for renumbering molecules when copying a system

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -260,6 +260,47 @@ class System(_SireWrapper):
         """Return the number of molecules in the system."""
         return self.nMolecules()
 
+    def copy(self, renumber=False):
+        """
+        Return a copy of this System.
+
+        Parameters
+        ----------
+
+        renumber : bool
+            Whether to give the copied molecules unique molecule numbers.
+
+        Returns
+        -------
+
+        System : :class:`System <BioSimSpace._SireWrappers.System>`
+            A copy of the object.
+        """
+
+        if not isinstance(renumber, bool):
+            raise TypeError("'renumber' must be of type 'bool'")
+
+        if not renumber:
+            return super().copy()
+
+        # Create a molecules container.
+        mols = _SireMol.MoleculeGroup("all")
+
+        # Give each molecule a unique molecule number.
+        for mol in self._sire_object:
+            cursor = mol.cursor()
+            cursor.number = _SireMol.MolNum.getUniqueNumber()
+            mols.add(cursor.commit())
+
+        # Create a new system.
+        system = _Molecules(mols).toSystem()
+
+        # Copy over the system properties.
+        for prop in self._sire_object.propertyKeys():
+            system._sire_object.setProperty(prop, self._sire_object.property(prop))
+
+        return system
+
     def nMolecules(self):
         """
         Return the number of molecules in the system.

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -260,6 +260,47 @@ class System(_SireWrapper):
         """Return the number of molecules in the system."""
         return self.nMolecules()
 
+    def copy(self, renumber=False):
+        """
+        Return a copy of this System.
+
+        Parameters
+        ----------
+
+        renumber : bool
+            Whether to give the copied molecules unique molecule numbers.
+
+        Returns
+        -------
+
+        System : :class:`System <BioSimSpace._SireWrappers.System>`
+            A copy of the object.
+        """
+
+        if not isinstance(renumber, bool):
+            raise TypeError("'renumber' must be of type 'bool'")
+
+        if not renumber:
+            return super().copy()
+
+        # Create a molecules container.
+        mols = _SireMol.MoleculeGroup("all")
+
+        # Give each molecule a unique molecule number.
+        for mol in self._sire_object:
+            cursor = mol.cursor()
+            cursor.number = _SireMol.MolNum.getUniqueNumber()
+            mols.add(cursor.commit())
+
+        # Create a new system.
+        system = _Molecules(mols).toSystem()
+
+        # Copy over the system properties.
+        for prop in self._sire_object.propertyKeys():
+            system._sire_object.setProperty(prop, self._sire_object.property(prop))
+
+        return system
+
     def nMolecules(self):
         """
         Return the number of molecules in the system.

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -508,3 +508,26 @@ def test_remove_box(system):
 
     # Make sure the box is removed.
     assert not "space" in system._sire_object.propertyKeys()
+
+
+def test_renumber(system):
+    # Make sure all the molecules retain their original numbers
+    # using the default copy.
+    for mol0, mol1 in zip(system, system.copy()):
+        assert mol0.number() == mol1.number()
+
+    # Store the set of original molecule numbers.
+    original_numbers = set(mol.number() for mol in system)
+
+    # Create a renumbered copy of the system.
+    renumbered_system = system.copy(renumber=True)
+
+    # Make sure that all of the numbers differ when renumbering.
+    for mol0, mol1 in zip(system, renumbered_system):
+        assert mol0.number() != mol1.number()
+
+    # Store the set of renumbered molecule numbers.
+    renumbered_numbers = set(mol.number() for mol in renumbered_system)
+
+    # Make sure that no original numbers are present in the renumbered set.
+    assert original_numbers.isdisjoint(renumbered_numbers)

--- a/tests/_SireWrappers/test_system.py
+++ b/tests/_SireWrappers/test_system.py
@@ -498,3 +498,26 @@ def test_remove_box(system):
 
     # Make sure the box is removed.
     assert not "space" in system._sire_object.propertyKeys()
+
+
+def test_renumber(system):
+    # Make sure all the molecules retain their original numbers
+    # using the default copy.
+    for mol0, mol1 in zip(system, system.copy()):
+        assert mol0.number() == mol1.number()
+
+    # Store the set of original molecule numbers.
+    original_numbers = set(mol.number() for mol in system)
+
+    # Create a renumbered copy of the system.
+    renumbered_system = system.copy(renumber=True)
+
+    # Make sure that all of the numbers differ when renumbering.
+    for mol0, mol1 in zip(system, renumbered_system):
+        assert mol0.number() != mol1.number()
+
+    # Store the set of renumbered molecule numbers.
+    renumbered_numbers = set(mol.number() for mol in renumbered_system)
+
+    # Make sure that no original numbers are present in the renumbered set.
+    assert original_numbers.isdisjoint(renumbered_numbers)


### PR DESCRIPTION
This PR closes #439 by adding a `renumber` kwarg to the `System.copy()` method. When `True`, molecules in the system are given a unique number. The default behaviour is `renumber=False`, for consistency with the existing code and for performance.

Closes #443

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
