### PR TITLE
Fix issue #467

### DIFF
--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -2037,6 +2037,9 @@ class OpenMM(_process.Process):
                     "'CUDA' platform selected but 'CUDA_VISIBLE_DEVICES' "
                     "environment variable is unset. Defaulting to '0'."
                 )
+            else:
+                num_devices = len(cuda_devices.split(","))
+                cuda_devices = ",".join([str(x) for x in range(num_devices)])
             self.addToConfig("properties = {'CudaDeviceIndex': '%s'}" % cuda_devices)
         elif self._platform == "OPENCL":
             opencl_devices = _os.environ.get("OPENCL_VISIBLE_DEVICES")
@@ -2046,6 +2049,9 @@ class OpenMM(_process.Process):
                     "'OpenCL' platform selected but 'OPENCL_VISIBLE_DEVICES' "
                     "environment variable is unset. Defaulting to '0'."
                 )
+            else:
+                num_devices = len(opencl_devices.split(","))
+                opencl_devices = ",".join([str(x) for x in range(num_devices)])
             self.addToConfig(
                 "properties = {'OpenCLDeviceIndex': '%s'}" % opencl_devices
             )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_openmm.py
@@ -1984,6 +1984,9 @@ class OpenMM(_process.Process):
                     "'CUDA' platform selected but 'CUDA_VISIBLE_DEVICES' "
                     "environment variable is unset. Defaulting to '0'."
                 )
+            else:
+                num_devices = len(cuda_devices.split(","))
+                cuda_devices = ",".join([str(x) for x in range(num_devices)])
             self.addToConfig("properties = {'CudaDeviceIndex': '%s'}" % cuda_devices)
         elif self._platform == "OPENCL":
             opencl_devices = _os.environ.get("OPENCL_VISIBLE_DEVICES")
@@ -1993,6 +1996,9 @@ class OpenMM(_process.Process):
                     "'OpenCL' platform selected but 'OPENCL_VISIBLE_DEVICES' "
                     "environment variable is unset. Defaulting to '0'."
                 )
+            else:
+                num_devices = len(opencl_devices.split(","))
+                opencl_devices = ",".join([str(x) for x in range(num_devices)])
             self.addToConfig(
                 "properties = {'OpenCLDeviceIndex': '%s'}" % opencl_devices
             )


### PR DESCRIPTION
This PR closes #467 by correcting setting the platform device index based on the number of entries in the `CUDA_VISIBLE_DEVICES` environment variable, not the values in variable itself. I've tested that this works correctly on `neogodzilla`.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have added a test for any new functionality in this pull request: [y]
* I confirm that I have added documentation (e.g. a new tutorial page or detailed guide) for any new functionality in this pull request: [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
