### PR TITLE
Write both SOMD1 and SOMD2 input in prepareFEP

### DIFF
--- a/nodes/playground/prepareFEP.ipynb
+++ b/nodes/playground/prepareFEP.ipynb
@@ -159,13 +159,6 @@
     "    BSS.Gateway.String(\n",
     "        help=\"The root name for the files describing the perturbation input1->input2.\"\n",
     "    ),\n",
-    ")\n",
-    "node.addInput(\n",
-    "    \"somd2\",\n",
-    "    BSS.Gateway.Boolean(\n",
-    "        help=\"Whether to generate input for SOMD2.\",\n",
-    "        default=False,\n",
-    "    ),\n",
     ")"
    ]
   },
@@ -198,11 +191,9 @@
    "source": [
     "do_mapping = True\n",
     "custom_mapping = node.getInput(\"mapping\")\n",
-    "# print (custom_mapping)\n",
     "if custom_mapping is not None:\n",
     "    do_mapping = False\n",
-    "    mapping = loadMapping(custom_mapping)\n",
-    "    # print (mapping)"
+    "    mapping = loadMapping(custom_mapping)"
    ]
   },
   {
@@ -218,8 +209,7 @@
     "    entries = prematchstring.split(\",\")\n",
     "    for entry in entries:\n",
     "        idxA, idxB = entry.split(\"-\")\n",
-    "        prematch[int(idxA)] = int(idxB)\n",
-    "# print (prematch)"
+    "        prematch[int(idxA)] = int(idxB)"
    ]
   },
   {
@@ -270,10 +260,9 @@
     "        scoring_function=\"RMSDalign\",\n",
     "        timeout=node.getInput(\"timeout\"),\n",
     "    )\n",
+    "    \n",
     "    # We retain the top mapping\n",
-    "    mapping = mappings[0]\n",
-    "    # print (len(mappings))\n",
-    "    # print (mappings)"
+    "    mapping = mappings[0]"
    ]
   },
   {
@@ -282,19 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# print (mapping)\n",
-    "# for x in range(0,len(mappings)):\n",
-    "#    print (mappings[x], scores[x])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "inverted_mapping = dict([[v, k] for k, v in mapping.items()])\n",
-    "# print (inverted_mapping)"
+    "inverted_mapping = dict([[v, k] for k, v in mapping.items()])"
    ]
   },
   {
@@ -307,6 +284,7 @@
     "# on a root mean squared displacement fit to find the optimal translation vector\n",
     "# (as opposed to merely taking the difference of centroids).\n",
     "lig2 = BSS.Align.rmsdAlign(lig2, lig1, inverted_mapping)\n",
+    "\n",
     "# Merge the two ligands based on the mapping.\n",
     "merged = BSS.Align.merge(\n",
     "    lig1,\n",
@@ -315,9 +293,11 @@
     "    allow_ring_breaking=node.getInput(\"allow_ring_breaking\"),\n",
     "    allow_ring_size_change=node.getInput(\"allow_ring_size_change\"),\n",
     ")\n",
+    "\n",
     "# Create a composite system\n",
     "system1.removeMolecules(lig1)\n",
     "system1.addMolecules(merged)\n",
+    "\n",
     "# Make sure the box vectors are in reduced form.\n",
     "system1.reduceBoxVectors()\n",
     "system1.rotateBoxVectors()"
@@ -331,10 +311,11 @@
    "source": [
     "# Log the mapping used\n",
     "writeLog(lig1, lig2, mapping)\n",
-    "# Are we saving output for SOMD2?\n",
-    "is_somd2 = node.getInput(\"somd2\")\n",
+    "\n",
     "# File root for all output.\n",
     "root = node.getInput(\"output\")\n",
+    "\n",
+    "# Save PDB of merged topology.\n",
     "BSS.IO.saveMolecules(\n",
     "    \"merged_at_lam0.pdb\",\n",
     "    merged,\n",
@@ -345,18 +326,20 @@
     "        \"element\": \"element0\",\n",
     "    },\n",
     ")\n",
-    "if is_somd2:\n",
-    "    BSS.Stream.save(system1, root)\n",
-    "    stream_file = \"%s.bss\" % root\n",
-    "else:\n",
-    "    # Generate package specific input\n",
-    "    protocol = BSS.Protocol.FreeEnergy(\n",
-    "        runtime=2 * BSS.Units.Time.femtosecond, num_lam=3\n",
-    "    )\n",
-    "    process = BSS.Process.Somd(system1, protocol)\n",
-    "    process.getOutput()\n",
-    "    with zipfile.ZipFile(\"somd_output.zip\", \"r\") as zip_hnd:\n",
-    "        zip_hnd.extractall(\".\")"
+    "\n",
+    "\n",
+    "# Generate SOMD1 input.\n",
+    "protocol = BSS.Protocol.FreeEnergy(\n",
+    "    runtime=2 * BSS.Units.Time.femtosecond, num_lam=3\n",
+    ")\n",
+    "process = BSS.Process.Somd(system1, protocol)\n",
+    "process.getOutput()\n",
+    "with zipfile.ZipFile(\"somd_output.zip\", \"r\") as zip_hnd:\n",
+    "    zip_hnd.extractall(\".\")\n",
+    "\n",
+    "# Generate SOMD2 input.\n",
+    "BSS.Stream.save(system1, root)\n",
+    "stream_file = \"%s.bss\" % root"
    ]
   },
   {
@@ -365,12 +348,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not is_somd2:\n",
-    "    mergedpdb = \"%s.mergeat0.pdb\" % root\n",
-    "    pert = \"%s.pert\" % root\n",
-    "    prm7 = \"%s.prm7\" % root\n",
-    "    rst7 = \"%s.rst7\" % root\n",
-    "    mapping_str = \"%s.mapping\" % root"
+    "# Remap ouput names.\n",
+    "mergedpdb = \"%s.mergeat0.pdb\" % root\n",
+    "pert = \"%s.pert\" % root\n",
+    "prm7 = \"%s.prm7\" % root\n",
+    "rst7 = \"%s.rst7\" % root\n",
+    "mapping_str = \"%s.mapping\" % root"
    ]
   },
   {
@@ -379,19 +362,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not is_somd2:\n",
-    "    os.replace(\"merged_at_lam0.pdb\", mergedpdb)\n",
-    "    os.replace(\"somd.pert\", pert)\n",
-    "    os.replace(\"somd.prm7\", prm7)\n",
-    "    os.replace(\"somd.rst7\", rst7)\n",
-    "    os.replace(\"somd.mapping\", mapping_str)\n",
-    "    try:\n",
-    "        os.remove(\"somd_output.zip\")\n",
-    "        os.remove(\"somd.cfg\")\n",
-    "        os.remove(\"somd.err\")\n",
-    "        os.remove(\"somd.out\")\n",
-    "    except Exception:\n",
-    "        pass"
+    "# Rename.\n",
+    "os.replace(\"merged_at_lam0.pdb\", mergedpdb)\n",
+    "os.replace(\"somd.pert\", pert)\n",
+    "os.replace(\"somd.prm7\", prm7)\n",
+    "os.replace(\"somd.rst7\", rst7)\n",
+    "os.replace(\"somd.mapping\", mapping_str)\n",
+    "try:\n",
+    "    # Remove redundant files.\n",
+    "    os.remove(\"somd_output.zip\")\n",
+    "    os.remove(\"somd.cfg\")\n",
+    "    os.remove(\"somd.err\")\n",
+    "    os.remove(\"somd.out\")\n",
+    "except Exception:\n",
+    "    pass"
    ]
   },
   {
@@ -400,10 +384,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if is_somd2:\n",
-    "    output = [stream_file]\n",
-    "else:\n",
-    "    output = [mergedpdb, pert, prm7, rst7, mapping_str]\n",
+    "# Set the node output.\n",
+    "output = [mergedpdb, pert, prm7, rst7, mapping_str, stream_file]\n",
     "node.setOutput(\"nodeoutput\", output)"
    ]
   },
