### PR TITLE
Fix issue #474

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/__init__.py
@@ -259,12 +259,12 @@ if _can_lazy_import:
     Trajectory = _lazy_import.lazy_module("BioSimSpace.Sandpit.Exscientia.Trajectory")
     Types = _lazy_import.lazy_module("BioSimSpace.Sandpit.Exscientia.Types")
     Units = _lazy_import.lazy_module("BioSimSpace.Sandpit.Exscientia.Units")
-
-    _Exceptions = _lazy_import.lazy_module("BioSimSpace.Sandpit.Exscientia._Exceptions")
     _SireWrappers = _lazy_import.lazy_module(
         "BioSimSpace.Sandpit.Exscientia._SireWrappers"
     )
-    _Utils = _lazy_import.lazy_module("BioSimSpace.Sandpit.Exscientia._Utils")
+
+    from . import _Exceptions
+    from . import _Utils
 
     del _lazy_import
 else:

--- a/python/BioSimSpace/__init__.py
+++ b/python/BioSimSpace/__init__.py
@@ -257,10 +257,10 @@ if _can_lazy_import:
     Trajectory = _lazy_import.lazy_module("BioSimSpace.Trajectory")
     Types = _lazy_import.lazy_module("BioSimSpace.Types")
     Units = _lazy_import.lazy_module("BioSimSpace.Units")
-
-    _Exceptions = _lazy_import.lazy_module("BioSimSpace._Exceptions")
     _SireWrappers = _lazy_import.lazy_module("BioSimSpace._SireWrappers")
-    _Utils = _lazy_import.lazy_module("BioSimSpace._Utils")
+
+    from . import _Exceptions
+    from . import _Utils
 
     del _lazy_import
 else:


### PR DESCRIPTION
This PR fixes lazy import issues by avoiding lazy imports for sub-modules that don't use Sire.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]