### PR TITLE
Fix issue #536

### DIFF
--- a/recipes/biosimspace/recipe.yaml
+++ b/recipes/biosimspace/recipe.yaml
@@ -56,6 +56,10 @@ tests:
   - python:
       imports:
         - BioSimSpace
+      # AmberTools can be pulled in transitively, and installs tools into
+      # site-packages whose metadata still pins numpy <2, so 'pip check'
+      # fails even though nothing here uses them.
+      pip_check: false
   - script:
       - if: unix
         then: PYTHONPATH=. pytest -vvv --color=yes --import-mode=importlib ./tests


### PR DESCRIPTION
This PR closes #536 by adding `pip_check: false` to the `rattler-build` recipe. The issue is ultimately down to `ambertools` and packaging inconsistencies/annoyances within the `omsf` ecosystem, but I'll fix in the easiest way that still allows us to test against the most up-to-date dependencies.

(Note that `openff-interchange-base` dropped Python 3.11 support in their 0.5.3 _patch_ release, a change that wasn't documented in the release notes. They also flipped a `pydantic` pin in the next patch release, which has caused resolution issues with other tools in the ecosystem, which haven't updated theirs.)

* I confirm that I have merged the latest version of `devel` into this branch before issuing this pull request (e.g. by running `git pull origin devel`): [y]
* I confirm that I have permission to release this code under the GPL3 license: [y]