@@ -413,6 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Validate.\n",
     "node.validate()"
    ]
   }
@@ -433,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/nodes/playground/prepareFEP.py
+++ b/nodes/playground/prepareFEP.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 # Author: Julien Michel
-#
+# 
 # email: julien.michel@ed.ac.uk
 
 # # PrepareFEP
@@ -133,13 +133,6 @@ node.addInput(
         help="The root name for the files describing the perturbation input1->input2."
     ),
 )
-node.addInput(
-    "somd2",
-    BSS.Gateway.Boolean(
-        help="Whether to generate input for SOMD2.",
-        default=False,
-    ),
-)
 
 
 # In[ ]:
@@ -162,11 +155,9 @@ node.showControls()
 
 do_mapping = True
 custom_mapping = node.getInput("mapping")
-# print (custom_mapping)
 if custom_mapping is not None:
     do_mapping = False
     mapping = loadMapping(custom_mapping)
-    # print (mapping)
 
 
 # In[ ]:
@@ -180,7 +171,6 @@ if len(prematchstring) > 0:
     for entry in entries:
         idxA, idxB = entry.split("-")
         prematch[int(idxA)] = int(idxB)
-# print (prematch)
 
 
 # In[ ]:
@@ -219,25 +209,15 @@ if do_mapping:
         scoring_function="RMSDalign",
         timeout=node.getInput("timeout"),
     )
+
     # We retain the top mapping
     mapping = mappings[0]
-    # print (len(mappings))
-    # print (mappings)
-
-
-# In[ ]:
-
-
-# print (mapping)
-# for x in range(0,len(mappings)):
-#    print (mappings[x], scores[x])
 
 
 # In[ ]:
 
 
 inverted_mapping = dict([[v, k] for k, v in mapping.items()])
