### PR TITLE
Fix issue #484

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -535,9 +535,8 @@ class ConfigFactory:
                         protocol_dict["pcoupl"] = "Berendsen"  # Berendsen barostat.
                     # Do the MC move every 100 steps to be the same as AMBER.
                     protocol_dict["nstpcouple"] = 100
-                    # 4ps time constant for pressure coupling.
-                    # As the tau-p has to be 10 times larger than nstpcouple * dt (4 fs)
-                    protocol_dict["tau-p"] = 4
+                    # 25 times larger than nstpcouple * dt.
+                    protocol_dict["tau-p"] = 2500 * timestep
                     protocol_dict["ref-p"] = (
                         f"{self.protocol.getPressure().bar().value():.5f}"  # Pressure in bar.
                     )

--- a/python/BioSimSpace/_Config/_gromacs.py
+++ b/python/BioSimSpace/_Config/_gromacs.py
@@ -188,9 +188,8 @@ class Gromacs(_Config):
                         protocol_dict["pcoupl"] = "berendsen"
                     # Do the MC move every 100 steps to be the same as AMBER.
                     protocol_dict["nstpcouple"] = 100
-                    # 4ps time constant for pressure coupling. The tau-p has to be
-                    # 10 times larger than nstpcouple * dt (4 fs)
-                    protocol_dict["tau-p"] = 4
+                    # 25 times larger than nstpcouple * dt.
+                    protocol_dict["tau-p"] = 2500 * timestep
                     # Pressure in bar.
                     protocol_dict["ref-p"] = (
                         f"{self._protocol.getPressure().bar().value():.5f}"


### PR DESCRIPTION
This PR closes #484 by updating the default GROMACS NPT configuration to match the Recursion sandpit. The updated defaults satisfy the constraint on `tau-p`, which is now strictly enforced by `gmx grompp`.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
