### PR TITLE
Allow translation of custom coordinates property

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -1463,6 +1463,16 @@ class Molecule(_SireWrapper):
             _property_map["coordinates"] = "coordinates1"
             mol = mol.move().translate(_SireMaths.Vector(vec), _property_map).commit()
 
+            # A user might have a custom coordinates property, so we need to check
+            # for this and translate too.
+            coord_prop = property_map.get("coordinates", "coordinates")
+            if self._sire_object.has_property(coord_prop):
+                mol = (
+                    self._sire_object.move()
+                    .translate(_SireMaths.Vector(vec), _property_map)
+                    .commit()
+                )
+
         else:
             mol = (
                 self._sire_object.move()

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1403,6 +1403,16 @@ class Molecule(_SireWrapper):
             _property_map["coordinates"] = "coordinates1"
             mol = mol.move().translate(_SireMaths.Vector(vec), _property_map).commit()
 
+            # A user might have a custom coordinates property, so we need to check
+            # for this and translate too.
+            coord_prop = property_map.get("coordinates", "coordinates")
+            if self._sire_object.has_property(coord_prop):
+                mol = (
+                    self._sire_object.move()
+                    .translate(_SireMaths.Vector(vec), _property_map)
+                    .commit()
+                )
+
         else:
             mol = (
                 self._sire_object.move()


### PR DESCRIPTION
This PR allows for translation of a custom `coordinates` property for perturbable molecules, which otherwise would only have `coordinates0` and `coordiantes1` translated.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