-# print (inverted_mapping)
 
 
 # In[ ]:
@@ -247,6 +227,7 @@ inverted_mapping = dict([[v, k] for k, v in mapping.items()])
 # on a root mean squared displacement fit to find the optimal translation vector
 # (as opposed to merely taking the difference of centroids).
 lig2 = BSS.Align.rmsdAlign(lig2, lig1, inverted_mapping)
+
 # Merge the two ligands based on the mapping.
 merged = BSS.Align.merge(
     lig1,
@@ -255,9 +236,11 @@ merged = BSS.Align.merge(
     allow_ring_breaking=node.getInput("allow_ring_breaking"),
     allow_ring_size_change=node.getInput("allow_ring_size_change"),
 )
+
 # Create a composite system
 system1.removeMolecules(lig1)
 system1.addMolecules(merged)
+
 # Make sure the box vectors are in reduced form.
 system1.reduceBoxVectors()
 system1.rotateBoxVectors()
@@ -268,10 +251,11 @@ system1.rotateBoxVectors()
 
 # Log the mapping used
 writeLog(lig1, lig2, mapping)
-# Are we saving output for SOMD2?
-is_somd2 = node.getInput("somd2")
+
 # File root for all output.
 root = node.getInput("output")
+
+# Save PDB of merged topology.
 BSS.IO.saveMolecules(
     "merged_at_lam0.pdb",
     merged,
@@ -282,60 +266,63 @@ BSS.IO.saveMolecules(
         "element": "element0",
     },
 )
-if is_somd2:
-    BSS.Stream.save(system1, root)
-    stream_file = "%s.bss" % root
-else:
-    # Generate package specific input
-    protocol = BSS.Protocol.FreeEnergy(
-        runtime=2 * BSS.Units.Time.femtosecond, num_lam=3
-    )
-    process = BSS.Process.Somd(system1, protocol)
-    process.getOutput()
-    with zipfile.ZipFile("somd_output.zip", "r") as zip_hnd:
-        zip_hnd.extractall(".")
+
+
+# Generate SOMD1 input.
+protocol = BSS.Protocol.FreeEnergy(
+    runtime=2 * BSS.Units.Time.femtosecond, num_lam=3
+)
+process = BSS.Process.Somd(system1, protocol)
+process.getOutput()
+with zipfile.ZipFile("somd_output.zip", "r") as zip_hnd:
+    zip_hnd.extractall(".")
+
+# Generate SOMD2 input.
+BSS.Stream.save(system1, root)
+stream_file = "%s.bss" % root
 
 
 # In[ ]:
 
 
-if not is_somd2:
-    mergedpdb = "%s.mergeat0.pdb" % root
-    pert = "%s.pert" % root
-    prm7 = "%s.prm7" % root
-    rst7 = "%s.rst7" % root
-    mapping_str = "%s.mapping" % root
+# Remap ouput names.
+mergedpdb = "%s.mergeat0.pdb" % root
+pert = "%s.pert" % root
+prm7 = "%s.prm7" % root
+rst7 = "%s.rst7" % root
+mapping_str = "%s.mapping" % root
 
 
 # In[ ]:
 
 
-if not is_somd2:
-    os.replace("merged_at_lam0.pdb", mergedpdb)
-    os.replace("somd.pert", pert)
-    os.replace("somd.prm7", prm7)
-    os.replace("somd.rst7", rst7)
-    os.replace("somd.mapping", mapping_str)
-    try:
-        os.remove("somd_output.zip")
-        os.remove("somd.cfg")
-        os.remove("somd.err")
-        os.remove("somd.out")
-    except Exception:
-        pass
+# Rename.
+os.replace("merged_at_lam0.pdb", mergedpdb)
+os.replace("somd.pert", pert)
+os.replace("somd.prm7", prm7)
+os.replace("somd.rst7", rst7)
+os.replace("somd.mapping", mapping_str)
+try:
+    # Remove redundant files.
+    os.remove("somd_output.zip")
+    os.remove("somd.cfg")
+    os.remove("somd.err")
+    os.remove("somd.out")
+except Exception:
+    pass
 
 
 # In[ ]:
 
 
-if is_somd2:
-    output = [stream_file]
-else:
-    output = [mergedpdb, pert, prm7, rst7, mapping_str]
+# Set the node output.
+output = [mergedpdb, pert, prm7, rst7, mapping_str, stream_file]
 node.setOutput("nodeoutput", output)
 
 
 # In[ ]:
 
 
+# Validate.
 node.validate()
+


### PR DESCRIPTION
This PR updates the `prepareFEP` script so that both SOMD1 _and_ SOMD2 inputs are written at the _same_ time, rather than one or the other.

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]
