### PR TITLE
Fix inconsistencies in merge code

### DIFF
--- a/python/BioSimSpace/Align/_merge.py
+++ b/python/BioSimSpace/Align/_merge.py
@@ -89,6 +89,7 @@ def merge(
     merged : Sire.Mol.Molecule
         The merged molecule.
     """
+    from sire.legacy import CAS as _SireCAS
     from sire.legacy import Mol as _SireMol
     from sire.legacy import Base as _SireBase
     from sire.legacy import MM as _SireMM
@@ -1033,10 +1034,16 @@ def merge(
 
     # Connect the bonded atoms in both end states.
     for bond in edit_mol.property("bond0").potentials():
-        conn0.connect(bond.atom0(), bond.atom1())
+        # Only connect bonds with non-zero force constants.
+        ab = _SireMM.AmberBond(bond.function(), _SireCAS.Symbol("r"))
+        if ab.k() != 0.0:
+            conn0.connect(bond.atom0(), bond.atom1())
     conn0 = conn0.commit()
     for bond in edit_mol.property("bond1").potentials():
-        conn1.connect(bond.atom0(), bond.atom1())
+        # Only connect bonds with non-zero force constants.
+        ab = _SireMM.AmberBond(bond.function(), _SireCAS.Symbol("r"))
+        if ab.k() != 0.0:
+            conn1.connect(bond.atom0(), bond.atom1())
     conn1 = conn1.commit()
 
     # Get the original connectivity of the two molecules.


### PR DESCRIPTION
This PR introduces some inconsistencies in the merge code introduced by the ROI merge feature.

* The wrong connectivity object was being used as a reference when comparing end state connectivities to determine whether rings have been broken or have undergone a size change.
* In certain cases, comments within the code referred to the _old_ merge implementation, so were inconsistent with the actual logic of the code.
* Several loops used in the reconstruction of the intrascale matrix were incorrectly indented.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
