### PR TITLE
Fix issue #459

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -805,7 +805,7 @@ class Trajectory:
                     self._trajectory.select_atoms("all").write(pdb_file)
 
             # Try to update the coordinates/velocities in the reference system.
-            if self._system is not None and self._system.nPerturbableMolecules() == 0:
+            if self._system is not None:
                 if self._backend == "SIRE" and frame.current().num_molecules() > 1:
                     try:
                         new_system = frame.current()._system

--- a/python/BioSimSpace/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Trajectory/_trajectory.py
@@ -805,7 +805,7 @@ class Trajectory:
                     self._trajectory.select_atoms("all").write(pdb_file)
 
             # Try to update the coordinates/velocities in the reference system.
-            if self._system is not None and self._system.nPerturbableMolecules() == 0:
+            if self._system is not None:
                 if self._backend == "SIRE" and frame.current().num_molecules() > 1:
                     try:
                         new_system = frame.current()._system


### PR DESCRIPTION
This PR closes #459 by fixing a conditional that incorrectly skipped trajectory frame reconstruction for systems containing perturbable molecules.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]

